### PR TITLE
[Feat] Add stop generating button and Escape shortcut

### DIFF
--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -1,7 +1,7 @@
 import { useRef, useCallback, useState, useEffect, useMemo, type KeyboardEvent, type ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Send, Paperclip, X, ChevronDown, Cpu, Brain, Mic, Loader2, TerminalSquare } from 'lucide-react';
+import { Send, Square, Paperclip, X, ChevronDown, Cpu, Brain, Mic, Loader2, TerminalSquare } from 'lucide-react';
 import type { MessageImageAttachment } from '@clawwork/shared';
 import { toast } from 'sonner';
 import { cn, modKey } from '@/lib/utils';
@@ -183,6 +183,14 @@ export default function ChatInput() {
     s.tasks.find((t) => t.id === s.activeTaskId),
   );
 
+  const isProcessing = useMessageStore((s) =>
+    activeTask ? s.processingTasks.has(activeTask.id) : false,
+  );
+  const isStreaming = useMessageStore((s) =>
+    activeTask ? Boolean(s.streamingByTask[activeTask.id]) || Boolean(s.streamingThinkingByTask[activeTask.id]) : false,
+  );
+  const isGenerating = isProcessing || isStreaming;
+
   const addMessage = useMessageStore((s) => s.addMessage);
   const setProcessing = useMessageStore((s) => s.setProcessing);
   const updateTaskTitle = useTaskStore((s) => s.updateTaskTitle);
@@ -350,6 +358,19 @@ export default function ChatInput() {
     void handleSend();
   }, [activeTask, handleSend]);
 
+  const [aborting, setAborting] = useState(false);
+  const handleAbort = useCallback(async () => {
+    if (!activeTask || aborting) return;
+    setAborting(true);
+    try {
+      await window.clawwork.abortChat(activeTask.gatewayId, activeTask.sessionKey);
+    } catch {
+      toast.error(t('chatInput.abortFailed'));
+    } finally {
+      setTimeout(() => setAborting(false), 500);
+    }
+  }, [activeTask, aborting, t]);
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       handleVoiceKeyDown(e);
@@ -407,6 +428,12 @@ export default function ChatInput() {
         }
       }
 
+      if (e.key === 'Escape' && isGenerating) {
+        e.preventDefault();
+        handleAbort();
+        return;
+      }
+
       // ── Send ──────────────────────────────────────────────────────────────────
       if (e.key === 'Enter') {
         const isCmdEnterMode = sendShortcut === 'cmdEnter';
@@ -418,7 +445,7 @@ export default function ChatInput() {
         }
       }
     },
-    [argPickerVisible, argPickerOptions, argPickerIndex, commitArgOption, closeArgPicker, slashMenuVisible, slashCommands, slashIndex, commitSlashCommand, handleSend, handleVoiceKeyDown, sendShortcut],
+    [argPickerVisible, argPickerOptions, argPickerIndex, commitArgOption, closeArgPicker, slashMenuVisible, slashCommands, slashIndex, commitSlashCommand, handleSend, handleAbort, isGenerating, handleVoiceKeyDown, sendShortcut],
   );
 
   const handleInput = useCallback(() => {
@@ -761,21 +788,52 @@ export default function ChatInput() {
                 {t('voiceInput.beta')}
               </span>
             </div>
-            <motion.div
-              whileHover={motionPresets.scale.whileHover}
-              whileTap={motionPresets.scale.whileTap}
-              transition={motionPresets.scale.transition}
-            >
-              <Button
-                variant="soft"
-                size="icon"
-                onClick={handleSend}
-                disabled={disabled}
-                className="rounded-xl"
-              >
-                <Send size={16} />
-              </Button>
-            </motion.div>
+            <AnimatePresence mode="wait">
+              {isGenerating ? (
+                <motion.div
+                  key="stop"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="danger"
+                        size="icon"
+                        onClick={handleAbort}
+                        disabled={aborting}
+                        className="rounded-xl"
+                      >
+                        <Square size={14} fill="currentColor" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('chatInput.stopGenerating')}</TooltipContent>
+                  </Tooltip>
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="send"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                  whileHover={motionPresets.scale.whileHover}
+                  whileTap={motionPresets.scale.whileTap}
+                >
+                  <Button
+                    variant="soft"
+                    size="icon"
+                    onClick={handleSend}
+                    disabled={disabled}
+                    className="rounded-xl"
+                  >
+                    <Send size={16} />
+                  </Button>
+                </motion.div>
+              )}
+            </AnimatePresence>
           </div>
         </div>
 

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -156,7 +156,9 @@
     "thinkingLow": "Low",
     "thinkingMedium": "Medium",
     "thinkingHigh": "High",
-    "thinkingAdaptive": "Adaptive"
+    "thinkingAdaptive": "Adaptive",
+    "stopGenerating": "Stop generating (Esc)",
+    "abortFailed": "Failed to stop generation"
   },
   "voiceInput": {
     "tooltip": "Voice Input (Beta)",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -156,7 +156,9 @@
     "thinkingLow": "低",
     "thinkingMedium": "中",
     "thinkingHigh": "高",
-    "thinkingAdaptive": "自适应"
+    "thinkingAdaptive": "自适应",
+    "stopGenerating": "停止生成 (Esc)",
+    "abortFailed": "停止生成失败"
   },
   "voiceInput": {
     "tooltip": "语音输入（Beta）",


### PR DESCRIPTION
## Summary

Add a Stop button that replaces the Send button while the agent is actively generating, plus an Escape keyboard shortcut. The entire backend pipeline (chat.abort RPC, IPC handler, preload API, aborted state handling) already existed — only the UI trigger was missing.

## Type of change

- [x] `[Feat]` new feature

## Why is this needed?

Previously the only way to abort an ongoing generation was via the `/abort` slash command. Users expect a visible Stop button (like ChatGPT, Claude web) and an Escape shortcut for quick cancellation.

## What changed?

- **ChatInput.tsx**: Subscribe to `processingTasks` / `streamingByTask` / `streamingThinkingByTask` to derive `isGenerating` state; add `handleAbort` callback with 500ms debounce; add Escape key handler (no conflict with slash menu / arg picker which consume Escape first); conditionally render Stop button (danger variant, filled square icon) vs Send button with `AnimatePresence` crossfade
- **en.json / zh.json**: Add `stopGenerating` and `abortFailed` i18n strings

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passes clean
```

## Screenshots or recordings

N/A

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Add a Stop button (and Escape shortcut) to abort AI generation mid-stream.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate