### PR TITLE
[Feat] Show tool call cards during streaming response

### DIFF
--- a/packages/desktop/src/renderer/components/StreamingMessage.tsx
+++ b/packages/desktop/src/renderer/components/StreamingMessage.tsx
@@ -2,16 +2,19 @@ import { memo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Bot, Brain, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import type { ToolCall } from '@clawwork/shared';
 import { cn } from '@/lib/utils';
 import { motion as motionPresets } from '@/styles/design-tokens';
 import MarkdownContent from './MarkdownContent';
+import ToolCallCard from './ToolCallCard';
 
 interface StreamingMessageProps {
   content: string;
   thinkingContent?: string;
+  toolCalls?: ToolCall[];
 }
 
-const StreamingMessage = memo(function StreamingMessage({ content, thinkingContent }: StreamingMessageProps) {
+const StreamingMessage = memo(function StreamingMessage({ content, thinkingContent, toolCalls }: StreamingMessageProps) {
   const { t } = useTranslation();
   const [thinkingOpen, setThinkingOpen] = useState(true);
 
@@ -68,6 +71,13 @@ const StreamingMessage = memo(function StreamingMessage({ content, thinkingConte
             </AnimatePresence>
           </div>
         )}
+        {toolCalls?.length ? (
+          <div className="mb-2 space-y-1">
+            {toolCalls.map((tc) => (
+              <ToolCallCard key={tc.id} toolCall={tc} />
+            ))}
+          </div>
+        ) : null}
         {content && (
           <div className="leading-relaxed text-[var(--text-primary)]">
             <MarkdownContent content={content} showCursor />

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { PanelRightOpen, RotateCcw, Archive, Plus, Server, ChevronDown, Bot, Cpu, ArrowUp, ArrowDown } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import type { ToolCall } from '@clawwork/shared'
 import { useTaskStore } from '@/stores/taskStore'
 import { useMessageStore, EMPTY_MESSAGES } from '@/stores/messageStore'
 import { useUiStore, type GatewayInfo } from '@/stores/uiStore'
@@ -23,6 +24,7 @@ import FileBrowser from '../FileBrowser'
 import logo from '@/assets/logo.png'
 
 const STICK_TO_BOTTOM_THRESHOLD_PX = 60
+const EMPTY_TOOL_CALLS: ToolCall[] = []
 
 interface MainAreaProps {
   onTogglePanel: () => void
@@ -294,6 +296,20 @@ function ChatContent() {
   const isProcessing = useMessageStore((s) =>
     activeTaskId ? s.processingTasks.has(activeTaskId) : false,
   )
+  const streamingToolCalls = useMessageStore((s) => {
+    if (!activeTaskId) return EMPTY_TOOL_CALLS
+    const msgs = s.messagesByTask[activeTaskId]
+    if (!msgs?.length) return EMPTY_TOOL_CALLS
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i].role === 'user') break
+      if (msgs[i].role === 'assistant' && msgs[i].toolCalls.length > 0) {
+        return msgs[i].toolCalls.some((tc) => tc.status === 'running')
+          ? msgs[i].toolCalls
+          : EMPTY_TOOL_CALLS
+      }
+    }
+    return EMPTY_TOOL_CALLS
+  })
   const viewportRef = useRef<HTMLDivElement>(null)
   const stickToBottom = useRef(true)
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null)
@@ -311,7 +327,7 @@ function ChatContent() {
     if (!stickToBottom.current) return
     const el = viewportRef.current
     if (el) el.scrollTop = el.scrollHeight
-  }, [messages.length, streamingContent, streamingThinkingContent, isProcessing])
+  }, [messages.length, streamingContent, streamingThinkingContent, isProcessing, streamingToolCalls])
 
   return (
     <>
@@ -328,9 +344,9 @@ function ChatContent() {
               onImageClick={setLightboxSrc}
             />
           ))}
-          {(streamingContent || streamingThinkingContent) && <StreamingMessage content={streamingContent} thinkingContent={streamingThinkingContent || undefined} />}
+          {(streamingContent || streamingThinkingContent || streamingToolCalls.length > 0) && <StreamingMessage content={streamingContent} thinkingContent={streamingThinkingContent || undefined} toolCalls={streamingToolCalls} />}
           <AnimatePresence>
-            {isProcessing && !streamingContent && !streamingThinkingContent && <ThinkingIndicator />}
+            {isProcessing && !streamingContent && !streamingThinkingContent && streamingToolCalls.length === 0 && <ThinkingIndicator />}
           </AnimatePresence>
         </div>
       </ScrollArea>


### PR DESCRIPTION
## Summary

Tool call cards (showing which tools the Agent is invoking) were only visible after the assistant message was finalized. During streaming — when the user is actively waiting — there was no indication of tool activity. This PR renders tool call cards in real time during streaming responses.

## Type of change

- [x] `[Feat]` new feature

## Why is this needed?

When the Agent executes tools (e.g. code execution, file reads), the user sees either a blank area or a "thinking" spinner with no detail. Showing tool call cards during streaming gives immediate feedback on what the Agent is doing, which tools it is calling, and their completion status.

## What changed?

- `StreamingMessage.tsx` — Added `toolCalls` prop; renders `ToolCallCard` list between thinking block and text content
- `MainArea/index.tsx` — Added `streamingToolCalls` selector that extracts running tool calls from the latest assistant message; passes them to `StreamingMessage`; adjusted render conditions so `StreamingMessage` shows when tool calls are active (even without text), and `ThinkingIndicator` hides when tool calls are visible
- Added `streamingToolCalls` to scroll-to-bottom effect dependencies

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passed with zero errors
```

## Screenshots or recordings

N/A

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Tool call cards now appear in real time during streaming responses, showing which tools the Agent is invoking before the message is finalized.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate