### PR TITLE
fix: tool call cards appearing above user message instead of below

### DIFF
--- a/packages/desktop/src/renderer/stores/messageStore.ts
+++ b/packages/desktop/src/renderer/stores/messageStore.ts
@@ -74,11 +74,18 @@ export const useMessageStore = create<MessageState>((set, get) => ({
   upsertToolCall: (taskId, tc) =>
     set((s) => {
       const msgs = s.messagesByTask[taskId] ?? [];
-      // Find the last assistant message to attach the tool call to
-      let targetIdx = -1;
+
+      let lastAssistantIdx = -1;
+      let lastUserIdx = -1;
       for (let i = msgs.length - 1; i >= 0; i--) {
-        if (msgs[i].role === 'assistant') { targetIdx = i; break; }
+        if (lastAssistantIdx < 0 && msgs[i].role === 'assistant') lastAssistantIdx = i;
+        if (lastUserIdx < 0 && msgs[i].role === 'user') lastUserIdx = i;
+        if (lastAssistantIdx >= 0 && lastUserIdx >= 0) break;
       }
+
+      const targetIdx = (lastAssistantIdx >= 0 && lastAssistantIdx > lastUserIdx)
+        ? lastAssistantIdx
+        : -1;
 
       const updatedMsgs = [...msgs];
       if (targetIdx >= 0) {
@@ -92,7 +99,6 @@ export const useMessageStore = create<MessageState>((set, get) => ({
         }
         updatedMsgs[targetIdx] = { ...target, toolCalls: nextToolCalls };
       } else {
-        // No assistant message yet — create a placeholder to host tool calls
         updatedMsgs.push({
           id: generateId(),
           taskId,


### PR DESCRIPTION
## Summary

- **Bug**: After sending a message, agent tool call cards appeared above the user message (attached to the previous round's assistant message) instead of below it
- **Root cause**: `upsertToolCall()` searched backward from the end of the message list for the last `role === 'assistant'` message, without checking whether that message comes after the latest user message. When the agent had not yet produced a new assistant reply, tool calls were attached to the previous round's assistant message
- **Fix**: Track both `lastAssistantIdx` and `lastUserIdx`; only reuse an assistant message that appears after the latest user message, otherwise create a new assistant placeholder message at the end of the list

## Changed files

- `packages/desktop/src/renderer/stores/messageStore.ts` — `upsertToolCall()` method