### PR TITLE
[Feat] Add exec approval dialog for agent command gating

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -327,6 +327,22 @@ export function registerWsHandlers(): void {
     await gw.abortChat(payload.sessionKey);
     return { ok: true };
   });
+
+  ipcMain.handle('ws:exec-approval-resolve', async (_event, payload: {
+    gatewayId: string;
+    id: string;
+    decision: string;
+  }) => {
+    const gw = getGatewayClient(payload.gatewayId);
+    if (!gw?.isConnected) return { ok: false, error: 'gateway not connected' };
+    try {
+      await gw.sendReq('exec.approval.resolve', { id: payload.id, decision: payload.decision });
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      return { ok: false, error: msg };
+    }
+  });
 }
 
 function safeJsonParse(raw: string): Record<string, unknown> | undefined {

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -235,6 +235,8 @@ export interface ClawWorkAPI {
   persistMessage: (msg: {
     id: string; taskId: string; role: string; content: string; timestamp: string;
   }) => Promise<IpcResult>;
+
+  resolveExecApproval: (gatewayId: string, id: string, decision: string) => Promise<IpcResult>;
 }
 
 declare global {

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -126,6 +126,9 @@ function buildApi(): ClawWorkAPI {
       id: string; taskId: string; role: string; content: string; timestamp: string;
     }) => ipcRenderer.invoke('data:create-message', msg),
 
+    resolveExecApproval: (gatewayId: string, id: string, decision: string) =>
+      ipcRenderer.invoke('ws:exec-approval-resolve', { gatewayId, id, decision }),
+
     removeAllListeners: (channel: string) => {
       ipcRenderer.removeAllListeners(channel);
     },

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import MainArea from './layouts/MainArea'
 import RightPanel from './layouts/RightPanel'
 import Setup from './layouts/Setup'
 import Settings from './layouts/Settings'
+import ApprovalDialog from './components/ApprovalDialog'
 import { useUiStore } from './stores/uiStore'
 import { useTaskStore } from './stores/taskStore'
 import { useGatewayEventDispatcher } from './hooks/useGatewayDispatcher'
@@ -147,6 +148,7 @@ export default function App() {
             },
           }}
         />
+        <ApprovalDialog />
       </div>
     </TooltipProvider>
   )

--- a/packages/desktop/src/renderer/components/ApprovalDialog.tsx
+++ b/packages/desktop/src/renderer/components/ApprovalDialog.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ShieldAlert } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useApprovalStore } from '../stores/approvalStore'
+
+function RiskBadge({ security }: { security?: string | null }) {
+  const { t } = useTranslation()
+  if (security === 'full') {
+    return (
+      <span className="rounded px-1.5 py-0.5 text-xs font-medium" style={{ background: 'color-mix(in srgb, #ef4444 15%, var(--bg-elevated))', color: '#ef4444' }}>
+        {t('approval.riskHigh')}
+      </span>
+    )
+  }
+  if (!security || security === 'allowlist') {
+    return (
+      <span className="rounded px-1.5 py-0.5 text-xs font-medium" style={{ background: 'var(--bg-elevated)', color: 'var(--text-secondary)' }}>
+        {t('approval.riskMedium')}
+      </span>
+    )
+  }
+  return null
+}
+
+function Countdown({ expiresAtMs }: { expiresAtMs: number }) {
+  const { t } = useTranslation()
+  const [remaining, setRemaining] = useState(() => Math.max(0, Math.ceil((expiresAtMs - Date.now()) / 1000)))
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRemaining(Math.max(0, Math.ceil((expiresAtMs - Date.now()) / 1000)))
+    }, 500)
+    return () => clearInterval(interval)
+  }, [expiresAtMs])
+
+  const pct = Math.min(100, (remaining / 120) * 100)
+  const color = remaining > 60 ? 'var(--accent)' : remaining > 20 ? '#f59e0b' : '#ef4444'
+
+  return (
+    <div className="space-y-1">
+      <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+        {t('approval.expiresIn', { seconds: remaining })}
+      </span>
+      <div className="h-1 w-full overflow-hidden rounded-full" style={{ background: 'var(--bg-elevated)' }}>
+        <div className="h-full rounded-full transition-all duration-500" style={{ width: `${pct}%`, background: color }} />
+      </div>
+    </div>
+  )
+}
+
+export default function ApprovalDialog() {
+  const { t } = useTranslation()
+  const pendingApprovals = useApprovalStore((s) => s.pendingApprovals)
+  const resolveApproval = useApprovalStore((s) => s.resolveApproval)
+  const current = pendingApprovals[0]
+
+  if (!current) return null
+
+  const { id, request, expiresAtMs } = current
+
+  return (
+    <Dialog open modal>
+      <DialogContent
+        className="max-w-lg"
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldAlert className="h-5 w-5" style={{ color: '#f59e0b' }} />
+            {t('approval.title')}
+            <RiskBadge security={request.security} />
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-secondary)' }}>
+              {t('approval.command')}
+            </p>
+            <pre
+              className="overflow-x-auto rounded-lg px-3 py-2.5 text-sm font-mono"
+              style={{ background: 'var(--bg-elevated)', color: 'var(--text-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}
+            >
+              {request.command}
+            </pre>
+          </div>
+
+          {(request.cwd || request.host) && (
+            <div className="flex flex-wrap gap-4 text-xs" style={{ color: 'var(--text-secondary)' }}>
+              {request.cwd && (
+                <span>
+                  <span className="font-medium">{t('approval.cwd')}: </span>
+                  <span className="font-mono">{request.cwd}</span>
+                </span>
+              )}
+              {request.host && (
+                <span>
+                  <span className="font-medium">{t('approval.host')}: </span>
+                  <span className="font-mono">{request.host}</span>
+                </span>
+              )}
+            </div>
+          )}
+
+          <Countdown expiresAtMs={expiresAtMs} />
+
+          {pendingApprovals.length > 1 && (
+            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+              {t('approval.queueMore', { count: pendingApprovals.length - 1 })}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <Button variant="danger" onClick={() => resolveApproval(id, 'deny')}>
+            {t('approval.deny')}
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => resolveApproval(id, 'allow-always')}>
+              {t('approval.allowAlways')}
+            </Button>
+            <Button onClick={() => resolveApproval(id, 'allow-once')} style={{ background: 'var(--accent)', color: '#000' }}>
+              {t('approval.allowOnce')}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { parseTaskIdFromSessionKey } from '@clawwork/shared';
-import type { ToolCall, ToolCallStatus, ModelListResponse, AgentListResponse } from '@clawwork/shared';
+import type { ToolCall, ToolCallStatus, ModelListResponse, AgentListResponse, ExecApprovalRequest, ExecApprovalResolved } from '@clawwork/shared';
 import { toast } from 'sonner';
 import i18n from '../i18n';
 import { useMessageStore } from '../stores/messageStore';
 import { useTaskStore } from '../stores/taskStore';
 import { useUiStore } from '../stores/uiStore';
+import { useApprovalStore } from '../stores/approvalStore';
 import { hydrateFromLocal, syncFromGateway } from '../lib/session-sync';
 
 function debugEvent(event: string, data: Record<string, unknown>, extra?: { traceId?: string; feature?: string }): void {
@@ -86,6 +87,11 @@ export function useGatewayEventDispatcher(): void {
         handleChatEvent(data.payload as unknown as ChatEventPayload);
       } else if (data.event === 'agent') {
         handleAgentEvent(data.payload as unknown as AgentToolEvent);
+      } else if (data.event === 'exec.approval.requested') {
+        useApprovalStore.getState().addApproval(data.gatewayId, data.payload as unknown as ExecApprovalRequest);
+        toast.warning(i18n.t('approval.newRequest'));
+      } else if (data.event === 'exec.approval.resolved') {
+        useApprovalStore.getState().removeApproval((data.payload as unknown as ExecApprovalResolved).id);
       }
     };
 
@@ -119,7 +125,6 @@ export function useGatewayEventDispatcher(): void {
         if (thinking) {
           store.appendThinkingDelta(taskId, thinking);
         }
-        // Also process toolCall blocks from delta content
         const toolCalls = extractToolCalls(payload);
         for (const tc of toolCalls) {
           store.upsertToolCall(taskId, tc);
@@ -133,7 +138,6 @@ export function useGatewayEventDispatcher(): void {
           store.appendThinkingDelta(taskId, thinking);
         }
         debugEvent('renderer.chat.final.received', { taskId, sessionKey, chars: text.length });
-        // Extract and attach any toolCall blocks before finalizing
         const toolCalls = extractToolCalls(payload);
         for (const tc of toolCalls) {
           store.upsertToolCall(taskId, tc);
@@ -175,7 +179,6 @@ export function useGatewayEventDispatcher(): void {
         useUiStore.getState().markUnread(taskId);
       }
 
-      // Map Gateway phase to our ToolCallStatus
       let status: ToolCallStatus = 'running';
       if (data.phase === 'result') status = data.isError ? 'error' : 'done';
       else if (data.phase === 'error') status = 'error';
@@ -191,7 +194,6 @@ export function useGatewayEventDispatcher(): void {
       };
 
       const store = useMessageStore.getState();
-      // Preserve startedAt from existing entry if we're updating
       const existingMsgs = store.messagesByTask[taskId] ?? [];
       for (let i = existingMsgs.length - 1; i >= 0; i--) {
         const existing = existingMsgs[i].toolCalls.find((t) => t.id === tc.id);
@@ -214,7 +216,6 @@ export function useGatewayEventDispatcher(): void {
     };
   }, []);
 
-  // Hydrate tasks + messages from local SQLite on mount
   useEffect(() => {
     hydrateFromLocal();
   }, []);
@@ -224,7 +225,6 @@ export function useGatewayEventDispatcher(): void {
   useEffect(() => {
     const { setGatewayStatusByGateway, setDefaultGatewayId } = useUiStore.getState();
 
-    // Fetch initial status for all gateways
     window.clawwork.gatewayStatus().then((statusMap) => {
       for (const [gwId, info] of Object.entries(statusMap)) {
         const status = info.connected ? 'connected' as const : 'disconnected' as const;
@@ -233,17 +233,14 @@ export function useGatewayEventDispatcher(): void {
           connectedGatewaysRef.current.add(gwId);
         }
       }
-      // If any gateway connected and not yet synced, sync
       if (connectedGatewaysRef.current.size > 0 && !syncedRef.current) {
         syncedRef.current = true;
         syncFromGateway();
-        // Fetch catalogs from the first connected gateway
         const firstConnected = connectedGatewaysRef.current.values().next().value;
         if (firstConnected) fetchCatalogs(firstConnected);
       }
     });
 
-    // Set default gateway and cache gateway info from config
     window.clawwork.listGateways().then((gateways) => {
       const defaultGw = gateways.find((g) => g.isDefault);
       if (defaultGw) {
@@ -251,7 +248,6 @@ export function useGatewayEventDispatcher(): void {
       } else if (gateways.length > 0) {
         setDefaultGatewayId(gateways[0].id);
       }
-      // Cache gateway info for display (TaskItem badges, selectors)
       const infoMap: Record<string, { id: string; name: string; color?: string }> = {};
       for (const gw of gateways) {
         infoMap[gw.id] = { id: gw.id, name: gw.name, color: gw.color };

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -193,5 +193,19 @@
     "categoryModel": "Model & Quality",
     "categoryAccess": "Access & Security",
     "categoryInfo": "Info & Help"
+  },
+  "approval": {
+    "title": "Execution Approval Required",
+    "command": "Command",
+    "cwd": "Working dir",
+    "host": "Host",
+    "riskMedium": "Medium Risk",
+    "riskHigh": "High Risk",
+    "expiresIn": "Expires in {{seconds}}s",
+    "queueMore": "{{count}} more pending",
+    "allowOnce": "Allow Once",
+    "allowAlways": "Always Allow",
+    "deny": "Deny",
+    "newRequest": "Agent is requesting execution approval"
   }
 }

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -193,5 +193,19 @@
     "categoryModel": "模型与质量",
     "categoryAccess": "权限与安全",
     "categoryInfo": "信息与帮助"
+  },
+  "approval": {
+    "title": "需要执行授权",
+    "command": "命令",
+    "cwd": "工作目录",
+    "host": "主机",
+    "riskMedium": "中风险",
+    "riskHigh": "高风险",
+    "expiresIn": "{{seconds}} 秒后超时",
+    "queueMore": "还有 {{count}} 个等待",
+    "allowOnce": "允许一次",
+    "allowAlways": "始终允许",
+    "deny": "拒绝",
+    "newRequest": "Agent 正在请求执行授权"
   }
 }

--- a/packages/desktop/src/renderer/stores/approvalStore.ts
+++ b/packages/desktop/src/renderer/stores/approvalStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+import type { ApprovalDecision, ExecApprovalRequest } from '@clawwork/shared';
+
+type PendingApproval = ExecApprovalRequest & { gatewayId: string };
+
+const expireTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+export const useApprovalStore = create<{
+  pendingApprovals: PendingApproval[];
+  addApproval: (gatewayId: string, req: ExecApprovalRequest) => void;
+  removeApproval: (id: string) => void;
+  resolveApproval: (id: string, decision: ApprovalDecision) => void;
+}>((set, get) => ({
+  pendingApprovals: [],
+
+  addApproval(gatewayId, req) {
+    if (get().pendingApprovals.some((a) => a.id === req.id)) return;
+    set((s) => ({ pendingApprovals: [...s.pendingApprovals, { ...req, gatewayId }] }));
+    const ttl = req.expiresAtMs - Date.now();
+    if (ttl > 0) {
+      expireTimers.set(req.id, setTimeout(() => {
+        expireTimers.delete(req.id);
+        get().removeApproval(req.id);
+      }, ttl));
+    }
+  },
+
+  removeApproval(id) {
+    clearTimeout(expireTimers.get(id));
+    expireTimers.delete(id);
+    set((s) => ({ pendingApprovals: s.pendingApprovals.filter((a) => a.id !== id) }));
+  },
+
+  resolveApproval(id, decision) {
+    const approval = get().pendingApprovals.find((a) => a.id === id);
+    if (!approval) return;
+    window.clawwork.resolveExecApproval(approval.gatewayId, id, decision).catch(() => {});
+    get().removeApproval(id);
+  },
+}));

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -173,3 +173,31 @@ export interface SessionPatchParams {
   responseUsage?: string | null;
   label?: string | null;
 }
+
+// ------------------------------------------------------------
+// Exec Approval (operator.approvals scope)
+// ------------------------------------------------------------
+
+export type ApprovalDecision = 'allow-once' | 'allow-always' | 'deny';
+
+export interface ExecApprovalRequest {
+  id: string;
+  request: {
+    command: string;
+    cwd?: string | null;
+    host?: string | null;
+    security?: string | null;
+    ask?: string | null;
+    agentId?: string | null;
+    sessionKey?: string | null;
+  };
+  createdAtMs: number;
+  expiresAtMs: number;
+}
+
+export interface ExecApprovalResolved {
+  id: string;
+  decision?: string | null;
+  resolvedBy?: string | null;
+  ts?: number | null;
+}


### PR DESCRIPTION
## Summary

When an agent requests to execute a potentially dangerous shell command, the Gateway emits an exec.approval.requested event. This PR wires up the full approval flow in the desktop client: event ingestion, a Zustand store managing the approval queue, and a blocking modal that lets the user allow (once or always) or deny the request before the agent proceeds.

## Type of change

- [x] [Feat] new feature

## Why is this needed?

Agents with shell access can execute arbitrary commands. Without an approval gate, users have no way to inspect or block dangerous operations. The Gateway already supports the operator.approvals scope and emits approval events; the desktop client was missing the UI layer to consume them.

## What changed?

- packages/shared/src/types.ts: added ExecApprovalRequest, ExecApprovalResolved, ApprovalDecision types
- packages/desktop/src/main/ipc/ws-handlers.ts: added ws:exec-approval-resolve IPC handler
- packages/desktop/src/preload/index.ts + clawwork.d.ts: exposed resolveExecApproval via context bridge
- packages/desktop/src/renderer/stores/approvalStore.ts (new): Zustand store with pending approvals queue and per-item expiry timers
- packages/desktop/src/renderer/components/ApprovalDialog.tsx (new): blocking modal with command display, cwd/host metadata, animated countdown bar, RiskBadge, and Deny/Always Allow/Allow Once buttons
- packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts: added exec.approval.requested and exec.approval.resolved event handling
- packages/desktop/src/renderer/App.tsx: mounted ApprovalDialog at app root
- packages/desktop/src/renderer/i18n/locales/{en,zh}.json: added approval.* i18n keys

## Linked issues

N/A

## Validation

- [x] pnpm typecheck
- [x] pnpm test
- [ ] pnpm build
- [ ] Manual smoke test

Commands, screenshots, or notes:

pnpm typecheck: 0 errors
pnpm test: 49/49 passed

## Screenshots or recordings

UI change - approval dialog renders as a blocking modal when exec.approval.requested arrives.

## Release note

- [x] User-facing change. Release note is included below.

Release note:
Add exec approval dialog: when an agent requests to run a shell command, a blocking modal prompts the user to allow (once or always) or deny the request before execution proceeds.

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate