### PR TITLE
[Fix] Stop infinite reconnect on auth failure and clean up sync timer

### DIFF
--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -28,6 +28,8 @@ import {
 } from './device-identity.js';
 import { getDebugLogger } from '../debug/index.js';
 
+const WS_CLOSE_POLICY_VIOLATION = 1008;
+
 type PendingReq = {
   resolve: (payload: Record<string, unknown>) => void;
   reject: (err: Error) => void;
@@ -132,11 +134,11 @@ export class GatewayClient {
         sendToWindow(this.mainWindow, 'gateway-status', {
           gatewayId: this.gatewayId,
           connected: false,
-          ...(code === 1008 ? { error: reasonStr || 'policy violation' } : {}),
+          ...(code === WS_CLOSE_POLICY_VIOLATION ? { error: reasonStr || 'policy violation' } : {}),
         });
       }
       // Don't retry when server explicitly rejects (pairing required, auth denied)
-      if (code === 1008) return;
+      if (code === WS_CLOSE_POLICY_VIOLATION) return;
       this.scheduleReconnect();
     });
 
@@ -198,7 +200,7 @@ export class GatewayClient {
           gatewayId: this.gatewayId,
           data: { payload: summarizePayload(frame.payload) },
         });
-        this.ws?.close(1008, 'connect challenge missing nonce');
+        this.ws?.close(WS_CLOSE_POLICY_VIOLATION, 'connect challenge missing nonce');
         return;
       }
       this.connectNonce = nonce;
@@ -322,7 +324,7 @@ export class GatewayClient {
           requestId: 'connect-handshake',
           error: { name: err.name, message: err.message, stack: err.stack },
         });
-        this.ws?.close();
+        this.ws?.close(WS_CLOSE_POLICY_VIOLATION, 'auth failed');
       });
   }
 

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
@@ -69,6 +69,7 @@ export function useGatewayEventDispatcher(): void {
   const activeTaskId = useTaskStore((s) => s.activeTaskId);
   const activeTaskIdRef = useRef(activeTaskId);
   activeTaskIdRef.current = activeTaskId;
+  const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const removeDebug = window.clawwork.onDebugEvent((event) => {
@@ -140,8 +141,10 @@ export function useGatewayEventDispatcher(): void {
         store.finalizeStream(taskId);
         debugEvent('renderer.chat.finalized', { taskId, sessionKey });
         autoTitleIfNeeded(taskId);
-        // Refresh session metadata to pick up token counts
-        refreshSessionMetadata(sessionKey);
+        clearTimeout(syncTimerRef.current ?? undefined);
+        syncTimerRef.current = setTimeout(() => {
+          syncFromGateway().catch(() => {});
+        }, 500);
       } else if (state === 'error' || state === 'aborted') {
         store.setProcessing(taskId, false);
         store.finalizeStream(taskId);
@@ -207,6 +210,7 @@ export function useGatewayEventDispatcher(): void {
     return () => {
       removeGatewayEvent();
       removeDebug();
+      clearTimeout(syncTimerRef.current ?? undefined);
     };
   }, []);
 
@@ -360,10 +364,3 @@ async function fetchCatalogs(gatewayId: string): Promise<void> {
   }
 }
 
-function refreshSessionMetadata(sessionKey: string): void {
-  // Re-sync session metadata from gateway to pick up updated token counts
-  // Use a small delay to let the server finish writing the session store
-  setTimeout(() => {
-    syncFromGateway().catch(() => {});
-  }, 500);
-}


### PR DESCRIPTION
## Summary

Auth failure in the Gateway handshake used close code 1000 (normal), causing the close handler to schedule a reconnect indefinitely. This PR fixes that by closing with 1008 (Policy Violation), which the existing handler already treats as a hard stop. It also fixes a timer leak in the renderer where rapid streaming events accumulated un-cleared `setTimeout` calls.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Two bugs reported as P1 issues (#5, #8, #6):
- A failed authentication (wrong token, pairing mismatch) triggered infinite reconnect loops, hammering the server and filling logs.
- Each `chat` event with `state === 'final'` scheduled a `syncFromGateway()` call via `setTimeout` with no timer ID stored, so rapid streaming output stacked many timers and none were cancelled on component unmount.

## What changed?

- `gateway-client.ts`: Use `WS_CLOSE_POLICY_VIOLATION` (1008) instead of default close code on auth failure; extracted constant for all four existing uses of 1008 in the file
- `useGatewayDispatcher.ts`: Added `syncTimerRef` at hook level; each final-state event now clears the previous timer before setting a new one; useEffect cleanup clears the timer on unmount; removed the now-redundant standalone `refreshSessionMetadata` function

## Linked issues

Closes #5, #8, #6

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm typecheck — passed, no errors
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate