### PR TITLE
[Fix] Switch preload output to CJS for sandbox compatibility

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -9,6 +9,13 @@ export default defineConfig({
   },
   preload: {
     plugins: [externalizeDepsPlugin({ exclude: ['@clawwork/shared'] })],
+    build: {
+      rollupOptions: {
+        output: {
+          format: 'cjs',
+        },
+      },
+    },
   },
   renderer: {
     resolve: {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -62,7 +62,7 @@ function createWindow(): BrowserWindow {
     trafficLightPosition: { x: 16, y: 16 },
     backgroundColor: readConfig()?.theme === 'light' ? '#FAFAFA' : '#1C1C1C',
     webPreferences: {
-      preload: join(__dirname, '../preload/index.mjs'),
+      preload: join(__dirname, '../preload/index.cjs'),
       sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -6,8 +6,22 @@ import { useUiStore, type Language } from './stores/uiStore';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 
+if (!window.clawwork) {
+  const root = document.getElementById('root')!;
+  const wrapper = document.createElement('div');
+  wrapper.style.cssText = 'display:flex;align-items:center;justify-content:center;height:100vh;color:var(--danger,#ef4444);font-family:monospace;padding:2rem;text-align:center';
+  const heading = document.createElement('h2');
+  heading.textContent = 'Preload bridge missing';
+  const detail = document.createElement('p');
+  detail.textContent = 'window.clawwork is undefined. The preload script failed to expose the ClawWork API. Check that the preload is built as CJS (not ESM) when sandbox is enabled.';
+  wrapper.appendChild(heading);
+  wrapper.appendChild(detail);
+  root.appendChild(wrapper);
+  throw new Error('[fatal] window.clawwork is undefined — preload bridge not loaded. Likely ESM/CJS format mismatch with sandbox:true.');
+}
+
 // Restore persisted language preference
-window.clawwork?.getSettings().then((settings) => {
+window.clawwork.getSettings().then((settings) => {
   const lang = settings?.language as Language | undefined;
   if (lang && lang !== i18n.language) {
     i18n.changeLanguage(lang);

--- a/packages/desktop/test/preload-build-integrity.test.ts
+++ b/packages/desktop/test/preload-build-integrity.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const SRC_DIR = resolve(__dirname, '../src');
+const VITE_CONFIG = resolve(__dirname, '../electron.vite.config.ts');
+const MAIN_ENTRY = resolve(SRC_DIR, 'main/index.ts');
+
+describe('preload sandbox compatibility', () => {
+  const viteConfig = readFileSync(VITE_CONFIG, 'utf-8');
+  const mainSource = readFileSync(MAIN_ENTRY, 'utf-8');
+
+  it('electron-vite preload output is configured as CJS', () => {
+    expect(viteConfig).toMatch(/format:\s*['"]cjs['"]/);
+  });
+
+  it('main process references a .cjs preload file', () => {
+    expect(mainSource).toMatch(/preload.*\.cjs/);
+  });
+
+  it('BrowserWindow has sandbox enabled', () => {
+    expect(mainSource).toMatch(/sandbox:\s*true/);
+  });
+});


### PR DESCRIPTION
## Summary

Commit c8cd575 enabled `sandbox: true` on BrowserWindow but left the preload built as ESM (`.mjs`). Electron's sandbox preload loader intercepts `require('electron')` but not ESM `import`, so `contextBridge.exposeInMainWorld` never executed and `window.clawwork` was `undefined` — causing immediate crash on startup.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The app white-screens on startup with `TypeError: Cannot read properties of undefined (reading 'onDebugEvent')` because the preload bridge fails silently in sandbox mode when using ESM format.

## What changed?

- `electron.vite.config.ts`: force preload output format to CJS (`format: 'cjs'`)
- `src/main/index.ts`: update preload path from `index.mjs` to `index.cjs`
- `src/renderer/main.tsx`: add fail-fast guard that shows a diagnostic screen if `window.clawwork` is missing, instead of cryptic React crash
- `test/preload-build-integrity.test.ts`: new test verifying the source-level contract (CJS config, `.cjs` path reference, sandbox enabled)

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build` (electron-vite build)
- [x] Manual smoke test

Commands, screenshots, or notes:

```text
$ pnpm typecheck   # pass
$ pnpm test        # 49/49 pass
$ pnpm --filter @clawwork/desktop exec electron-vite build  # preload → index.cjs
$ pnpm --filter @clawwork/desktop exec electron-vite dev    # app launches, UI renders correctly
```

## Screenshots or recordings

Before (crash):
![white screen with TypeError: Cannot read properties of undefined (reading 'onDebugEvent')](https://github.com/user-attachments/assets/placeholder-before)

After (working):
App launches normally with task list, gateway connection, and full UI.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate