### PR TITLE
fix: replace hardcoded Chinese strings with i18n keys

### DIFF
--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -111,7 +111,7 @@ export default function ChatInput() {
     setProcessing(activeTask.id, true);
 
     if (!activeTask.title) {
-      const titleSource = content || (images.length ? `[${t('chatInput.image', '图片')}]` : '');
+      const titleSource = content || (images.length ? `[${t('chatInput.image')}]` : '');
       const title = titleSource.slice(0, 30).replace(/\n/g, ' ').trim();
       updateTaskTitle(activeTask.id, title + (titleSource.length > 30 ? '\u2026' : ''));
     }
@@ -129,7 +129,7 @@ export default function ChatInput() {
     } catch (err) {
       setProcessing(activeTask.id, false);
       const msg = err instanceof Error ? err.message : String(err);
-      addMessage(activeTask.id, 'system', `\u53D1\u9001\u5931\u8D25: ${msg}`);
+      addMessage(activeTask.id, 'system', `${t('errors.sendFailed')}: ${msg}`);
       toast.error('Failed to send message', { description: msg });
     }
   }, [activeTask, addMessage, setProcessing, updateTaskTitle, isOffline, pendingImages, t]);

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -90,14 +90,16 @@
     "empty": "No archived chats"
   },
   "errors": {
-    "requestFailed": "Request failed"
+    "requestFailed": "Request failed",
+    "sendFailed": "Send failed"
   },
   "chatInput": {
     "describeTask": "Describe your task\u2026",
     "offlineReadOnly": "Offline \u2014 read-only",
     "createTaskFirst": "Create a task first\u2026",
     "poweredBy": "AI can make mistakes. Check important info.",
-    "offlineHint": "Offline \u2014 browse past tasks and files"
+    "offlineHint": "Offline \u2014 browse past tasks and files",
+    "image": "Image"
   },
   "chatMessage": {
     "copyMessage": "Copy message",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -90,14 +90,16 @@
     "empty": "暂无归档对话"
   },
   "errors": {
-    "requestFailed": "\u8bf7\u6c42\u51fa\u9519"
+    "requestFailed": "\u8bf7\u6c42\u51fa\u9519",
+    "sendFailed": "\u53d1\u9001\u5931\u8d25"
   },
   "chatInput": {
     "describeTask": "\u63cf\u8ff0\u4f60\u7684\u4efb\u52a1\u2026",
     "offlineReadOnly": "\u79bb\u7ebf\u6a21\u5f0f \u2014 \u53ea\u8bfb",
     "createTaskFirst": "\u8bf7\u5148\u521b\u5efa\u4e00\u4e2a\u4efb\u52a1\u2026",
     "poweredBy": "\u7531 OpenClaw \u9a71\u52a8 \u00b7 \u4efb\u52a1\u6587\u4ef6\u81ea\u52a8 Git \u5f52\u6863",
-    "offlineHint": "\u79bb\u7ebf\u6a21\u5f0f \u2014 \u53ef\u6d4f\u89c8\u5386\u53f2\u4efb\u52a1\u548c\u6587\u4ef6"
+    "offlineHint": "\u79bb\u7ebf\u6a21\u5f0f \u2014 \u53ef\u6d4f\u89c8\u5386\u53f2\u4efb\u52a1\u548c\u6587\u4ef6",
+    "image": "\u56fe\u7247"
   },
   "chatMessage": {
     "copyMessage": "\u590d\u5236\u6d88\u606f",


### PR DESCRIPTION
Fix 2 hardcoded Chinese strings in ChatInput that bypassed i18n:

- Remove `'图片'` fallback from `t('chatInput.image')`; add missing key to both locales
- Replace Unicode-escaped `发送失败` with `t('errors.sendFailed')`; add missing key to both locales