### PR TITLE
chore: release v0.0.5

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawwork/desktop",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "description": "OpenClaw desktop client with structured task management",
   "type": "module",


### PR DESCRIPTION
Bump desktop version from v0.0.4 to v0.0.5.