### PR TITLE
feat(chat): slash command autocomplete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ ClawWork is an OpenClaw desktop client inspired by Claude Cowork: three-panel la
 
 **Not** an OpenClaw admin console. **Not** a general-purpose IM client. **Not** a collaboration tool.
 
+## Related Repositories
+
+- **OpenClaw server source**: `~/git/openclaw` — reference for Gateway protocol, slash command definitions (`src/auto-reply/commands-registry.ts`), native command specs, and Telegram bot command registration (`extensions/telegram/src/bot-native-command-menu.ts`).
+
 ## Architecture
 
 ```

--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -15,6 +15,8 @@ import {
 import { useTaskStore } from '../stores/taskStore';
 import { useMessageStore } from '../stores/messageStore';
 import { useUiStore } from '../stores/uiStore';
+import SlashCommandMenu from './SlashCommandMenu';
+import { filterSlashCommands, parseSlashQuery, type SlashCommand } from '@/lib/slash-commands';
 
 interface PendingImage {
   file: File;
@@ -70,6 +72,42 @@ export default function ChatInput() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([]);
 
+  // ── Slash command autocomplete state ─────────────────────────────────────────
+  const [slashMenuVisible, setSlashMenuVisible] = useState(false);
+  const [slashQuery, setSlashQuery] = useState('');
+  const [slashIndex, setSlashIndex] = useState(0);
+  const slashCommands = filterSlashCommands(slashQuery);
+
+  /** Evaluate the current textarea value and cursor position to determine
+   *  whether to show the slash command menu. */
+  const updateSlashMenu = useCallback(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const result = parseSlashQuery(ta.value, ta.selectionStart ?? 0);
+    if (result.active) {
+      setSlashQuery(result.query);
+      setSlashIndex(0);
+      setSlashMenuVisible(true);
+    } else {
+      setSlashMenuVisible(false);
+    }
+  }, []);
+
+  /** Insert the selected command name into the textarea. */
+  const commitSlashCommand = useCallback((cmd: SlashCommand) => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const newValue = `/${cmd.name} `;
+    ta.value = newValue;
+    ta.style.height = 'auto';
+    ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
+    ta.setSelectionRange(newValue.length, newValue.length);
+    ta.focus();
+    setSlashMenuVisible(false);
+    setSlashQuery('');
+    setSlashIndex(0);
+  }, []);
+
   const activeTask = useTaskStore((s) =>
     s.tasks.find((t) => t.id === s.activeTaskId),
   );
@@ -94,7 +132,6 @@ export default function ChatInput() {
     if (!activeTask) return;
     const { updateTaskMetadata } = useTaskStore.getState();
     updateTaskMetadata(activeTask.id, { model: modelId });
-    // OpenClaw sessions.patch uses `modelOverride` (provider/model format), not `model`
     window.clawwork.patchSession(activeTask.gatewayId, activeTask.sessionKey, { modelOverride: modelId }).catch(() => {
       toast.error('Failed to update model');
     });
@@ -104,7 +141,6 @@ export default function ChatInput() {
     if (!activeTask) return;
     const { updateTaskMetadata } = useTaskStore.getState();
     updateTaskMetadata(activeTask.id, { thinkingLevel: level === 'off' ? undefined : level });
-    // OpenClaw accepts "off" | "low" | "medium" | "high" as thinkingLevel string
     window.clawwork.patchSession(activeTask.gatewayId, activeTask.sessionKey, { thinkingLevel: level }).catch(() => {
       toast.error('Failed to update thinking level');
     });
@@ -148,7 +184,6 @@ export default function ChatInput() {
     const images = [...pendingImages];
     setPendingImages([]);
 
-    // Store preview data URLs in message for chat display
     const msgImages: MessageImageAttachment[] | undefined = images.length
       ? images.map((img) => ({ fileName: img.file.name, dataUrl: img.previewUrl }))
       : undefined;
@@ -163,7 +198,6 @@ export default function ChatInput() {
     }
 
     try {
-      // Read base64 only at send time
       const attachments = images.length
         ? await Promise.all(images.map(async (img) => ({
             mimeType: img.file.type || 'image/png',
@@ -184,16 +218,42 @@ export default function ChatInput() {
       addMessage(activeTask.id, 'system', `${t('errors.sendFailed')}: ${msg}`);
       toast.error('Failed to send message', { description: msg });
     }
-  }, [activeTask, addMessage, setProcessing, updateTaskTitle, isOffline, pendingImages, t]);;
+  }, [activeTask, addMessage, setProcessing, updateTaskTitle, isOffline, pendingImages, t]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // ── Slash menu keyboard navigation ────────────────────────────────────────
+      if (slashMenuVisible && slashCommands.length > 0) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setSlashIndex((i) => (i + 1) % slashCommands.length);
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setSlashIndex((i) => (i - 1 + slashCommands.length) % slashCommands.length);
+          return;
+        }
+        if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+          e.preventDefault();
+          const cmd = slashCommands[slashIndex];
+          if (cmd) commitSlashCommand(cmd);
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setSlashMenuVisible(false);
+          return;
+        }
+      }
+
+      // ── Normal send ───────────────────────────────────────────────────────────
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         handleSend();
       }
     },
-    [handleSend],
+    [slashMenuVisible, slashCommands, slashIndex, commitSlashCommand, handleSend],
   );
 
   const handleInput = useCallback(() => {
@@ -201,7 +261,9 @@ export default function ChatInput() {
     if (!textarea) return;
     textarea.style.height = 'auto';
     textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
-  }, []);
+    // Re-evaluate slash menu on every input change
+    updateSlashMenu();
+  }, [updateSlashMenu]);
 
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
     const items = e.clipboardData?.items;
@@ -345,71 +407,87 @@ export default function ChatInput() {
           </div>
         )}
 
-        <div className={cn(
-          'flex items-end gap-2',
-          'bg-[var(--bg-elevated)] rounded-2xl p-3.5',
-          'border border-[var(--border-subtle)]',
-          'shadow-[var(--shadow-elevated)]',
-          'ring-accent-focus transition-all duration-200',
-          isOffline && 'opacity-60',
-        )}>
-          {/* Hidden file input */}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={ACCEPTED_TYPES}
-            multiple
-            className="hidden"
-            onChange={handleFileSelect}
-          />
+        {/* Input area — relative wrapper for SlashCommandMenu positioning */}
+        <div className="relative">
+          {/* Slash command autocomplete menu */}
+          {slashMenuVisible && (
+            <SlashCommandMenu
+              commands={slashCommands}
+              selectedIndex={slashIndex}
+              onSelect={commitSlashCommand}
+              onHoverIndex={setSlashIndex}
+              onClose={() => setSlashMenuVisible(false)}
+            />
+          )}
 
-          {/* Attach button */}
-          <motion.div
-            whileHover={motionPresets.scale.whileHover}
-            whileTap={motionPresets.scale.whileTap}
-            transition={motionPresets.scale.transition}
-          >
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={disabled}
-              className="rounded-xl text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-            >
-              <Paperclip size={16} />
-            </Button>
-          </motion.div>
+          <div className={cn(
+            'flex items-end gap-2',
+            'bg-[var(--bg-elevated)] rounded-2xl p-3.5',
+            'border border-[var(--border-subtle)]',
+            'shadow-[var(--shadow-elevated)]',
+            'ring-accent-focus transition-all duration-200',
+            isOffline && 'opacity-60',
+          )}>
+            {/* Hidden file input */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPTED_TYPES}
+              multiple
+              className="hidden"
+              onChange={handleFileSelect}
+            />
 
-          <textarea
-            ref={textareaRef}
-            rows={1}
-            placeholder={placeholder}
-            disabled={disabled}
-            onKeyDown={handleKeyDown}
-            onInput={handleInput}
-            onPaste={handlePaste}
-            className={cn(
-              'flex-1 resize-none bg-transparent',
-              'text-[var(--text-primary)] placeholder:text-[var(--text-muted)]',
-              'outline-none max-h-40 disabled:opacity-50',
-            )}
-          />
-          <motion.div
-            whileHover={motionPresets.scale.whileHover}
-            whileTap={motionPresets.scale.whileTap}
-            transition={motionPresets.scale.transition}
-          >
-            <Button
-              variant="soft"
-              size="icon"
-              onClick={handleSend}
-              disabled={disabled}
-              className="rounded-xl"
+            {/* Attach button */}
+            <motion.div
+              whileHover={motionPresets.scale.whileHover}
+              whileTap={motionPresets.scale.whileTap}
+              transition={motionPresets.scale.transition}
             >
-              <Send size={16} />
-            </Button>
-          </motion.div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={disabled}
+                className="rounded-xl text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              >
+                <Paperclip size={16} />
+              </Button>
+            </motion.div>
+
+            <textarea
+              ref={textareaRef}
+              rows={1}
+              placeholder={placeholder}
+              disabled={disabled}
+              onKeyDown={handleKeyDown}
+              onInput={handleInput}
+              onPaste={handlePaste}
+              onClick={updateSlashMenu}
+              className={cn(
+                'flex-1 resize-none bg-transparent',
+                'text-[var(--text-primary)] placeholder:text-[var(--text-muted)]',
+                'outline-none max-h-40 disabled:opacity-50',
+              )}
+            />
+            <motion.div
+              whileHover={motionPresets.scale.whileHover}
+              whileTap={motionPresets.scale.whileTap}
+              transition={motionPresets.scale.transition}
+            >
+              <Button
+                variant="soft"
+                size="icon"
+                onClick={handleSend}
+                disabled={disabled}
+                className="rounded-xl"
+              >
+                <Send size={16} />
+              </Button>
+            </motion.div>
+          </div>
         </div>
+
         <p className="text-xs text-[var(--text-muted)] text-center mt-2.5 tracking-wide">
           {isOffline
             ? t('chatInput.offlineHint')

--- a/packages/desktop/src/renderer/components/SlashCommandMenu.tsx
+++ b/packages/desktop/src/renderer/components/SlashCommandMenu.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { cn } from '@/lib/utils';
+import type { SlashCommand } from '@/lib/slash-commands';
+
+interface SlashCommandMenuProps {
+  commands: SlashCommand[];
+  selectedIndex: number;
+  onSelect: (command: SlashCommand) => void;
+  onHoverIndex: (index: number) => void;
+  onClose: () => void;
+  className?: string;
+}
+
+export default function SlashCommandMenu({
+  commands,
+  selectedIndex,
+  onSelect,
+  onHoverIndex,
+  onClose,
+  className,
+}: SlashCommandMenuProps) {
+  const listRef = useRef<HTMLUListElement>(null);
+  const selectedItemRef = useRef<HTMLLIElement>(null);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    selectedItemRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  return (
+    <AnimatePresence>
+      {commands.length > 0 && (
+        <>
+          {/* Backdrop — clicking outside closes */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={onClose}
+            aria-hidden
+          />
+          <motion.div
+            role="listbox"
+            aria-label="Slash commands"
+            className={cn(
+              'absolute bottom-full left-0 right-0 mb-1 z-50',
+              'surface-elevated rounded-xl overflow-hidden',
+              'border border-[var(--border-subtle)]',
+              'shadow-[var(--shadow-elevated)]',
+              className,
+            )}
+            initial={{ opacity: 0, y: 4, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 4, scale: 0.98 }}
+            transition={{ duration: 0.12, ease: 'easeOut' }}
+          >
+            <ul ref={listRef} className="max-h-52 overflow-y-auto py-1">
+              {commands.map((cmd, index) => (
+                <li
+                  key={cmd.name}
+                  ref={index === selectedIndex ? selectedItemRef : undefined}
+                  role="option"
+                  aria-selected={index === selectedIndex}
+                  className={cn(
+                    'flex items-baseline gap-3 px-4 py-2 cursor-pointer select-none',
+                    'transition-colors duration-75',
+                    index === selectedIndex
+                      ? 'bg-[var(--accent-soft)] text-[var(--fg-primary)]'
+                      : 'text-[var(--fg-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--fg-primary)]',
+                  )}
+                  onMouseEnter={() => onHoverIndex(index)}
+                  onMouseDown={(e) => {
+                    // Prevent textarea blur before selection
+                    e.preventDefault();
+                    onSelect(cmd);
+                  }}
+                >
+                  {/* Command name */}
+                  <span className="font-mono text-[13px] font-medium text-[var(--accent)] shrink-0">
+                    /{cmd.name}
+                  </span>
+                  {/* Description */}
+                  <span className="text-xs truncate">{cmd.description}</span>
+                  {/* Arg hint */}
+                  {cmd.argHint && (
+                    <span className="ml-auto text-xs font-mono text-[var(--fg-muted)] shrink-0">
+                      {cmd.argHint}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <div className="px-4 py-1.5 border-t border-[var(--border-subtle)] flex gap-3 text-[10px] text-[var(--fg-muted)]">
+              <span><kbd className="font-mono">↑↓</kbd> navigate</span>
+              <span><kbd className="font-mono">↵</kbd> select</span>
+              <span><kbd className="font-mono">Esc</kbd> close</span>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/desktop/src/renderer/lib/slash-commands.ts
+++ b/packages/desktop/src/renderer/lib/slash-commands.ts
@@ -1,0 +1,92 @@
+/**
+ * Slash command definitions for ClawWork input autocomplete.
+ *
+ * Source: mirrors OpenClaw's native command surface.
+ * Reference: ~/git/openclaw/src/tui/commands.ts (getSlashCommands)
+ *            ~/git/openclaw/src/auto-reply/commands-registry.ts (NativeCommandSpec)
+ *
+ * PLACEHOLDER: In a future version, this list should be fetched dynamically from
+ * the Gateway via a `commands.list` RPC (not yet exposed in the Gateway API).
+ * When that RPC is available, extend `gateway-client.ts` with `listCommands()`,
+ * add an IPC handler `ws:commands-list`, and replace the static list below with
+ * a store that hydrates on gateway connect.
+ */
+
+export interface SlashCommand {
+  name: string;
+  description: string;
+  /** Optional argument hint shown in the menu, e.g. "<model>" or "on|off" */
+  argHint?: string;
+}
+
+/**
+ * Static list of OpenClaw native slash commands supported in ClawWork sessions.
+ * Derived from ~/git/openclaw/src/tui/commands.ts and the gateway NativeCommandSpec list.
+ *
+ * PLACEHOLDER: replace/extend with dynamic gateway commands when available.
+ */
+export const STATIC_SLASH_COMMANDS: SlashCommand[] = [
+  // ── Session / Agent control ─────────────────────────────────────────────────
+  { name: 'new',      description: 'Reset the session',            argHint: undefined },
+  { name: 'reset',    description: 'Reset the session',            argHint: undefined },
+  { name: 'abort',    description: 'Abort the active run',         argHint: undefined },
+  { name: 'agent',    description: 'Switch agent (or open picker)', argHint: '<id>' },
+  { name: 'agents',   description: 'Open agent picker',            argHint: undefined },
+  { name: 'session',  description: 'Switch session (or open picker)', argHint: '<key>' },
+  { name: 'sessions', description: 'Open session picker',          argHint: undefined },
+
+  // ── Model / Quality ─────────────────────────────────────────────────────────
+  { name: 'model',    description: 'Set model (or open picker)',   argHint: '<provider/model>' },
+  { name: 'models',   description: 'Open model picker',            argHint: undefined },
+  { name: 'think',    description: 'Set thinking level',           argHint: 'off|low|medium|high' },
+  { name: 'fast',     description: 'Set fast mode',                argHint: 'status|on|off' },
+  { name: 'verbose',  description: 'Set verbose on/off',           argHint: 'on|off' },
+  { name: 'reasoning',description: 'Set reasoning on/off',         argHint: 'on|off' },
+  { name: 'usage',    description: 'Toggle per-response usage line', argHint: 'off|tokens|full' },
+
+  // ── Access / Security ───────────────────────────────────────────────────────
+  { name: 'elevated', description: 'Set elevated permission level', argHint: 'on|off|ask|full' },
+  { name: 'elev',     description: 'Alias for /elevated',          argHint: 'on|off|ask|full' },
+  { name: 'activation', description: 'Set group activation mode', argHint: 'mention|always' },
+
+  // ── Info / Help ─────────────────────────────────────────────────────────────
+  { name: 'help',     description: 'Show slash command help',      argHint: undefined },
+  { name: 'status',   description: 'Show gateway status summary',  argHint: undefined },
+  { name: 'settings', description: 'Open settings',                argHint: undefined },
+];
+
+/**
+ * Filter slash commands by the text the user has typed after the `/`.
+ * Returns all commands when query is empty (bare "/" input).
+ */
+export function filterSlashCommands(
+  query: string,
+  commands: SlashCommand[] = STATIC_SLASH_COMMANDS,
+): SlashCommand[] {
+  const q = query.toLowerCase();
+  if (!q) return commands;
+  return commands.filter((cmd) => cmd.name.startsWith(q));
+}
+
+/**
+ * Parse the textarea value to determine if slash-command autocomplete should show.
+ *
+ * Rules:
+ * - The cursor must be on the *first* line.
+ * - The line must start with `/`.
+ * - There must be no whitespace-separated second token yet (i.e. we haven't
+ *   entered the argument phase).
+ *
+ * Returns `{ active: true, query }` or `{ active: false }`.
+ */
+export function parseSlashQuery(value: string, selectionStart: number): { active: false } | { active: true; query: string } {
+  // Only consider text up to cursor
+  const before = value.slice(0, selectionStart);
+  // Must be on the first line (no newlines before cursor)
+  if (before.includes('\n')) return { active: false };
+  if (!before.startsWith('/')) return { active: false };
+  const afterSlash = before.slice(1);
+  // If there's already a space in the command name, we're in arg territory
+  if (afterSlash.includes(' ')) return { active: false };
+  return { active: true, query: afterSlash };
+}


### PR DESCRIPTION
## Summary

- Add `/` trigger in chat input that opens a floating autocomplete menu with 20 static OpenClaw native commands
- Full keyboard navigation: ↑↓ to move, Enter/Tab to select, Esc to dismiss; mouse hover also updates selection
- `parseSlashQuery()` is cursor-aware — only activates on the first line, before any space (i.e. command name only, not args)

## Files changed

| File | Change |
|------|--------|
| `renderer/lib/slash-commands.ts` | **New** — `SlashCommand` interface, 20-command static list, `filterSlashCommands()`, `parseSlashQuery()` |
| `renderer/components/SlashCommandMenu.tsx` | **New** — animated floating menu component |
| `renderer/components/ChatInput.tsx` | **Modified** — slash state, keyboard/mouse wiring, `onClick` re-evaluation |
| `CLAUDE.md` | Added Related Repositories reference |

## Notes

Dynamic command list via a `commands.list` Gateway RPC is not yet available. Static list is used for now with `PLACEHOLDER` comments marking where to extend when the RPC lands.

## Verification

- `tsc --noEmit` passes with zero errors