### PR TITLE
feat: add Homebrew Cask distribution

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,61 @@
+name: Update Homebrew Tap
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish to Homebrew tap (for example: v0.0.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  update-homebrew-tap:
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease != true }}
+    runs-on: ubuntu-latest
+    env:
+      CLAWWORK_REPO: clawwork-ai/clawwork
+      TAP_DIR: homebrew-clawwork
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v4
+        with:
+          repository: clawwork-ai/homebrew-clawwork
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-clawwork
+
+      - name: Update clawwork cask
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAWWORK_REPO: ${{ env.CLAWWORK_REPO }}
+          TAP_DIR: ${{ env.TAP_DIR }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          bash scripts/update-homebrew-tap.sh
+
+      - name: Configure git identity
+        working-directory: homebrew-clawwork
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push tap update
+        working-directory: homebrew-clawwork
+        run: |
+          if git diff --quiet; then
+            echo "No Homebrew tap changes to commit."
+            exit 0
+          fi
+
+          git add Casks/clawwork.rb
+          git commit -m "chore: update clawwork cask for ${RELEASE_TAG}"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Configure the Gateway address and token in **Settings** (bottom-left gear icon),
 OPENCLAW_GATEWAY_TOKEN=<your-token> pnpm dev
 ```
 
+## Install with Homebrew
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
 ## Build
 
 ```bash

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CLAWWORK_REPO="${CLAWWORK_REPO:-clawwork-ai/clawwork}"
+TAP_DIR="${TAP_DIR:-homebrew-clawwork}"
+RELEASE_TAG="${RELEASE_TAG:-${GITHUB_REF_NAME:-}}"
+
+if [[ -z "${RELEASE_TAG}" ]]; then
+  echo "RELEASE_TAG is required" >&2
+  exit 1
+fi
+
+asset_json="$(gh release view "${RELEASE_TAG}" -R "${CLAWWORK_REPO}" --json assets --jq '.assets[] | select(.name | endswith("-mac-universal.dmg"))' | head -n 1)"
+
+if [[ -z "${asset_json}" ]]; then
+  echo "No macOS universal DMG asset found for ${RELEASE_TAG}" >&2
+  exit 1
+fi
+
+asset_name="$(jq -r '.name' <<<"${asset_json}")"
+asset_url="$(jq -r '.url' <<<"${asset_json}")"
+asset_digest="$(jq -r '.digest // empty' <<<"${asset_json}")"
+sha256="${asset_digest#sha256:}"
+version="${RELEASE_TAG#v}"
+
+if [[ -z "${sha256}" ]]; then
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir}"' EXIT
+
+  gh release download "${RELEASE_TAG}" -R "${CLAWWORK_REPO}" --pattern "${asset_name}" --dir "${tmp_dir}"
+  sha256="$(shasum -a 256 "${tmp_dir}/${asset_name}" | awk '{print $1}')"
+fi
+
+mkdir -p "${TAP_DIR}/Casks"
+
+cat > "${TAP_DIR}/Casks/clawwork.rb" <<EOF
+cask "clawwork" do
+  version "${version}"
+  sha256 "${sha256}"
+
+  url "${asset_url}"
+  name "ClawWork"
+  desc "Desktop client for OpenClaw"
+  homepage "https://github.com/clawwork-ai/clawwork"
+
+  app "ClawWork.app"
+
+  postflight do
+    system_command "xattr", args: ["-cr", "#{appdir}/ClawWork.app"]
+  end
+end
+EOF


### PR DESCRIPTION
## Summary

- add dedicated Homebrew tap automation for ClawWork
- document `brew tap clawwork-ai/clawwork && brew install --cask clawwork`
- add a manual/automatic workflow to sync the tap repo from GitHub releases

## Notes

- initialize `clawwork-ai/homebrew-clawwork` with a stable `clawwork` cask
- publish the current `v0.0.2` release through the tap without cutting `v0.0.3`

Fixes #24