### PR TITLE
[Fix] Add path traversal boundary check and safe JSON.parse for tags

### DIFF
--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron';
-import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { readFileSync } from 'fs';
+import { resolve, sep } from 'path';
 import { eq } from 'drizzle-orm';
 import { getDb } from '../db/index.js';
 import { artifacts } from '../db/schema.js';
@@ -85,8 +85,11 @@ export function registerArtifactHandlers(): void {
     const workspacePath = getWorkspacePath();
     if (!workspacePath) return { ok: false, error: 'workspace not configured' };
     try {
-      const fullPath = join(workspacePath, params.localPath);
-      if (!existsSync(fullPath)) return { ok: false, error: 'file not found' };
+      const normalizedBase = resolve(workspacePath);
+      const fullPath = resolve(normalizedBase, params.localPath);
+      if (!fullPath.startsWith(normalizedBase + sep) && fullPath !== normalizedBase) {
+        return { ok: false, error: 'invalid path' };
+      }
       const encoding = isTextFile(params.localPath) ? 'utf-8' : 'base64';
       const content = readFileSync(fullPath, encoding);
       return { ok: true, result: { content, encoding } };

--- a/packages/desktop/src/main/ipc/data-handlers.ts
+++ b/packages/desktop/src/main/ipc/data-handlers.ts
@@ -97,7 +97,11 @@ export function registerDataHandlers(): void {
     try {
       const db = getDb();
       const rows = db.select().from(tasks).orderBy(desc(tasks.createdAt)).all();
-      return { ok: true, rows: rows.map((r) => ({ ...r, tags: JSON.parse(r.tags as string) })) };
+      return { ok: true, rows: rows.map((r) => {
+        let tags: string[] = [];
+        try { tags = JSON.parse(r.tags as string); } catch { }
+        return { ...r, tags };
+      }) };
     } catch (err) {
       console.error('[data] list-tasks failed:', err);
       return ipcError(err);


### PR DESCRIPTION
## Summary

Fixes a P0 path traversal vulnerability in `artifact:read-file` IPC handler where `path.join(workspacePath, userInput)` allowed reading arbitrary files outside the workspace. Also wraps `JSON.parse(tags)` in try/catch to prevent crashes on malformed data.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

`artifact:read-file` accepted a renderer-supplied `localPath` and joined it directly onto `workspacePath` without boundary check — attacker could supply `../../.ssh/id_rsa` to read arbitrary host files. `JSON.parse(tags)` in `data:list-tasks` had no error handling, crashing on corrupt DB rows.

## What changed?

- Replace `path.join(base, userInput)` with `path.resolve()` + `startsWith(normalizedBase + sep)` boundary check; out-of-bounds returns `{ ok: false, error: 'invalid path' }`
- Remove TOCTOU `existsSync` pre-check; let `readFileSync` throw naturally
- Remove unused `join` and `existsSync` imports
- Wrap `JSON.parse(r.tags)` in try/catch, fall back to `[]` on parse error

## Linked issues

Refs issues.md P0 #2, P2 #14

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm typecheck — exit 0
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate