### PR TITLE
[Fix] Enable SQLite foreign keys and handle DB init failure gracefully

### DIFF
--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -51,6 +51,7 @@ export function initDatabase(workspacePath: string): void {
   const dbPath = join(workspacePath, DB_FILE_NAME);
   sqlite = new Database(dbPath);
   sqlite.pragma('journal_mode = WAL');
+  sqlite.pragma('foreign_keys = ON');
   sqlite.exec(CREATE_TABLES_SQL);
 
   // Migration: add gateway_id column to existing tasks table

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain, globalShortcut } from 'electron';
+import { app, shell, BrowserWindow, ipcMain, globalShortcut, dialog } from 'electron';
 import { join } from 'path';
 import { writeFileSync } from 'fs';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
@@ -120,6 +120,9 @@ app.whenReady().then(() => {
         data: { workspacePath: wsPath },
         error: { name: err.name, message: err.message, stack: err.stack },
       });
+      dialog.showErrorBox('Database Error', err.message);
+      app.quit();
+      return;
     }
   }
 


### PR DESCRIPTION
## Summary

Enable SQLite foreign key enforcement and surface DB initialization failures to the user instead of silently continuing. Without these fixes, orphaned records could accumulate undetected, and a broken DB would show a normal UI where all operations silently fail.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Two P1 data safety issues:
1. SQLite does not enforce foreign key constraints by default. The schema defines FK relationships (`messages.task_id → tasks.id`, `artifacts.task_id → tasks.id`, etc.) but they were never enforced, allowing orphaned records to silently accumulate.
2. If DB initialization fails (corrupt file, permission error, disk full), the app continued to create a window and register IPC handlers. Users saw a normal UI but every DB operation would throw, with no indication of the root cause.

## What changed?

- `packages/desktop/src/main/db/index.ts`: add `sqlite.pragma('foreign_keys = ON')` after the WAL pragma
- `packages/desktop/src/main/index.ts`: on DB init failure, call `dialog.showErrorBox('Database Error', err.message)` then `app.quit()` to prevent the window from being created

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
> clawwork@ typecheck
packages/desktop/node_modules/.bin/tsc -b packages/shared/tsconfig.json && \
packages/desktop/node_modules/.bin/tsc --noEmit -p packages/desktop/tsconfig.json
(exit 0)
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate