### PR TITLE
[Fix] Enable sandbox and remove unsafe preload fallback

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -63,7 +63,9 @@ function createWindow(): BrowserWindow {
     backgroundColor: readConfig()?.theme === 'light' ? '#FAFAFA' : '#1C1C1C',
     webPreferences: {
       preload: join(__dirname, '../preload/index.mjs'),
-      sandbox: false,
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
     },
   });
 

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -137,11 +137,8 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('electron', electronAPI);
     contextBridge.exposeInMainWorld('clawwork', buildApi());
   } catch (error) {
-    console.error(error);
+    throw new Error(`[preload] Failed to expose ClawWork API: ${error instanceof Error ? error.message : String(error)}`);
   }
 } else {
-  // @ts-ignore fallback for non-isolated context
-  window.electron = electronAPI;
-  // @ts-ignore
-  window.clawwork = buildApi();
+  throw new Error('[preload] contextIsolation must be enabled.');
 }


### PR DESCRIPTION
## Summary

Enable Electron sandbox mode and contextIsolation on BrowserWindow, and remove the @ts-ignore fallback in the preload script that allowed the app to silently run without contextIsolation.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

With sandbox: false and no contextIsolation enforcement, the renderer had direct Node.js access — any XSS was a full RCE. The preload fallback explicitly permitted running without contextIsolation. Both are P0 security issues.

## What changed?

- main/index.ts: set sandbox: true, contextIsolation: true, nodeIntegration: false on BrowserWindow
- preload/index.ts: remove @ts-ignore fallback; throw in both the else branch and catch block

## Linked issues

N/A

## Validation

- [x] pnpm typecheck
- [ ] pnpm test
- [ ] pnpm build
- [ ] Manual smoke test

## Release note

- [x] No user-facing change. Release note is NONE.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate