### PR TITLE
[Docs] Add contributor PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report a problem in ClawWork
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. A tight repro beats a long story.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the problem and the visible impact.
+      placeholder: The app freezes after I switch workspaces while a task is still running.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the shortest reliable reproduction you have.
+      placeholder: |
+        1. Open ClawWork
+        2. Start a task
+        3. Switch to another workspace
+        4. Observe the crash
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: The task should keep running and the workspace switch should succeed.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Renderer UI
+        - Task execution
+        - Workspace or Git artifacts
+        - Search or indexing
+        - Settings or gateway connection
+        - Packaging or install
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include app version, commit, OS version, and anything else relevant.
+      placeholder: |
+        ClawWork version:
+        Commit:
+        macOS / Windows version:
+        OpenClaw server version:
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or recordings
+      description: Paste logs or attach screenshots if they help explain the problem.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else that narrows the bug down.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Propose an improvement to ClawWork
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Focus on the problem first, not the implementation fantasy.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the current pain point or missing workflow.
+      placeholder: It is hard to compare multiple task runs without manually opening each artifact directory.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What change would you like to see?
+      description: Describe the behavior or workflow you want.
+      placeholder: Add a side-by-side compare view for task outputs and generated files.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary area
+      options:
+        - Renderer UI
+        - Task execution
+        - Workspace or Git artifacts
+        - Search or indexing
+        - Settings or gateway connection
+        - Packaging or install
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: user_value
+    attributes:
+      label: Why does this matter?
+      description: Explain the user value, operational value, or workflow improvement.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe current workarounds or other options you considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Mockups, examples from other tools, screenshots, or related links.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+## Summary
+
+Describe the change and the problem it solves.
+
+## Type of change
+
+- [ ] `[Feat]` new feature
+- [ ] `[Fix]` bug fix
+- [ ] `[UI]` UI or UX change
+- [ ] `[Docs]` documentation-only change
+- [ ] `[Refactor]` internal cleanup
+- [ ] `[Build]` CI, packaging, or tooling change
+- [ ] `[Chore]` maintenance
+
+## Why is this needed?
+
+Explain the user problem, engineering problem, or follow-up this PR addresses.
+
+## What changed?
+
+- 
+
+## Linked issues
+
+Closes #
+
+## Validation
+
+- [ ] `pnpm lint`
+- [ ] `pnpm test`
+- [ ] `pnpm build`
+- [ ] Manual smoke test
+- [ ] Not run
+
+Commands, screenshots, or notes:
+
+```text
+
+```
+
+## Screenshots or recordings
+
+If the change affects the UI, add screenshots or a short recording.
+
+## Release note
+
+- [ ] No user-facing change. Release note is `NONE`.
+- [ ] User-facing change. Release note is included below.
+
+```release-note
+NONE
+```
+
+## Checklist
+
+- [ ] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
+- [ ] The summary explains both what changed and why
+- [ ] Validation reflects the commands actually run for this PR
+- [ ] The release note block is accurate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to ClawWork
+
+Thanks for contributing.
+
+This project is still early. Keep changes focused, explain the problem clearly, and prefer small pull requests over broad refactors.
+
+## Before you start
+
+1. Open or find an issue for the problem when the change is non-trivial.
+2. Make sure the work belongs in this repository.
+3. Keep user-facing behavior, testing, and release impact explicit in the PR.
+
+## Development setup
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Useful verification commands:
+
+```bash
+pnpm lint
+pnpm test
+pnpm build
+```
+
+## Pull request expectations
+
+Use one or more title prefixes:
+
+- `[Feat]` new user-visible capability
+- `[Fix]` bug fix
+- `[UI]` renderer or UX change
+- `[Docs]` documentation-only change
+- `[Refactor]` internal cleanup without intended behavior change
+- `[Build]` CI, packaging, dependencies, or tooling
+- `[Chore]` maintenance work
+
+Every PR should include:
+
+- a clear summary of what changed and why
+- linked issues when applicable
+- the verification you actually ran
+- screenshots or recordings for visible UI changes
+- a release note for user-facing changes
+
+## Release notes
+
+If the change affects users, fill in the `release-note` block in the PR template with a short sentence written from the user's point of view.
+
+Examples:
+
+- `Added a task detail view for inspecting tool calls and artifacts.`
+- `Fixed a crash when switching workspaces before the initial sync completed.`
+
+If the change is not user-facing, set the block to `NONE`.
+
+## Scope
+
+Good first contributions:
+
+- focused bug fixes
+- docs improvements
+- UI polish with screenshots
+- tests for existing behavior
+
+Avoid mixing unrelated changes in one PR.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ packages/
 
 ## Contributing
 
-Contributions are welcome. Please open an issue first to discuss what you would like to change.
+Contributions are welcome. For issue and pull request expectations, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

Initialize lightweight contributor templates for this repository so new contributors have a clear path for filing issues and opening PRs.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [x] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The project is still early, but contribution paths were underspecified. This adds a simple initial structure modeled after the parts of Kueue and semantic-router that are actually useful here: PR classification, explicit validation, and release-note handling for user-facing changes.

## What changed?

- added `.github/PULL_REQUEST_TEMPLATE.md` with type, rationale, validation, and `release-note` sections
- added issue forms for bug reports and feature requests
- added `.github/ISSUE_TEMPLATE/config.yml`
- added `CONTRIBUTING.md` with title prefix and release note guidance
- linked the contribution guide from `README.md`

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
git diff --check
ruby -e 'require "yaml"; %w[.github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml].each { |f| YAML.load_file(f); puts "OK #{f}" }'
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate
