### PR TITLE
[Fix] perf(renderer): add React.memo to message list components

### DIFF
--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { Message } from '@clawwork/shared';
 import { Bot, User, Brain, ChevronDown } from 'lucide-react';
@@ -15,7 +15,7 @@ interface ChatMessageProps {
   onImageClick?: (src: string) => void;
 }
 
-export default function ChatMessage({ message, highlighted, onHighlightDone, onImageClick }: ChatMessageProps) {
+const ChatMessage = memo(function ChatMessage({ message, highlighted, onHighlightDone, onImageClick }: ChatMessageProps) {
   const { t } = useTranslation();
   const isUser = message.role === 'user';
   const isSystem = message.role === 'system';
@@ -155,4 +155,6 @@ export default function ChatMessage({ message, highlighted, onHighlightDone, onI
       </div>
     </motion.div>
   );
-}
+});
+
+export default ChatMessage;

--- a/packages/desktop/src/renderer/components/StreamingMessage.tsx
+++ b/packages/desktop/src/renderer/components/StreamingMessage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Bot, Brain, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -11,7 +11,7 @@ interface StreamingMessageProps {
   thinkingContent?: string;
 }
 
-export default function StreamingMessage({ content, thinkingContent }: StreamingMessageProps) {
+const StreamingMessage = memo(function StreamingMessage({ content, thinkingContent }: StreamingMessageProps) {
   const { t } = useTranslation();
   const [thinkingOpen, setThinkingOpen] = useState(true);
 
@@ -76,4 +76,6 @@ export default function StreamingMessage({ content, thinkingContent }: Streaming
       </div>
     </motion.div>
   );
-}
+});
+
+export default StreamingMessage;

--- a/packages/desktop/src/renderer/components/ToolCallCard.tsx
+++ b/packages/desktop/src/renderer/components/ToolCallCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronDown, ChevronRight, Loader2, Check, X } from 'lucide-react';
 import type { ToolCall } from '@clawwork/shared';
@@ -25,12 +25,14 @@ function StatusIcon({ status }: { status: ToolCall['status'] }) {
   }
 }
 
-export default function ToolCallCard({ toolCall }: ToolCallCardProps) {
+const ToolCallCard = memo(function ToolCallCard({ toolCall }: ToolCallCardProps) {
   const [open, setOpen] = useState(false);
 
-  const duration = toolCall.completedAt
-    ? `${((new Date(toolCall.completedAt).getTime() - new Date(toolCall.startedAt).getTime()) / 1000).toFixed(1)}s`
-    : null;
+  const duration = useMemo(() => {
+    if (!toolCall.completedAt) return null;
+    const elapsed = new Date(toolCall.completedAt).getTime() - new Date(toolCall.startedAt).getTime();
+    return `${(elapsed / 1000).toFixed(1)}s`;
+  }, [toolCall.completedAt, toolCall.startedAt]);
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -102,4 +104,6 @@ export default function ToolCallCard({ toolCall }: ToolCallCardProps) {
       </div>
     </Collapsible>
   );
-}
+});
+
+export default ToolCallCard;

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -298,6 +298,7 @@ function ChatContent() {
   const stickToBottom = useRef(true)
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null)
   const closeLightbox = useCallback(() => setLightboxSrc(null), [])
+  const handleHighlightDone = useCallback(() => setHighlightedMessage(null), [setHighlightedMessage])
 
   const handleScroll = useCallback(() => {
     const el = viewportRef.current
@@ -323,7 +324,7 @@ function ChatContent() {
               key={msg.id}
               message={msg}
               highlighted={msg.id === highlightedId}
-              onHighlightDone={() => setHighlightedMessage(null)}
+              onHighlightDone={handleHighlightDone}
               onImageClick={setLightboxSrc}
             />
           ))}


### PR DESCRIPTION
## Summary

Wrap ChatMessage, StreamingMessage, and ToolCallCard with React.memo() to prevent unnecessary re-renders during streaming. During streaming the store updates every ~50ms; without memoization, all message list items re-render on every tick. Also fix a callback stability bug where an inline arrow function passed as `onHighlightDone` defeated memo on every parent render.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

During AI streaming, the message store updates at ~50ms intervals. Without memo, 10 messages × 20 updates/sec = 200 unnecessary re-renders/sec. The fix reduces this to only the actively-streaming component re-rendering.

## What changed?

- `ChatMessage.tsx`: wrap default export with `React.memo()`
- `StreamingMessage.tsx`: wrap default export with `React.memo()`
- `ToolCallCard.tsx`: wrap default export with `React.memo()`; move `duration` calculation into `useMemo()`
- `MainArea/index.tsx`: extract `onHighlightDone` inline arrow into `handleHighlightDone = useCallback(...)` to preserve stable prop reference

## Linked issues

Closes #7

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
> clawwork@ typecheck
> tsc -b packages/shared/tsconfig.json && tsc --noEmit -p packages/desktop/tsconfig.json
(exit 0)
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate