### PR TITLE
fix(renderer): add root ErrorBoundary to prevent white screen crashes

### DIFF
--- a/packages/desktop/src/renderer/components/ErrorBoundary.tsx
+++ b/packages/desktop/src/renderer/components/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ErrorBoundary]', error, info)
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children
+
+    return (
+      <div className="flex h-screen items-center justify-center bg-[var(--bg-primary)]">
+        <div className="flex flex-col items-center gap-4 max-w-md px-6 text-center">
+          <div className="w-12 h-12 rounded-full bg-[var(--accent-dim)] flex items-center justify-center">
+            <AlertTriangle size={22} className="text-[var(--accent)]" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <p className="text-[var(--text-primary)] font-medium">Something went wrong</p>
+            <p className="text-[var(--text-muted)] text-sm font-mono break-all">
+              {this.state.error?.message}
+            </p>
+          </div>
+          <button
+            onClick={() => window.location.reload()}
+            className="flex items-center gap-2 px-4 py-2 rounded-md bg-[var(--accent)] text-black text-sm font-medium hover:opacity-90 transition-opacity"
+          >
+            <RefreshCw size={14} />
+            Reload
+          </button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -4,6 +4,7 @@ import './styles/theme.css';
 import i18n from './i18n';
 import { useUiStore, type Language } from './stores/uiStore';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 
 // Restore persisted language preference
 window.clawwork?.getSettings().then((settings) => {
@@ -17,6 +18,8 @@ window.clawwork?.getSettings().then((settings) => {
 const root = createRoot(document.getElementById('root')!);
 root.render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- Add `ErrorBoundary` component to catch render-time errors
- Wrap App root with ErrorBoundary for graceful error display
- Refs: issues.md P0 #3