### PR TITLE
fix: chat auto-scroll on new messages

### DIFF
--- a/packages/desktop/src/renderer/components/ui/scroll-area.tsx
+++ b/packages/desktop/src/renderer/components/ui/scroll-area.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 
 interface ScrollAreaProps
   extends React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
-  viewportRef?: React.Ref<HTMLDivElement>
+  viewportRef?: React.Ref<React.ComponentRef<typeof ScrollAreaPrimitive.Viewport>>
 }
 
 const ScrollArea = React.forwardRef<

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -16,6 +16,8 @@ import ThinkingIndicator from '@/components/ThinkingIndicator'
 import ChatInput from '@/components/ChatInput'
 import FileBrowser from '../FileBrowser'
 
+const STICK_TO_BOTTOM_THRESHOLD_PX = 60
+
 interface MainAreaProps {
   onTogglePanel: () => void
 }
@@ -110,9 +112,8 @@ function ChatContent() {
   const handleScroll = useCallback(() => {
     const el = viewportRef.current
     if (!el) return
-    const threshold = 60
     stickToBottom.current =
-      el.scrollHeight - el.scrollTop - el.clientHeight < threshold
+      el.scrollHeight - el.scrollTop - el.clientHeight < STICK_TO_BOTTOM_THRESHOLD_PX
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Fix chat not auto-scrolling to bottom when new messages arrive or during streaming responses
- Root cause: `ScrollArea` forwards `ref` to Radix `Root` (`overflow:hidden`), not the scrollable `Viewport`
- Add `viewportRef` prop to `ScrollArea` to expose the actual scrollable element
- Track scroll position so auto-scroll is skipped when the user has manually scrolled up (60px threshold)

Closes #2

## Test plan

- [ ] Send a message and verify the view auto-scrolls as the agent reply streams in
- [ ] When reply exceeds one screen, confirm it keeps scrolling to the bottom
- [ ] Manually scroll up during a streaming reply — verify it stops forcing you back down
- [ ] Scroll back to the bottom — verify auto-scroll re-engages on next update

Made with [Cursor](https://cursor.com)