### PR TITLE
[Feat] Voice input via local whisper.cpp sidecar

### DIFF
--- a/docs/voice-input-setup.md
+++ b/docs/voice-input-setup.md
@@ -1,0 +1,56 @@
+# Voice Input Setup
+
+> **Status:** Beta — tested on macOS only.
+
+ClawWork supports hold-Space-to-dictate via a local [whisper.cpp](https://github.com/ggerganov/whisper.cpp) sidecar. No cloud API is involved; all transcription runs on your machine.
+
+## Prerequisites
+
+1. **Install whisper-cpp** (provides the `whisper-cli` binary):
+
+   ```bash
+   brew install whisper-cpp
+   ```
+
+2. **Download a Whisper model.** The `large-v3-turbo` model offers a good balance of speed and accuracy. You can substitute any GGML-format Whisper model that fits your hardware:
+
+   | Model | Size | Notes |
+   |-------|------|-------|
+   | `ggml-tiny.bin` | ~75 MB | Fastest, lowest accuracy |
+   | `ggml-base.bin` | ~142 MB | Good for quick tests |
+   | `ggml-small.bin` | ~466 MB | Reasonable quality |
+   | `ggml-medium.bin` | ~1.5 GB | Better quality |
+   | `ggml-large-v3-turbo.bin` | ~1.6 GB | Recommended |
+   | `ggml-large-v3.bin` | ~3.1 GB | Best accuracy, slower |
+
+   ```bash
+   mkdir -p ~/models/whisper
+   cd ~/models/whisper
+   curl -LO https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin
+   ```
+
+## Model Search Paths
+
+ClawWork looks for models in the following directories (first match wins):
+
+- `~/models/whisper/`
+- `/opt/homebrew/share/whisper-cpp/models/`
+- `~/.local/share/whisper-cpp/models/`
+
+## Usage
+
+1. Open a task in ClawWork.
+2. **Hold Space** in the chat input to start recording.
+3. **Release Space** to stop recording and begin transcription.
+4. The transcript is inserted at the cursor position. It is never sent automatically.
+
+A short Space press still types a normal space.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Mic button shows "unsupported" | Verify `whisper-cli` is on your PATH: `which whisper-cli` |
+| "Microphone access was denied" | Grant microphone permission in **System Settings → Privacy & Security → Microphone** |
+| Transcription is slow | Use a smaller model (`ggml-base.bin` or `ggml-small.bin`) |
+| Wrong language detected | whisper.cpp auto-detects language. For best results, speak clearly in one language per recording |

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -23,6 +23,8 @@ mac:
   category: public.app-category.developer-tools
   identity: null
   icon: build/icon.icns
+  extendInfo:
+    NSMicrophoneUsageDescription: ClawWork needs microphone access for voice dictation in chat input.
 dmg:
   writeUpdateInfo: false
 win:

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import { registerSearchHandlers } from './ipc/search-handlers.js';
 import { registerDataHandlers } from './ipc/data-handlers.js';
 import { registerUpdateHandlers } from './ipc/update-handlers.js';
 import { registerDebugHandlers } from './ipc/debug-handlers.js';
+import { configureVoicePermissionHandlers, registerVoiceHandlers } from './ipc/voice-handlers.js';
 import { getWorkspacePath, readConfig } from './workspace/config.js';
 import { initDatabase, closeDatabase } from './db/index.js';
 
@@ -101,6 +102,8 @@ app.whenReady().then(() => {
   registerDataHandlers();
   registerUpdateHandlers();
   registerDebugHandlers();
+  registerVoiceHandlers();
+  configureVoicePermissionHandlers();
 
   const wsPath = getWorkspacePath();
   if (wsPath) {

--- a/packages/desktop/src/main/ipc/voice-handlers.ts
+++ b/packages/desktop/src/main/ipc/voice-handlers.ts
@@ -1,0 +1,190 @@
+import { ipcMain, session, systemPreferences } from 'electron';
+import { execFile } from 'child_process';
+import { writeFileSync, unlinkSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir, homedir } from 'os';
+import { randomUUID } from 'crypto';
+
+export type VoicePermissionStatus = 'granted' | 'not-determined' | 'denied' | 'unsupported';
+
+interface MediaPermissionDetails {
+  mediaType?: string;
+  mediaTypes?: string[];
+}
+
+interface WhisperCheckResult {
+  available: boolean;
+  binaryPath: string | null;
+  modelPath: string | null;
+  error?: string;
+}
+
+interface WhisperTranscribeResult {
+  ok: boolean;
+  transcript?: string;
+  error?: string;
+}
+
+const WHISPER_BINARY_CANDIDATES = [
+  '/opt/homebrew/bin/whisper-cli',
+  '/usr/local/bin/whisper-cli',
+  '/opt/homebrew/bin/whisper-cpp',
+  '/usr/local/bin/whisper-cpp',
+];
+
+const WHISPER_MODEL_DIRS = [
+  join(homedir(), 'models', 'whisper'),
+  '/opt/homebrew/share/whisper-cpp/models',
+  join(homedir(), '.local', 'share', 'whisper-cpp', 'models'),
+];
+
+const WHISPER_MODEL_NAMES = [
+  'ggml-large-v3-turbo.bin',
+  'ggml-large-v3.bin',
+  'ggml-large.bin',
+  'ggml-medium.bin',
+  'ggml-base.bin',
+  'ggml-small.bin',
+  'ggml-tiny.bin',
+];
+
+let cachedBinary: string | null | undefined;
+let cachedModel: string | null | undefined;
+
+function findWhisperBinary(): string | null {
+  if (cachedBinary !== undefined) return cachedBinary;
+  for (const candidate of WHISPER_BINARY_CANDIDATES) {
+    if (existsSync(candidate)) {
+      cachedBinary = candidate;
+      return candidate;
+    }
+  }
+  cachedBinary = null;
+  return null;
+}
+
+function findWhisperModel(): string | null {
+  if (cachedModel !== undefined) return cachedModel;
+  for (const dir of WHISPER_MODEL_DIRS) {
+    for (const name of WHISPER_MODEL_NAMES) {
+      const fullPath = join(dir, name);
+      if (existsSync(fullPath)) {
+        cachedModel = fullPath;
+        return fullPath;
+      }
+    }
+  }
+  cachedModel = null;
+  return null;
+}
+
+function whisperTranscribe(binaryPath: string, modelPath: string, audioPath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      binaryPath,
+      ['-m', modelPath, '-f', audioPath, '--no-timestamps', '-l', 'auto'],
+      { timeout: 60_000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr || error.message));
+          return;
+        }
+        const transcript = stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0)
+          .join(' ')
+          .trim();
+        resolve(transcript);
+      },
+    );
+  });
+}
+
+export function registerVoiceHandlers(): void {
+  ipcMain.handle('voice:get-microphone-permission', () => {
+    return { status: getMicrophonePermissionStatus() };
+  });
+
+  ipcMain.handle('voice:request-microphone-permission', async () => {
+    return { status: await requestMicrophonePermission() };
+  });
+
+  ipcMain.handle('voice:check-whisper', (): WhisperCheckResult => {
+    const binaryPath = findWhisperBinary();
+    if (!binaryPath) {
+      return { available: false, binaryPath: null, modelPath: null, error: 'whisper-cpp not found' };
+    }
+    const modelPath = findWhisperModel();
+    if (!modelPath) {
+      return { available: false, binaryPath, modelPath: null, error: 'no whisper model found' };
+    }
+    return { available: true, binaryPath, modelPath };
+  });
+
+  ipcMain.handle('voice:transcribe', async (_event, args: { audio: ArrayBuffer }): Promise<WhisperTranscribeResult> => {
+    const binaryPath = findWhisperBinary();
+    const modelPath = findWhisperModel();
+    if (!binaryPath || !modelPath) {
+      return { ok: false, error: 'whisper-cpp or model not found' };
+    }
+
+    const tempPath = join(tmpdir(), `clawwork-voice-${randomUUID()}.wav`);
+    try {
+      writeFileSync(tempPath, Buffer.from(args.audio));
+      const transcript = await whisperTranscribe(binaryPath, modelPath, tempPath);
+      return { ok: true, transcript };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    } finally {
+      try { unlinkSync(tempPath); } catch {}
+    }
+  });
+}
+
+export function configureVoicePermissionHandlers(): void {
+  const defaultSession = session.defaultSession;
+  if (!defaultSession) return;
+
+  defaultSession.setPermissionCheckHandler((_webContents, permission, _requestingOrigin, details) => {
+    if (permission !== 'media') return false;
+    return allowsAudioMedia(details as MediaPermissionDetails);
+  });
+
+  defaultSession.setPermissionRequestHandler((_webContents, permission, callback, details) => {
+    if (permission !== 'media') {
+      callback(false);
+      return;
+    }
+    callback(allowsAudioMedia(details as MediaPermissionDetails));
+  });
+}
+
+function getMicrophonePermissionStatus(): VoicePermissionStatus {
+  if (process.platform === 'darwin' || process.platform === 'win32') {
+    return normalizeMediaAccessStatus(systemPreferences.getMediaAccessStatus('microphone'));
+  }
+  return 'granted';
+}
+
+async function requestMicrophonePermission(): Promise<VoicePermissionStatus> {
+  if (process.platform === 'darwin') {
+    const granted = await systemPreferences.askForMediaAccess('microphone');
+    return granted ? 'granted' : 'denied';
+  }
+  return getMicrophonePermissionStatus();
+}
+
+function normalizeMediaAccessStatus(status: string): VoicePermissionStatus {
+  if (status === 'granted') return 'granted';
+  if (status === 'not-determined') return 'not-determined';
+  return 'denied';
+}
+
+function allowsAudioMedia(details: MediaPermissionDetails | undefined): boolean {
+  if (!details) return false;
+  if (Array.isArray(details.mediaTypes) && details.mediaTypes.includes('audio')) {
+    return true;
+  }
+  return details.mediaType === 'audio' || details.mediaType === 'unknown';
+}

--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -15,6 +15,10 @@ export interface GatewayServerConfig {
   color?: string;
 }
 
+export interface VoiceInputConfig {
+  introSeen?: boolean;
+}
+
 export interface AppConfig {
   workspacePath: string;
   theme?: 'dark' | 'light';
@@ -26,6 +30,7 @@ export interface AppConfig {
   bootstrapToken?: string;
   password?: string;
   tlsFingerprint?: string;
+  voiceInput?: VoiceInputConfig;
 }
 
 function configFilePath(): string {
@@ -45,6 +50,7 @@ function migrateConfigIfNeeded(config: AppConfig): AppConfig {
       workspacePath: config.workspacePath,
       theme: config.theme,
       language: config.language,
+      voiceInput: config.voiceInput,
       gateways: [
         {
           id,

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -68,7 +68,12 @@ interface AppSettings {
   bootstrapToken?: string;
   password?: string;
   tlsFingerprint?: string;
+  voiceInput?: {
+    introSeen?: boolean;
+  };
 }
+
+export type VoicePermissionStatus = 'granted' | 'not-determined' | 'denied' | 'unsupported';
 
 interface UpdateCheckResult {
   currentVersion: string;
@@ -198,6 +203,10 @@ export interface ClawWorkAPI {
   // Settings
   getSettings: () => Promise<AppSettings | null>;
   updateSettings: (partial: Partial<AppSettings>) => Promise<{ ok: boolean; config: AppSettings }>;
+  getMicrophonePermission: () => Promise<{ status: VoicePermissionStatus }>;
+  requestMicrophonePermission: () => Promise<{ status: VoicePermissionStatus }>;
+  checkWhisper: () => Promise<{ available: boolean; binaryPath: string | null; modelPath: string | null; error?: string }>;
+  transcribeAudio: (audio: ArrayBuffer) => Promise<{ ok: boolean; transcript?: string; error?: string }>;
 
   // Gateway management
   addGateway: (gateway: GatewayServerConfig) => Promise<IpcResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -86,6 +86,14 @@ function buildApi(): ClawWorkAPI {
       ipcRenderer.invoke('settings:get'),
     updateSettings: (partial: Record<string, unknown>) =>
       ipcRenderer.invoke('settings:update', partial),
+    getMicrophonePermission: () =>
+      ipcRenderer.invoke('voice:get-microphone-permission'),
+    requestMicrophonePermission: () =>
+      ipcRenderer.invoke('voice:request-microphone-permission'),
+    checkWhisper: () =>
+      ipcRenderer.invoke('voice:check-whisper'),
+    transcribeAudio: (audio: ArrayBuffer) =>
+      ipcRenderer.invoke('voice:transcribe', { audio }),
 
     addGateway: (gateway: GatewayServerConfig) =>
       ipcRenderer.invoke('settings:add-gateway', gateway),

--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -1,21 +1,25 @@
 import { useRef, useCallback, useState, useEffect, type KeyboardEvent, type ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Send, Paperclip, X, ChevronDown, Cpu, Brain } from 'lucide-react';
+import { Send, Paperclip, X, ChevronDown, Cpu, Brain, Mic, Loader2 } from 'lucide-react';
 import type { MessageImageAttachment } from '@clawwork/shared';
 import { toast } from 'sonner';
 import { cn, modKey } from '@/lib/utils';
 import { motion as motionPresets } from '@/styles/design-tokens';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   DropdownMenu, DropdownMenuTrigger,
   DropdownMenuContent, DropdownMenuItem,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
+import { createWhisperSttSession } from '@/lib/voice/whisper-stt';
+import { useVoiceInput } from '@/hooks/useVoiceInput';
 import { useTaskStore } from '../stores/taskStore';
 import { useMessageStore } from '../stores/messageStore';
 import { useUiStore } from '../stores/uiStore';
 import SlashCommandMenu from './SlashCommandMenu';
+import VoiceIntroDialog from './VoiceIntroDialog';
 import { filterSlashCommands, parseSlashQuery, type SlashCommand } from '@/lib/slash-commands';
 
 interface PendingImage {
@@ -79,6 +83,8 @@ export default function ChatInput() {
   const slashCommands = filterSlashCommands(slashQuery);
 
   const sendShortcut = useUiStore((s) => s.sendShortcut);
+  const mainView = useUiStore((s) => s.mainView);
+  const settingsOpen = useUiStore((s) => s.settingsOpen);
 
   /** Evaluate the current textarea value and cursor position to determine
    *  whether to show the slash command menu. */
@@ -126,9 +132,57 @@ export default function ChatInput() {
   const modelCatalog = useUiStore((s) => s.modelCatalog);
   const currentModel = activeTask?.model;
   const currentThinking = (activeTask?.thinkingLevel ?? 'off') as ThinkingLevel;
+  const [whisperAvailable, setWhisperAvailable] = useState(false);
+  useEffect(() => {
+    window.clawwork.checkWhisper().then((r) => setWhisperAvailable(r.available));
+  }, []);
   const modelLabel = currentModel
     ? modelCatalog.find((m) => m.id === currentModel)?.name ?? currentModel.split('/').pop() ?? currentModel
     : modelCatalog[0]?.name ?? 'Default';
+
+  const loadVoiceIntroSeen = useCallback(async () => {
+    const settings = await window.clawwork.getSettings();
+    return Boolean(settings?.voiceInput?.introSeen);
+  }, []);
+
+  const markVoiceIntroSeen = useCallback(async () => {
+    await window.clawwork.updateSettings({
+      voiceInput: {
+        introSeen: true,
+      },
+    });
+  }, []);
+
+  const requestVoicePermission = useCallback(async () => {
+    const result = await window.clawwork.requestMicrophonePermission();
+    return result.status;
+  }, []);
+
+  const {
+    isSupported: isVoiceSupported,
+    isListening: isVoiceListening,
+    isTranscribing: isVoiceTranscribing,
+    isIntroOpen: isVoiceIntroOpen,
+    interimTranscript,
+    errorCode: voiceErrorCode,
+    handleKeyDown: handleVoiceKeyDown,
+    handleKeyUp: handleVoiceKeyUp,
+    confirmIntro: confirmVoiceIntro,
+    dismissIntro: dismissVoiceIntro,
+    startFromTrigger: startVoiceInput,
+    stopListening: stopVoiceInput,
+  } = useVoiceInput({
+    textareaRef,
+    hasActiveTask: Boolean(activeTask) && !isOffline,
+    activeTaskKey: activeTask?.id ?? null,
+    mainView,
+    settingsOpen,
+    loadIntroSeen: loadVoiceIntroSeen,
+    markIntroSeen: markVoiceIntroSeen,
+    requestPermission: requestVoicePermission,
+    createSession: createWhisperSttSession,
+    isSupported: whisperAvailable,
+  });
 
   const handleModelChange = useCallback((modelId: string) => {
     if (!activeTask) return;
@@ -177,6 +231,7 @@ export default function ChatInput() {
   const handleSend = useCallback(async () => {
     const textarea = textareaRef.current;
     if (!textarea || !activeTask || isOffline) return;
+    stopVoiceInput();
 
     const content = textarea.value.trim();
     if (!content && !pendingImages.length) return;
@@ -220,10 +275,15 @@ export default function ChatInput() {
       addMessage(activeTask.id, 'system', `${t('errors.sendFailed')}: ${msg}`);
       toast.error('Failed to send message', { description: msg });
     }
-  }, [activeTask, addMessage, setProcessing, updateTaskTitle, isOffline, pendingImages, t]);
+  }, [activeTask, addMessage, setProcessing, updateTaskTitle, isOffline, pendingImages, stopVoiceInput, t]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      handleVoiceKeyDown(e);
+      if (e.defaultPrevented) {
+        return;
+      }
+
       // ── Slash menu keyboard navigation ────────────────────────────────────────
       if (slashMenuVisible && slashCommands.length > 0) {
         if (e.key === 'ArrowDown') {
@@ -260,7 +320,7 @@ export default function ChatInput() {
         }
       }
     },
-    [slashMenuVisible, slashCommands, slashIndex, commitSlashCommand, handleSend, sendShortcut],
+    [slashMenuVisible, slashCommands, slashIndex, commitSlashCommand, handleSend, handleVoiceKeyDown, sendShortcut],
   );
 
   const handleInput = useCallback(() => {
@@ -293,12 +353,37 @@ export default function ChatInput() {
     }
   }, []);
 
+  const voiceActive = isVoiceListening || isVoiceTranscribing;
   const disabled = !activeTask || isOffline;
   const placeholder = isOffline
     ? t('chatInput.offlineReadOnly')
     : !activeTask
       ? t('chatInput.createTaskFirst')
       : t('chatInput.describeTask');
+  const voiceTooltip = !isVoiceSupported
+    ? t('voiceInput.unsupportedTooltip')
+    : t('voiceInput.tooltip');
+
+  const prevTranscribingRef = useRef(false);
+  useEffect(() => {
+    if (prevTranscribingRef.current && !isVoiceTranscribing) {
+      textareaRef.current?.focus();
+    }
+    prevTranscribingRef.current = isVoiceTranscribing;
+  }, [isVoiceTranscribing]);
+
+  useEffect(() => {
+    if (!voiceErrorCode) return;
+    if (voiceErrorCode === 'permission-denied') {
+      toast.error(t('voiceInput.permissionDenied'));
+      return;
+    }
+    if (voiceErrorCode === 'unsupported') {
+      toast.error(t('voiceInput.unsupported'));
+      return;
+    }
+    toast.error(t('voiceInput.recognitionFailed'));
+  }, [voiceErrorCode, t]);
 
   return (
     <div className="flex-shrink-0 px-6 pb-5">
@@ -462,21 +547,87 @@ export default function ChatInput() {
               </Button>
             </motion.div>
 
-            <textarea
-              ref={textareaRef}
-              rows={1}
-              placeholder={placeholder}
-              disabled={disabled}
-              onKeyDown={handleKeyDown}
-              onInput={handleInput}
-              onPaste={handlePaste}
-              onClick={updateSlashMenu}
-              className={cn(
-                'flex-1 resize-none bg-transparent',
-                'text-[var(--text-primary)] placeholder:text-[var(--text-muted)]',
-                'outline-none max-h-40 disabled:opacity-50',
-              )}
-            />
+            <div className="flex-1 relative min-h-[24px]">
+              <textarea
+                ref={textareaRef}
+                rows={1}
+                placeholder={placeholder}
+                disabled={disabled || isVoiceTranscribing}
+                onKeyDown={handleKeyDown}
+                onKeyUp={handleVoiceKeyUp}
+                onInput={handleInput}
+                onPaste={handlePaste}
+                onClick={updateSlashMenu}
+                className={cn(
+                  'w-full resize-none bg-transparent',
+                  'text-[var(--text-primary)] placeholder:text-[var(--text-muted)]',
+                  'outline-none max-h-40 disabled:opacity-50',
+                  voiceActive && 'invisible',
+                )}
+              />
+              <AnimatePresence>
+                {voiceActive && (
+                  <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.15 }}
+                    className="absolute inset-0 flex items-center gap-2.5"
+                  >
+                    {isVoiceListening && (
+                      <>
+                        <span className="relative flex h-2.5 w-2.5">
+                          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--accent)] opacity-60" />
+                          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--accent)]" />
+                        </span>
+                        <span className="text-sm text-[var(--text-secondary)]">
+                          {t('voiceInput.listeningStatus')}
+                        </span>
+                      </>
+                    )}
+                    {isVoiceTranscribing && (
+                      <>
+                        <Loader2 size={14} className="animate-spin text-[var(--accent)]" />
+                        <span className="text-sm text-[var(--text-secondary)]">
+                          {t('voiceInput.transcribing')}
+                        </span>
+                      </>
+                    )}
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+            <div className="flex items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <Button
+                      variant={isVoiceListening ? 'soft' : 'ghost'}
+                      size="icon"
+                      onClick={() => {
+                        if (isVoiceListening) {
+                          stopVoiceInput();
+                          return;
+                        }
+                        void startVoiceInput();
+                      }}
+                      disabled={disabled}
+                      className={cn(
+                        'rounded-xl',
+                        isVoiceListening && 'text-[var(--accent)]',
+                        !isVoiceListening && 'text-[var(--text-muted)] hover:text-[var(--text-primary)]',
+                      )}
+                    >
+                      <Mic size={16} />
+                    </Button>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{voiceTooltip}</TooltipContent>
+              </Tooltip>
+              <span className="rounded-full bg-[var(--accent-soft)] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--accent)]">
+                {t('voiceInput.beta')}
+              </span>
+            </div>
             <motion.div
               whileHover={motionPresets.scale.whileHover}
               whileTap={motionPresets.scale.whileTap}
@@ -503,6 +654,11 @@ export default function ChatInput() {
               : t('chatInput.poweredBy')}
         </p>
       </div>
+      <VoiceIntroDialog
+        open={isVoiceIntroOpen}
+        onConfirm={confirmVoiceIntro}
+        onCancel={dismissVoiceIntro}
+      />
     </div>
   );
 }

--- a/packages/desktop/src/renderer/components/VoiceIntroDialog.tsx
+++ b/packages/desktop/src/renderer/components/VoiceIntroDialog.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface VoiceIntroDialogProps {
+  open: boolean
+  onConfirm: () => Promise<void> | void
+  onCancel: () => void
+}
+
+export default function VoiceIntroDialog({ open, onConfirm, onCancel }: VoiceIntroDialogProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onCancel() }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('voiceInput.introTitle')}</DialogTitle>
+          <DialogDescription>{t('voiceInput.introDescription')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-4 space-y-3">
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-4 py-3">
+            <p className="text-sm font-medium text-[var(--text-primary)]">{t('voiceInput.introStepHold')}</p>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">{t('voiceInput.introStepInsert')}</p>
+          </div>
+          <p className="text-sm text-[var(--text-secondary)]">{t('voiceInput.introStepBeta')}</p>
+        </div>
+
+        <DialogFooter className="mt-6">
+          <Button variant="ghost" onClick={onCancel}>
+            {t('voiceInput.introSkip')}
+          </Button>
+          <Button variant="soft" onClick={() => void onConfirm()}>
+            {t('voiceInput.introConfirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/desktop/src/renderer/components/ui/dialog.tsx
+++ b/packages/desktop/src/renderer/components/ui/dialog.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/50 backdrop-blur-sm',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out',
+      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-elevated)]',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close
+        className="absolute right-4 top-4 rounded-md p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+      >
+        <X size={16} />
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-col gap-1.5 text-left', className)} {...props} />
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex items-center justify-end gap-2', className)} {...props} />
+}
+
+const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold tracking-tight text-[var(--text-primary)]', className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm leading-relaxed text-[var(--text-secondary)]', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogPortal,
+  DialogClose,
+  DialogOverlay,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/packages/desktop/src/renderer/hooks/useVoiceInput.ts
+++ b/packages/desktop/src/renderer/hooks/useVoiceInput.ts
@@ -1,0 +1,335 @@
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent, type RefObject } from 'react';
+import {
+  insertTranscriptAtCaret,
+  resolveVoicePressAction,
+  shouldHandleVoiceHotkey,
+} from '@/lib/voice/voice-input-utils';
+import type { CreateVoiceSessionHandlers, VoiceErrorCode, VoicePermissionStatus, VoiceSession } from '@/lib/voice/types';
+
+export type { CreateVoiceSessionHandlers, VoiceErrorCode, VoicePermissionStatus, VoiceSession } from '@/lib/voice/types';
+
+interface UseVoiceInputOptions {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  hasActiveTask: boolean;
+  activeTaskKey?: string | null;
+  mainView: 'chat' | 'files' | 'archived';
+  settingsOpen: boolean;
+  loadIntroSeen: () => Promise<boolean>;
+  markIntroSeen: () => Promise<void>;
+  requestPermission: () => Promise<VoicePermissionStatus>;
+  createSession: (handlers: CreateVoiceSessionHandlers) => VoiceSession | null;
+  pressHoldDelayMs?: number;
+  isSupported?: boolean;
+  onTextInserted?: () => void;
+}
+
+interface UseVoiceInputResult {
+  isSupported: boolean;
+  isListening: boolean;
+  isTranscribing: boolean;
+  isIntroOpen: boolean;
+  interimTranscript: string;
+  errorCode: VoiceErrorCode | null;
+  handleKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  handleKeyUp: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  confirmIntro: () => Promise<void>;
+  dismissIntro: () => void;
+  startFromTrigger: () => Promise<void>;
+  stopListening: () => void;
+}
+
+export function useVoiceInput({
+  textareaRef,
+  hasActiveTask,
+  activeTaskKey,
+  mainView,
+  settingsOpen,
+  loadIntroSeen,
+  markIntroSeen,
+  requestPermission,
+  createSession,
+  pressHoldDelayMs = 220,
+  isSupported = true,
+  onTextInserted,
+}: UseVoiceInputOptions): UseVoiceInputResult {
+  const [isIntroOpen, setIsIntroOpen] = useState(false);
+  const [isListening, setIsListening] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const [interimTranscript, setInterimTranscript] = useState('');
+  const [errorCode, setErrorCode] = useState<VoiceErrorCode | null>(null);
+
+  const sessionRef = useRef<VoiceSession | null>(null);
+  const holdTimerRef = useRef<number | null>(null);
+  const pressStartedAtRef = useRef<number | null>(null);
+  const pressActiveRef = useRef(false);
+  const startedFromCurrentPressRef = useRef(false);
+  const isListeningRef = useRef(false);
+  const introSeenRef = useRef(false);
+  const startRequestIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadIntroSeen().then((seen) => {
+      if (cancelled) return;
+      introSeenRef.current = seen;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadIntroSeen]);
+
+  useEffect(() => {
+    isListeningRef.current = isListening;
+  }, [isListening]);
+
+  const clearHoldTimer = useCallback(() => {
+    if (holdTimerRef.current != null) {
+      window.clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+  }, []);
+
+  const releaseSession = useCallback((shouldStop: boolean) => {
+    const session = sessionRef.current;
+    sessionRef.current = null;
+    if (!session) return;
+    if (shouldStop) {
+      session.stop();
+    } else {
+      session.destroy?.();
+    }
+  }, []);
+
+  const clearListeningState = useCallback(() => {
+    setIsListening(false);
+    isListeningRef.current = false;
+    setInterimTranscript('');
+  }, []);
+
+  const stopListening = useCallback(() => {
+    clearHoldTimer();
+    const wasListening = isListeningRef.current;
+    releaseSession(true);
+    clearListeningState();
+    if (wasListening) {
+      setIsTranscribing(true);
+    }
+  }, [clearHoldTimer, releaseSession, clearListeningState]);
+
+  const insertIntoTextarea = useCallback((transcript: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const result = insertTranscriptAtCaret({
+      value: textarea.value,
+      selectionStart: textarea.selectionStart ?? textarea.value.length,
+      selectionEnd: textarea.selectionEnd ?? textarea.value.length,
+      transcript,
+    });
+
+    textarea.value = result.value;
+    textarea.setSelectionRange(result.selectionStart, result.selectionEnd);
+    textarea.focus();
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    onTextInserted?.();
+  }, [textareaRef, onTextInserted]);
+
+  const insertLiteralSpace = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const selectionStart = textarea.selectionStart ?? textarea.value.length;
+    const selectionEnd = textarea.selectionEnd ?? textarea.value.length;
+    const nextValue = `${textarea.value.slice(0, selectionStart)} ${textarea.value.slice(selectionEnd)}`;
+    const nextCaret = selectionStart + 1;
+    textarea.value = nextValue;
+    textarea.setSelectionRange(nextCaret, nextCaret);
+    textarea.focus();
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    onTextInserted?.();
+  }, [textareaRef, onTextInserted]);
+
+  const beginListening = useCallback(async (requiresActivePress: boolean) => {
+    if (!isSupported) {
+      setErrorCode('unsupported');
+      return;
+    }
+
+    setErrorCode(null);
+    const requestId = startRequestIdRef.current + 1;
+    startRequestIdRef.current = requestId;
+
+    const permissionStatus = await requestPermission();
+
+    if (startRequestIdRef.current !== requestId) return;
+    if (requiresActivePress && !pressActiveRef.current) return;
+
+    if (permissionStatus !== 'granted') {
+      setErrorCode(
+        permissionStatus === 'unsupported'
+          ? 'unsupported'
+          : 'permission-denied',
+      );
+      clearListeningState();
+      return;
+    }
+
+    const session = createSession({
+      onInterimResult: (text) => {
+        setInterimTranscript(text);
+      },
+      onFinalResult: (text) => {
+        setInterimTranscript('');
+        setIsTranscribing(false);
+        insertIntoTextarea(text);
+      },
+      onError: (code) => {
+        setErrorCode(code);
+        setIsTranscribing(false);
+        releaseSession(false);
+        clearListeningState();
+      },
+      onEnd: () => {
+        setIsTranscribing(false);
+        releaseSession(false);
+        clearListeningState();
+      },
+    });
+
+    if (!session) {
+      setErrorCode('unsupported');
+      clearListeningState();
+      return;
+    }
+
+    sessionRef.current = session;
+    session.start();
+    startedFromCurrentPressRef.current = requiresActivePress;
+    setInterimTranscript('');
+    setIsListening(true);
+    isListeningRef.current = true;
+  }, [isSupported, requestPermission, createSession, insertIntoTextarea, releaseSession, clearListeningState]);
+
+  const handleLongPress = useCallback(() => {
+    clearHoldTimer();
+    if (!introSeenRef.current) {
+      setIsIntroOpen(true);
+      return;
+    }
+    void beginListening(true);
+  }, [clearHoldTimer, beginListening]);
+
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === ' ' && pressActiveRef.current) {
+      event.preventDefault();
+      return;
+    }
+    if (!isSupported) return;
+    if (!shouldHandleVoiceHotkey({
+      key: event.key,
+      repeat: event.repeat,
+      altKey: event.altKey,
+      ctrlKey: event.ctrlKey,
+      metaKey: event.metaKey,
+      shiftKey: event.shiftKey,
+      isComposing: event.nativeEvent.isComposing,
+      hasActiveTask,
+      mainView,
+      settingsOpen,
+    })) {
+      return;
+    }
+
+    event.preventDefault();
+    clearHoldTimer();
+    pressActiveRef.current = true;
+    pressStartedAtRef.current = Date.now();
+    startedFromCurrentPressRef.current = false;
+    holdTimerRef.current = window.setTimeout(handleLongPress, pressHoldDelayMs);
+  }, [hasActiveTask, isSupported, mainView, settingsOpen, clearHoldTimer, handleLongPress, pressHoldDelayMs]);
+
+  const handleKeyUp = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== ' ') return;
+    if (pressStartedAtRef.current == null) return;
+
+    event.preventDefault();
+    const pressDuration = Date.now() - pressStartedAtRef.current;
+    pressStartedAtRef.current = null;
+    pressActiveRef.current = false;
+    clearHoldTimer();
+
+    if (isListeningRef.current || startedFromCurrentPressRef.current) {
+      stopListening();
+      return;
+    }
+
+    if (resolveVoicePressAction(pressDuration, pressHoldDelayMs) === 'insert-space') {
+      insertLiteralSpace();
+    }
+  }, [clearHoldTimer, insertLiteralSpace, pressHoldDelayMs, stopListening]);
+
+  const confirmIntro = useCallback(async () => {
+    await markIntroSeen();
+    introSeenRef.current = true;
+    setIsIntroOpen(false);
+  }, [markIntroSeen]);
+
+  const dismissIntro = useCallback(() => {
+    setIsIntroOpen(false);
+  }, []);
+
+  const startFromTrigger = useCallback(async () => {
+    if (!hasActiveTask || mainView !== 'chat' || settingsOpen) return;
+    if (!isSupported) {
+      setErrorCode('unsupported');
+      return;
+    }
+    if (!introSeenRef.current) {
+      setIsIntroOpen(true);
+      return;
+    }
+    await beginListening(false);
+  }, [hasActiveTask, isSupported, mainView, settingsOpen, beginListening]);
+
+  useEffect(() => {
+    if (!isListening) return;
+    const onWindowKeyUp = (e: globalThis.KeyboardEvent): void => {
+      if (e.key !== ' ') return;
+      if (!isListeningRef.current) return;
+      e.preventDefault();
+      pressStartedAtRef.current = null;
+      pressActiveRef.current = false;
+      clearHoldTimer();
+      stopListening();
+    };
+    window.addEventListener('keyup', onWindowKeyUp);
+    return () => window.removeEventListener('keyup', onWindowKeyUp);
+  }, [isListening, clearHoldTimer, stopListening]);
+
+  useEffect(() => {
+    if (!hasActiveTask || mainView !== 'chat' || settingsOpen) {
+      stopListening();
+    }
+  }, [activeTaskKey, hasActiveTask, mainView, settingsOpen, stopListening]);
+
+  useEffect(() => {
+    return () => {
+      clearHoldTimer();
+      releaseSession(false);
+    };
+  }, [clearHoldTimer, releaseSession]);
+
+  return {
+    isSupported,
+    isListening,
+    isTranscribing,
+    isIntroOpen,
+    interimTranscript,
+    errorCode,
+    handleKeyDown,
+    handleKeyUp,
+    confirmIntro,
+    dismissIntro,
+    startFromTrigger,
+    stopListening,
+  };
+}

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -156,6 +156,24 @@
     "thinkingMedium": "Medium",
     "thinkingHigh": "High"
   },
+  "voiceInput": {
+    "tooltip": "Voice Input (Beta)",
+    "unsupportedTooltip": "Voice input requires whisper-cpp. Run: brew install whisper-cpp",
+    "listeningStatus": "Recording... release Space to transcribe",
+    "interimLabel": "Heard so far",
+    "beta": "Beta",
+    "permissionDenied": "Microphone access was denied",
+    "unsupported": "whisper-cpp not found. Run: brew install whisper-cpp, then download a model to ~/models/whisper/",
+    "transcribing": "Transcribing...",
+    "recognitionFailed": "Voice recognition failed",
+    "introTitle": "Voice Input (Beta)",
+    "introDescription": "Hold Space to dictate, then release to finish.",
+    "introStepHold": "The transcript is inserted into the input box and is never sent automatically.",
+    "introStepInsert": "Short press Space still inserts a normal space.",
+    "introStepBeta": "Requires whisper-cpp installed locally. Run: brew install whisper-cpp",
+    "introConfirm": "Got it",
+    "introSkip": "Not now"
+  },
   "chatMessage": {
     "copyMessage": "Copy message",
     "copyCode": "Copy code",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -156,6 +156,24 @@
     "thinkingMedium": "中",
     "thinkingHigh": "高"
   },
+  "voiceInput": {
+    "tooltip": "语音输入（Beta）",
+    "unsupportedTooltip": "语音输入需要 whisper-cpp，请运行: brew install whisper-cpp",
+    "listeningStatus": "正在录音…松开 Space 开始识别",
+    "interimLabel": "当前识别",
+    "beta": "Beta",
+    "permissionDenied": "麦克风权限被拒绝",
+    "unsupported": "未找到 whisper-cpp，请运行 brew install whisper-cpp 并下载模型到 ~/models/whisper/",
+    "transcribing": "正在识别…",
+    "recognitionFailed": "语音识别失败",
+    "introTitle": "语音输入（Beta）",
+    "introDescription": "按住 Space 说话，松开后结束。",
+    "introStepHold": "识别结果会写入输入框，不会自动发送。",
+    "introStepInsert": "短按 Space 仍然会输入普通空格。",
+    "introStepBeta": "需要本地安装 whisper-cpp，请运行: brew install whisper-cpp",
+    "introConfirm": "知道了",
+    "introSkip": "暂不使用"
+  },
   "chatMessage": {
     "copyMessage": "复制消息",
     "copyCode": "复制代码",

--- a/packages/desktop/src/renderer/lib/voice/types.ts
+++ b/packages/desktop/src/renderer/lib/voice/types.ts
@@ -1,0 +1,21 @@
+export interface VoiceSession {
+  start: () => void;
+  stop: () => void;
+  destroy?: () => void;
+}
+
+export interface CreateVoiceSessionHandlers {
+  onInterimResult: (text: string) => void;
+  onFinalResult: (text: string) => void;
+  onError: (code: VoiceErrorCode) => void;
+  onEnd: () => void;
+}
+
+export type VoicePermissionStatus = 'granted' | 'not-determined' | 'denied' | 'unsupported';
+
+export type VoiceErrorCode =
+  | 'permission-denied'
+  | 'unsupported'
+  | 'mic-access-failed'
+  | 'transcription-failed'
+  | (string & {});

--- a/packages/desktop/src/renderer/lib/voice/voice-input-utils.ts
+++ b/packages/desktop/src/renderer/lib/voice/voice-input-utils.ts
@@ -1,0 +1,85 @@
+type MainView = 'chat' | 'files' | 'archived';
+
+interface InsertTranscriptParams {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+  transcript: string;
+}
+
+interface InsertTranscriptResult {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+  insertedText: string;
+}
+
+interface VoiceHotkeyParams {
+  key: string;
+  repeat: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  isComposing: boolean;
+  hasActiveTask: boolean;
+  mainView: MainView;
+  settingsOpen: boolean;
+}
+
+export function insertTranscriptAtCaret({
+  value,
+  selectionStart,
+  selectionEnd,
+  transcript,
+}: InsertTranscriptParams): InsertTranscriptResult {
+  const trimmedTranscript = transcript.trim();
+  if (!trimmedTranscript) {
+    return {
+      value,
+      selectionStart,
+      selectionEnd,
+      insertedText: '',
+    };
+  }
+
+  const prefix = needsLeadingSpace(value, selectionStart) ? ' ' : '';
+  const insertedText = `${prefix}${trimmedTranscript}`;
+  const nextValue = `${value.slice(0, selectionStart)}${insertedText}${value.slice(selectionEnd)}`;
+  const nextCaret = selectionStart + insertedText.length;
+
+  return {
+    value: nextValue,
+    selectionStart: nextCaret,
+    selectionEnd: nextCaret,
+    insertedText,
+  };
+}
+
+export function shouldHandleVoiceHotkey({
+  key,
+  repeat,
+  altKey,
+  ctrlKey,
+  metaKey,
+  shiftKey,
+  isComposing,
+  hasActiveTask,
+  mainView,
+  settingsOpen,
+}: VoiceHotkeyParams): boolean {
+  if (key !== ' ') return false;
+  if (repeat || altKey || ctrlKey || metaKey || shiftKey || isComposing) return false;
+  if (!hasActiveTask || mainView !== 'chat' || settingsOpen) return false;
+  return true;
+}
+
+export function resolveVoicePressAction(durationMs: number, thresholdMs: number): 'insert-space' | 'start-voice' {
+  return durationMs >= thresholdMs ? 'start-voice' : 'insert-space';
+}
+
+function needsLeadingSpace(value: string, selectionStart: number): boolean {
+  if (selectionStart <= 0) return false;
+  const previousChar = value[selectionStart - 1];
+  return !/\s/.test(previousChar) && previousChar !== '(';
+}

--- a/packages/desktop/src/renderer/lib/voice/whisper-stt.ts
+++ b/packages/desktop/src/renderer/lib/voice/whisper-stt.ts
@@ -1,0 +1,143 @@
+import type { CreateVoiceSessionHandlers, VoiceSession } from '@/lib/voice/types';
+
+const TARGET_SAMPLE_RATE = 16000;
+
+export function createWhisperSttSession(
+  handlers: CreateVoiceSessionHandlers,
+): VoiceSession | null {
+  if (!navigator.mediaDevices?.getUserMedia) return null;
+
+  let stream: MediaStream | null = null;
+  let audioContext: AudioContext | null = null;
+  let source: MediaStreamAudioSourceNode | null = null;
+  let processor: ScriptProcessorNode | null = null;
+  let chunks: Float32Array[] = [];
+  let stopped = false;
+
+  function cleanup(): void {
+    if (processor) {
+      processor.disconnect();
+      processor.onaudioprocess = null;
+      processor = null;
+    }
+    if (source) {
+      source.disconnect();
+      source = null;
+    }
+    if (audioContext) {
+      void audioContext.close();
+      audioContext = null;
+    }
+    if (stream) {
+      stream.getTracks().forEach((t) => t.stop());
+      stream = null;
+    }
+    chunks = [];
+  }
+
+  return {
+    start: () => {
+      stopped = false;
+      navigator.mediaDevices
+        .getUserMedia({ audio: { channelCount: 1 } })
+        .then((mediaStream) => {
+          if (stopped) {
+            mediaStream.getTracks().forEach((t) => t.stop());
+            return;
+          }
+          stream = mediaStream;
+          audioContext = new AudioContext({ sampleRate: TARGET_SAMPLE_RATE });
+          source = audioContext.createMediaStreamSource(stream);
+          processor = audioContext.createScriptProcessor(4096, 1, 1);
+          processor.onaudioprocess = (e) => {
+            const data = e.inputBuffer.getChannelData(0);
+            chunks.push(new Float32Array(data));
+          };
+          source.connect(processor);
+          processor.connect(audioContext.destination);
+        })
+        .catch((err) => {
+          handlers.onError(err instanceof Error ? err.message : 'mic-access-failed');
+        });
+    },
+
+    stop: () => {
+      stopped = true;
+      const captured = chunks;
+      const capturedContext = audioContext;
+      cleanup();
+
+      if (captured.length === 0) {
+        handlers.onEnd();
+        return;
+      }
+
+      const sampleRate = capturedContext?.sampleRate ?? TARGET_SAMPLE_RATE;
+      const wav = encodeWav(captured, sampleRate);
+
+      window.clawwork
+        .transcribeAudio(wav)
+        .then((result) => {
+          if (result.ok && result.transcript) {
+            handlers.onFinalResult(result.transcript);
+          } else {
+            handlers.onError(result.error ?? 'transcription-failed');
+          }
+        })
+        .catch((err) => {
+          handlers.onError(err instanceof Error ? err.message : 'transcription-failed');
+        })
+        .finally(() => {
+          handlers.onEnd();
+        });
+    },
+
+    destroy: () => {
+      stopped = true;
+      cleanup();
+    },
+  };
+}
+
+function encodeWav(chunks: Float32Array[], sampleRate: number): ArrayBuffer {
+  let totalLength = 0;
+  for (const chunk of chunks) totalLength += chunk.length;
+
+  const pcm = new Int16Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    for (let i = 0; i < chunk.length; i++) {
+      const s = Math.max(-1, Math.min(1, chunk[i]));
+      pcm[offset++] = s < 0 ? s * 0x8000 : s * 0x7fff;
+    }
+  }
+
+  const dataLength = pcm.length * 2;
+  const buffer = new ArrayBuffer(44 + dataLength);
+  const view = new DataView(buffer);
+
+  writeString(view, 0, 'RIFF');
+  view.setUint32(4, 36 + dataLength, true);
+  writeString(view, 8, 'WAVE');
+  writeString(view, 12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeString(view, 36, 'data');
+  view.setUint32(40, dataLength, true);
+
+  const pcmBytes = new Uint8Array(pcm.buffer);
+  new Uint8Array(buffer).set(pcmBytes, 44);
+
+  return buffer;
+}
+
+function writeString(view: DataView, offset: number, str: string): void {
+  for (let i = 0; i < str.length; i++) {
+    view.setUint8(offset + i, str.charCodeAt(i));
+  }
+}

--- a/packages/desktop/test/use-voice-input.test.tsx
+++ b/packages/desktop/test/use-voice-input.test.tsx
@@ -1,0 +1,411 @@
+// @vitest-environment jsdom
+
+import { act, type ReactElement, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVoiceInput, type VoicePermissionStatus } from '../src/renderer/hooks/useVoiceInput';
+
+interface FakeSession {
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  emitInterim: (text: string) => void;
+  emitFinal: (text: string) => void;
+  emitError: (code: string) => void;
+  emitEnd: () => void;
+}
+
+function createFakeSessionFactory(): {
+  createSession: ReturnType<typeof vi.fn>;
+  getLastSession: () => FakeSession | null;
+} {
+  let lastSession: FakeSession | null = null;
+
+  const createSession = vi.fn((handlers: {
+    onInterimResult: (text: string) => void;
+    onFinalResult: (text: string) => void;
+    onError: (code: string) => void;
+    onEnd: () => void;
+  }) => {
+    lastSession = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+      emitInterim: (text: string) => handlers.onInterimResult(text),
+      emitFinal: (text: string) => handlers.onFinalResult(text),
+      emitError: (code: string) => handlers.onError(code),
+      emitEnd: () => handlers.onEnd(),
+    };
+
+    return lastSession;
+  });
+
+  return {
+    createSession,
+    getLastSession: () => lastSession,
+  };
+}
+
+function render(ui: ReactElement): { container: HTMLDivElement; unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+interface HarnessProps {
+  hasActiveTask?: boolean;
+  mainView?: 'chat' | 'files' | 'archived';
+  settingsOpen?: boolean;
+  isSupported?: boolean;
+  initialValue?: string;
+  loadIntroSeen?: () => Promise<boolean>;
+  markIntroSeen?: () => Promise<void>;
+  requestPermission?: () => Promise<VoicePermissionStatus>;
+  createSession?: ReturnType<typeof vi.fn>;
+}
+
+function Harness({
+  hasActiveTask = true,
+  mainView = 'chat',
+  settingsOpen = false,
+  isSupported = true,
+  initialValue = '',
+  loadIntroSeen = async () => true,
+  markIntroSeen = async () => {},
+  requestPermission = async () => 'granted',
+  createSession,
+}: HarnessProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const voice = useVoiceInput({
+    textareaRef,
+    hasActiveTask,
+    mainView,
+    settingsOpen,
+    loadIntroSeen,
+    markIntroSeen,
+    requestPermission,
+    createSession: createSession ?? (() => null),
+    pressHoldDelayMs: 220,
+    isSupported,
+  });
+
+  return (
+    <>
+      <textarea
+        ref={textareaRef}
+        defaultValue={initialValue}
+        onKeyDown={voice.handleKeyDown}
+        onKeyUp={voice.handleKeyUp}
+      />
+      <button type="button" data-testid="confirm-intro" onClick={() => void voice.confirmIntro()}>
+        confirm
+      </button>
+      <button type="button" data-testid="start-trigger" onClick={() => void voice.startFromTrigger()}>
+        start
+      </button>
+      <div data-testid="intro-state">{voice.isIntroOpen ? 'open' : 'closed'}</div>
+      <div data-testid="listening-state">{voice.isListening ? 'listening' : 'idle'}</div>
+      <div data-testid="interim">{voice.interimTranscript}</div>
+      <div data-testid="error">{voice.errorCode ?? ''}</div>
+    </>
+  );
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('useVoiceInput', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('treats a short space press as normal whitespace', async () => {
+    const requestPermission = vi.fn(async () => 'granted' as const);
+    const sessionFactory = createFakeSessionFactory();
+    const { container, unmount } = render(
+      <Harness
+        initialValue="hello"
+        loadIntroSeen={async () => true}
+        requestPermission={requestPermission}
+        createSession={sessionFactory.createSession}
+      />,
+    );
+
+    await flushAsync();
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    textarea!.focus();
+    textarea!.setSelectionRange(5, 5);
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', bubbles: true }));
+    });
+
+    expect(textarea!.value).toBe('hello ');
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(sessionFactory.createSession).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('swallows repeated keydown events during a held space press', async () => {
+    const requestPermission = vi.fn(async () => 'granted' as const);
+    const sessionFactory = createFakeSessionFactory();
+    const { container, unmount } = render(
+      <Harness
+        initialValue=""
+        loadIntroSeen={async () => true}
+        requestPermission={requestPermission}
+        createSession={sessionFactory.createSession}
+      />,
+    );
+
+    await flushAsync();
+
+    const textarea = container.querySelector('textarea');
+    textarea!.focus();
+    textarea!.setSelectionRange(0, 0);
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', repeat: true, bubbles: true }));
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', repeat: true, bubbles: true }));
+      vi.advanceTimersByTime(100);
+      textarea!.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', bubbles: true }));
+    });
+
+    expect(textarea!.value).toBe(' ');
+    expect(requestPermission).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('opens the intro dialog on the first long press without starting recognition', async () => {
+    const requestPermission = vi.fn(async () => 'granted' as const);
+    const sessionFactory = createFakeSessionFactory();
+    const { container, unmount } = render(
+      <Harness
+        loadIntroSeen={async () => false}
+        requestPermission={requestPermission}
+        createSession={sessionFactory.createSession}
+      />,
+    );
+
+    await flushAsync();
+
+    const textarea = container.querySelector('textarea');
+    const introState = container.querySelector('[data-testid="intro-state"]');
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      vi.advanceTimersByTime(220);
+    });
+
+    await flushAsync();
+
+    expect(introState?.textContent).toBe('open');
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(sessionFactory.createSession).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('starts recognition after intro confirmation and inserts transcripts correctly', async () => {
+    const requestPermission = vi.fn(async () => 'granted' as const);
+    const markIntroSeen = vi.fn(async () => {});
+    const sessionFactory = createFakeSessionFactory();
+    const { container, unmount } = render(
+      <Harness
+        initialValue="alpha"
+        loadIntroSeen={async () => false}
+        markIntroSeen={markIntroSeen}
+        requestPermission={requestPermission}
+        createSession={sessionFactory.createSession}
+      />,
+    );
+
+    await flushAsync();
+
+    const textarea = container.querySelector('textarea');
+    const confirmButton = container.querySelector('[data-testid="confirm-intro"]');
+    const introState = container.querySelector('[data-testid="intro-state"]');
+    const listeningState = container.querySelector('[data-testid="listening-state"]');
+    const interim = container.querySelector('[data-testid="interim"]');
+
+    textarea!.focus();
+    textarea!.setSelectionRange(5, 5);
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      vi.advanceTimersByTime(220);
+    });
+
+    expect(introState?.textContent).toBe('open');
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', bubbles: true }));
+    });
+
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(markIntroSeen).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      vi.advanceTimersByTime(220);
+    });
+
+    await flushAsync();
+
+    const session = sessionFactory.getLastSession();
+
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(sessionFactory.createSession).toHaveBeenCalledTimes(1);
+    expect(session?.start).toHaveBeenCalledTimes(1);
+    expect(listeningState?.textContent).toBe('listening');
+
+    act(() => {
+      session?.emitInterim('beta');
+    });
+
+    expect(interim?.textContent).toBe('beta');
+    expect(textarea!.value).toBe('alpha');
+
+    act(() => {
+      session?.emitFinal('gamma');
+    });
+
+    expect(textarea!.value).toBe('alpha gamma');
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', bubbles: true }));
+    });
+
+    expect(session?.stop).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it('reports permission denial and does not start recognition', async () => {
+    const requestPermission = vi.fn(async () => 'denied' as const);
+    const sessionFactory = createFakeSessionFactory();
+    const { container, unmount } = render(
+      <Harness
+        loadIntroSeen={async () => true}
+        requestPermission={requestPermission}
+        createSession={sessionFactory.createSession}
+      />,
+    );
+
+    await flushAsync();
+
+    const textarea = container.querySelector('textarea');
+    const error = container.querySelector('[data-testid="error"]');
+    const listeningState = container.querySelector('[data-testid="listening-state"]');
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      vi.advanceTimersByTime(220);
+    });
+
+    await flushAsync();
+
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(sessionFactory.createSession).not.toHaveBeenCalled();
+    expect(error?.textContent).toBe('permission-denied');
+    expect(listeningState?.textContent).toBe('idle');
+
+    unmount();
+  });
+
+  it('stops and destroys the active session on unmount', async () => {
+    const sessionFactory = createFakeSessionFactory();
+    const { container, unmount } = render(
+      <Harness
+        loadIntroSeen={async () => true}
+        requestPermission={async () => 'granted'}
+        createSession={sessionFactory.createSession}
+      />,
+    );
+
+    await flushAsync();
+
+    const textarea = container.querySelector('textarea');
+
+    act(() => {
+      textarea!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      vi.advanceTimersByTime(220);
+    });
+
+    await flushAsync();
+
+    const session = sessionFactory.getLastSession();
+    expect(session?.start).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(session?.stop).not.toHaveBeenCalled();
+    expect(session?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports unsupported when trigger start is requested in an unsupported runtime', async () => {
+    const requestPermission = vi.fn(async () => 'granted' as const);
+    const sessionFactory = createFakeSessionFactory();
+    const { container, unmount } = render(
+      <Harness
+        isSupported={false}
+        loadIntroSeen={async () => true}
+        requestPermission={requestPermission}
+        createSession={sessionFactory.createSession}
+      />,
+    );
+
+    await flushAsync();
+
+    const startButton = container.querySelector('[data-testid="start-trigger"]');
+    const error = container.querySelector('[data-testid="error"]');
+
+    await act(async () => {
+      startButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(error?.textContent).toBe('unsupported');
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(sessionFactory.createSession).not.toHaveBeenCalled();
+
+    unmount();
+  });
+});

--- a/packages/desktop/test/voice-input-utils.test.ts
+++ b/packages/desktop/test/voice-input-utils.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import {
+  insertTranscriptAtCaret,
+  resolveVoicePressAction,
+  shouldHandleVoiceHotkey,
+} from '../src/renderer/lib/voice/voice-input-utils';
+
+describe('insertTranscriptAtCaret', () => {
+  it('inserts trimmed transcript into an empty input', () => {
+    const result = insertTranscriptAtCaret({
+      value: '',
+      selectionStart: 0,
+      selectionEnd: 0,
+      transcript: '  hello world  ',
+    });
+
+    expect(result).toEqual({
+      value: 'hello world',
+      selectionStart: 11,
+      selectionEnd: 11,
+      insertedText: 'hello world',
+    });
+  });
+
+  it('replaces the current selection with the transcript', () => {
+    const result = insertTranscriptAtCaret({
+      value: 'alpha beta',
+      selectionStart: 6,
+      selectionEnd: 10,
+      transcript: 'gamma',
+    });
+
+    expect(result).toEqual({
+      value: 'alpha gamma',
+      selectionStart: 11,
+      selectionEnd: 11,
+      insertedText: 'gamma',
+    });
+  });
+
+  it('adds a leading space when inserting after a word character', () => {
+    const result = insertTranscriptAtCaret({
+      value: 'alpha',
+      selectionStart: 5,
+      selectionEnd: 5,
+      transcript: 'beta',
+    });
+
+    expect(result).toEqual({
+      value: 'alpha beta',
+      selectionStart: 10,
+      selectionEnd: 10,
+      insertedText: ' beta',
+    });
+  });
+
+  it('does not add a leading space after whitespace, newlines, or opening brackets', () => {
+    const whitespace = insertTranscriptAtCaret({
+      value: 'alpha ',
+      selectionStart: 6,
+      selectionEnd: 6,
+      transcript: 'beta',
+    });
+    const newline = insertTranscriptAtCaret({
+      value: 'alpha\n',
+      selectionStart: 6,
+      selectionEnd: 6,
+      transcript: 'beta',
+    });
+    const bracket = insertTranscriptAtCaret({
+      value: 'alpha(',
+      selectionStart: 6,
+      selectionEnd: 6,
+      transcript: 'beta',
+    });
+
+    expect(whitespace.insertedText).toBe('beta');
+    expect(whitespace.value).toBe('alpha beta');
+    expect(newline.insertedText).toBe('beta');
+    expect(newline.value).toBe('alpha\nbeta');
+    expect(bracket.insertedText).toBe('beta');
+    expect(bracket.value).toBe('alpha(beta');
+  });
+});
+
+describe('shouldHandleVoiceHotkey', () => {
+  it('allows space on chat view when there is an active task and no blockers', () => {
+    expect(shouldHandleVoiceHotkey({
+      key: ' ',
+      repeat: false,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      hasActiveTask: true,
+      mainView: 'chat',
+      settingsOpen: false,
+    })).toBe(true);
+  });
+
+  it('rejects the hotkey when view or modifier state makes it unsafe', () => {
+    expect(shouldHandleVoiceHotkey({
+      key: ' ',
+      repeat: false,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      hasActiveTask: true,
+      mainView: 'files',
+      settingsOpen: false,
+    })).toBe(false);
+
+    expect(shouldHandleVoiceHotkey({
+      key: ' ',
+      repeat: false,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: true,
+      shiftKey: false,
+      isComposing: false,
+      hasActiveTask: true,
+      mainView: 'chat',
+      settingsOpen: false,
+    })).toBe(false);
+
+    expect(shouldHandleVoiceHotkey({
+      key: ' ',
+      repeat: false,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: true,
+      hasActiveTask: true,
+      mainView: 'chat',
+      settingsOpen: false,
+    })).toBe(false);
+
+    expect(shouldHandleVoiceHotkey({
+      key: ' ',
+      repeat: true,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      hasActiveTask: true,
+      mainView: 'chat',
+      settingsOpen: false,
+    })).toBe(false);
+
+    expect(shouldHandleVoiceHotkey({
+      key: 'Enter',
+      repeat: false,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      hasActiveTask: true,
+      mainView: 'chat',
+      settingsOpen: false,
+    })).toBe(false);
+  });
+});
+
+describe('resolveVoicePressAction', () => {
+  it('treats presses shorter than the threshold as a normal space', () => {
+    expect(resolveVoicePressAction(219, 220)).toBe('insert-space');
+  });
+
+  it('treats presses at or beyond the threshold as voice activation', () => {
+    expect(resolveVoicePressAction(220, 220)).toBe('start-voice');
+    expect(resolveVoicePressAction(480, 220)).toBe('start-voice');
+  });
+});


### PR DESCRIPTION
## Summary

Add hold-Space-to-dictate voice input to the chat input, powered by a local whisper.cpp sidecar process. All transcription runs on-device — no cloud API involved. Includes first-use onboarding dialog, mic button, inline recording/transcribing overlay, and setup documentation.

## Type of change

- [x] `[Feat]` new feature

## Why is this needed?

Voice dictation significantly improves input speed for longer task descriptions. Running transcription locally via whisper.cpp keeps data private and avoids external service dependencies.

## What changed?

- **Main process:** `voice-handlers.ts` — IPC handlers for microphone permission, whisper.cpp binary/model detection (with module-level caching), and audio transcription via `execFile`
- **Preload bridge:** Exposed `getMicrophonePermission`, `requestMicrophonePermission`, `checkWhisper`, `transcribeAudio` APIs
- **Voice hook:** `useVoiceInput` — state machine managing hold-to-record, permission flow, intro dialog gating, and session lifecycle
- **Audio capture:** `whisper-stt.ts` — MediaStream → AudioContext → ScriptProcessorNode PCM capture, WAV encoding, IPC transcription
- **Pure utils:** `voice-input-utils.ts` — transcript-at-caret insertion, hotkey guard, press duration classification
- **Voice types:** Extracted `VoiceSession`, `CreateVoiceSessionHandlers`, `VoicePermissionStatus`, `VoiceErrorCode` into `lib/voice/types.ts`
- **ChatInput UI:** Mic button with tooltip, inline recording (pulsing dot) and transcribing (spinner) overlays, error toasts, auto-refocus after transcription
- **VoiceIntroDialog:** First-use onboarding explaining hold-Space mechanics
- **shadcn Dialog:** Added `ui/dialog.tsx` (Radix-based)
- **i18n:** en.json + zh.json voice input strings
- **macOS:** `NSMicrophoneUsageDescription` in electron-builder config
- **Docs:** `docs/voice-input-setup.md` — installation guide for whisper-cpp and model download
- **Tests:** 15 tests covering voice-input-utils (8) and useVoiceInput hook (7)
- **Cleanup:** Removed dead `browser-stt.ts` (unreachable in Electron), fixed `VoiceErrorCode` type collapse, cached filesystem probes, fixed `releaseSession` stop/destroy semantics

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck  ✓
pnpm test       ✓ 38 tests passed (4 suites)
Manual test     ✓ hold-Space recording, release-to-transcribe, mic button toggle, continuous dictation, intro dialog
```

## Screenshots or recordings

N/A

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Voice input (Beta): Hold Space in the chat input to dictate via local whisper.cpp. Requires `brew install whisper-cpp` and a downloaded model. See docs/voice-input-setup.md.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate