### PR TITLE
fix: archived tasks view crashes with infinite loop white screen

### DIFF
--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { PanelRightOpen, RotateCcw, Archive, Plus, Server, ChevronDown, Bot, Cpu, ArrowUp, ArrowDown } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -341,12 +341,15 @@ function ChatContent() {
 
 function ArchivedTasks() {
   const { t } = useTranslation()
-  const archivedTasks = useTaskStore((s) =>
-    s.tasks.filter((task) => task.status === 'archived'),
-  )
+  const tasks = useTaskStore((s) => s.tasks)
   const setActiveTask = useTaskStore((s) => s.setActiveTask)
   const updateTaskStatus = useTaskStore((s) => s.updateTaskStatus)
   const setMainView = useUiStore((s) => s.setMainView)
+
+  const archivedTasks = useMemo(
+    () => tasks.filter((task) => task.status === 'archived'),
+    [tasks],
+  )
 
   const handleReactivate = (taskId: string): void => {
     updateTaskStatus(taskId, 'active')


### PR DESCRIPTION
## Summary

- **Bug**: Opening the archived tasks view caused a white screen crash with `getSnapshot should be cached` and `Maximum update depth exceeded` errors
- **Root cause**: Zustand selector in `ArchivedTasks` called `.filter()` inline, creating a new array reference on every snapshot check → infinite re-render loop
- **Fix**: Move `.filter()` from selector to `useMemo`, selector now returns the stable `s.tasks` reference

## Changes

`packages/desktop/src/renderer/layouts/MainArea/index.tsx`
- Import `useMemo` from React
- Selector: `useTaskStore((s) => s.tasks)` (stable reference)
- Filter: `useMemo(() => tasks.filter(...), [tasks])` (recomputes only when tasks change)

Consistent with the existing pattern in `LeftNav` (line 77-79).