### PR TITLE
[Fix] Fix WSS connection errors and add device pairing UX

### DIFF
--- a/packages/desktop/src/main/ipc/settings-handlers.ts
+++ b/packages/desktop/src/main/ipc/settings-handlers.ts
@@ -84,25 +84,21 @@ export function registerSettingsHandlers(): void {
       { noReconnect: true },
     );
     try {
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          testClient.destroy();
-          reject(new Error('timeout'));
-        }, 10000);
-        // Poll — isConnected flips to true after auth handshake completes
-        const checkInterval = setInterval(() => {
-          if (testClient.isConnected) {
-            clearTimeout(timeout);
-            clearInterval(checkInterval);
-            resolve();
-          }
-        }, 300);
-      });
+      testClient.connect();
+      const deadline = Date.now() + 10000;
+      while (Date.now() < deadline) {
+        if (testClient.isConnected) return { ok: true };
+        if (testClient.lastConnectionError) break;
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      const errorCode = testClient.lastConnectionErrorCode;
+      const msg = testClient.lastConnectionError ?? 'timeout';
+      if (errorCode === 'PAIRING_REQUIRED') {
+        return { ok: false, error: msg, pairingRequired: true };
+      }
+      return { ok: false, error: msg };
+    } finally {
       testClient.destroy();
-      return { ok: true };
-    } catch (e) {
-      testClient.destroy();
-      return { ok: false, error: e instanceof Error ? e.message : 'connection failed' };
     }
   });
 }

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -138,9 +138,13 @@ export function registerWsHandlers(): void {
 
   ipcMain.handle('ws:gateway-status', () => {
     const clients = getAllGatewayClients();
-    const statusMap: Record<string, { connected: boolean; name: string }> = {};
+    const statusMap: Record<string, { connected: boolean; name: string; error?: string }> = {};
     for (const [id, client] of clients) {
-      statusMap[id] = { connected: client.isConnected, name: client.name };
+      statusMap[id] = {
+        connected: client.isConnected,
+        name: client.name,
+        error: client.lastConnectionError ?? undefined,
+      };
     }
     return statusMap;
   });

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -29,6 +29,7 @@ import {
 import { getDebugLogger } from '../debug/index.js';
 
 const WS_CLOSE_POLICY_VIOLATION = 1008;
+const WS_HANDSHAKE_TIMEOUT_MS = 10_000;
 
 type PendingReq = {
   resolve: (payload: Record<string, unknown>) => void;
@@ -59,6 +60,8 @@ export class GatewayClient {
   private gatewayName: string;
   private connectNonce: string | null = null;
   private deviceIdentity: DeviceIdentity;
+  private lastError: string | null = null;
+  private lastErrorCode: string | null = null;
 
   constructor(config: GatewayClientConfig, opts?: { noReconnect?: boolean }) {
     this.gatewayId = config.id;
@@ -93,6 +96,7 @@ export class GatewayClient {
   connect(): void {
     if (this.destroyed) return;
     this.cleanup();
+    this.lastError = null;
 
     getDebugLogger().info({
       domain: 'gateway',
@@ -101,7 +105,7 @@ export class GatewayClient {
       attempt: this.reconnectAttempts + 1,
       data: { wsUrl: this.wsUrl },
     });
-    this.ws = new WebSocket(this.wsUrl);
+    this.ws = new WebSocket(this.wsUrl, { handshakeTimeout: WS_HANDSHAKE_TIMEOUT_MS });
 
     this.ws.on('open', () => {
       getDebugLogger().info({
@@ -118,6 +122,7 @@ export class GatewayClient {
 
     this.ws.on('close', (code, reason) => {
       const reasonStr = reason.toString();
+      const error = this.lastError ?? (code === WS_CLOSE_POLICY_VIOLATION ? reasonStr || 'policy violation' : undefined);
       getDebugLogger().warn({
         domain: 'gateway',
         event: 'gateway.ws.close',
@@ -134,7 +139,7 @@ export class GatewayClient {
         sendToWindow(this.mainWindow, 'gateway-status', {
           gatewayId: this.gatewayId,
           connected: false,
-          ...(code === WS_CLOSE_POLICY_VIOLATION ? { error: reasonStr || 'policy violation' } : {}),
+          error,
         });
       }
       // Don't retry when server explicitly rejects (pairing required, auth denied)
@@ -143,12 +148,20 @@ export class GatewayClient {
     });
 
     this.ws.on('error', (err) => {
+      this.lastError = err.message;
       getDebugLogger().error({
         domain: 'gateway',
         event: 'gateway.ws.error',
         gatewayId: this.gatewayId,
         error: { name: err.name, message: err.message, stack: err.stack },
       });
+      if (this.mainWindow) {
+        sendToWindow(this.mainWindow, 'gateway-status', {
+          gatewayId: this.gatewayId,
+          connected: false,
+          error: err.message,
+        });
+      }
     });
   }
 
@@ -298,6 +311,8 @@ export class GatewayClient {
           });
           this.authenticated = true;
           this.reconnectAttempts = 0;
+          this.lastError = null;
+          this.lastErrorCode = null;
           this.storeDeviceTokenFromPayload(payload);
           this.startHeartbeat();
           if (this.mainWindow) {
@@ -316,13 +331,16 @@ export class GatewayClient {
           });
         }
       })
-      .catch((err: Error) => {
+      .catch((err: Error & { details?: Record<string, unknown> }) => {
+        this.lastError = err.message;
+        this.lastErrorCode = (err.details?.code as string) ?? null;
         getDebugLogger().error({
           domain: 'gateway',
           event: 'gateway.connect.failed',
           gatewayId: this.gatewayId,
           requestId: 'connect-handshake',
           error: { name: err.name, message: err.message, stack: err.stack },
+          data: { errorCode: this.lastErrorCode },
         });
         this.ws?.close(WS_CLOSE_POLICY_VIOLATION, 'auth failed');
       });
@@ -398,7 +416,11 @@ export class GatewayClient {
         error: { message: errMsg, code: frame.error?.code },
         data: { method: pending.method },
       });
-      pending.reject(new Error(errMsg));
+      const err = new Error(errMsg) as Error & { details?: Record<string, unknown> };
+      if (frame.error?.details) {
+        err.details = frame.error.details;
+      }
+      pending.reject(err);
     }
   }
 
@@ -529,6 +551,14 @@ export class GatewayClient {
     return this.authenticated && this.ws?.readyState === WebSocket.OPEN;
   }
 
+  get lastConnectionError(): string | null {
+    return this.lastError;
+  }
+
+  get lastConnectionErrorCode(): string | null {
+    return this.lastErrorCode;
+  }
+
   private startHeartbeat(): void {
     this.stopHeartbeat();
     getDebugLogger().info({
@@ -617,12 +647,12 @@ export class GatewayClient {
     }
     if (this.ws) {
       this.ws.removeAllListeners();
+      this.ws.on('error', () => {});
       try {
         if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
           this.ws.close();
         }
       } catch {
-        // ws lib may throw when closing a CONNECTING socket before the HTTP upgrade completes
       }
       this.ws = null;
     }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -2,6 +2,7 @@ interface IpcResult {
   ok: boolean;
   result?: Record<string, unknown>;
   error?: string;
+  pairingRequired?: boolean;
 }
 
 interface ConnectionStatus {
@@ -50,7 +51,7 @@ export interface GatewayServerConfig {
 }
 
 interface GatewayStatusMap {
-  [gatewayId: string]: { connected: boolean; name: string };
+  [gatewayId: string]: { connected: boolean; name: string; error?: string };
 }
 
 interface GatewayListItem extends GatewayServerConfig {

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
@@ -227,7 +227,7 @@ export function useGatewayEventDispatcher(): void {
 
     window.clawwork.gatewayStatus().then((statusMap) => {
       for (const [gwId, info] of Object.entries(statusMap)) {
-        const status = info.connected ? 'connected' as const : 'disconnected' as const;
+        const status = info.connected ? 'connected' as const : info.error ? 'disconnected' as const : 'connecting' as const;
         setGatewayStatusByGateway(gwId, status);
         if (info.connected) {
           connectedGatewaysRef.current.add(gwId);
@@ -359,4 +359,3 @@ async function fetchCatalogs(gatewayId: string): Promise<void> {
     console.warn('[catalogs] Failed to fetch model/agent catalogs');
   }
 }
-

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -209,5 +209,14 @@
     "allowAlways": "Always Allow",
     "deny": "Deny",
     "newRequest": "Agent is requesting execution approval"
+  },
+  "pairing": {
+    "title": "Device Pairing Required",
+    "description": "This is the first time connecting to this remote gateway. The gateway administrator needs to approve this device before it can connect.",
+    "instructions": "Open the OpenClaw Web UI, go to Devices, and approve the pending request for this device.",
+    "waiting": "Waiting for approval\u2026",
+    "retry": "Retry",
+    "approved": "Device approved! Connection established.",
+    "stillPending": "Not approved yet. Please check the Devices page in OpenClaw Web UI."
   }
 }

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -209,5 +209,14 @@
     "allowAlways": "始终允许",
     "deny": "拒绝",
     "newRequest": "Agent 正在请求执行授权"
+  },
+  "pairing": {
+    "title": "需要设备配对",
+    "description": "这是首次连接此远程网关。网关管理员需要批准此设备后才能连接。",
+    "instructions": "请打开 OpenClaw Web UI，进入「设备」页面，批准此设备的待审请求。",
+    "waiting": "等待批准中…",
+    "retry": "重试",
+    "approved": "设备已批准！连接成功。",
+    "stillPending": "尚未批准。请检查 OpenClaw Web UI 的设备页面。"
   }
 }

--- a/packages/desktop/src/renderer/layouts/Settings/index.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/index.tsx
@@ -2,13 +2,14 @@ import { useState, useEffect, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   X, Moon, Sun, Globe, Star, Bug, Plus, Trash2, Pencil,
-  CheckCircle2, XCircle, Loader2, Server, Crown, RefreshCw,
+  CheckCircle2, XCircle, Loader2, Server, Crown, RefreshCw, ShieldCheck,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { cn, modKey } from '@/lib/utils'
 import { motion as motionPresets } from '@/styles/design-tokens'
 import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { useUiStore, type Language, type GatewayConnectionStatus, type SendShortcut } from '@/stores/uiStore'
 
@@ -166,6 +167,8 @@ export default function Settings({ onClose }: SettingsProps) {
   const [form, setForm] = useState<GatewayFormData>(EMPTY_FORM)
   const [testing, setTesting] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [showPairingDialog, setShowPairingDialog] = useState(false)
+  const [pairingRetrying, setPairingRetrying] = useState(false)
 
   const loadGateways = useCallback(async () => {
     const settings = await window.clawwork.getSettings()
@@ -232,20 +235,36 @@ export default function Settings({ onClose }: SettingsProps) {
     setForm(EMPTY_FORM)
   }, [])
 
+  const testAuth = useCallback(() => ({ token: form.token || undefined, password: form.password || undefined }), [form.token, form.password])
+
   const handleTest = useCallback(async () => {
     try { new URL(form.url) } catch {
       toast.error(t('settings.invalidUrl'))
       return
     }
     setTesting(true)
-    const res = await window.clawwork.testGateway(form.url, { token: form.token || undefined, password: form.password || undefined })
+    const res = await window.clawwork.testGateway(form.url, testAuth())
     setTesting(false)
     if (res.ok) {
       toast.success(t('settings.testSuccess'))
+    } else if (res.pairingRequired) {
+      setShowPairingDialog(true)
     } else {
       toast.error(t('settings.testFailed'), { description: res.error })
     }
-  }, [form, t])
+  }, [form.url, testAuth, t])
+
+  const handlePairingRetry = useCallback(async () => {
+    setPairingRetrying(true)
+    const res = await window.clawwork.testGateway(form.url, testAuth())
+    setPairingRetrying(false)
+    if (res.ok) {
+      setShowPairingDialog(false)
+      toast.success(t('pairing.approved'))
+    } else {
+      toast.error(t('pairing.stillPending'))
+    }
+  }, [form.url, testAuth, t])
 
   const handleSave = useCallback(async () => {
     if (!form.name.trim()) { toast.error(t('settings.nameRequired')); return }
@@ -319,6 +338,7 @@ export default function Settings({ onClose }: SettingsProps) {
   )
 
   return (
+    <>
     <motion.div {...motionPresets.fadeIn} className="flex flex-col h-full">
       <header className="flex items-center justify-between h-12 px-4 border-b border-[var(--border)] flex-shrink-0">
         <h2 className="font-medium text-[var(--text-primary)]">{t('common.settings')}</h2>
@@ -600,5 +620,42 @@ export default function Settings({ onClose }: SettingsProps) {
         </section>
       </div>
     </motion.div>
+
+      <Dialog open={showPairingDialog} onOpenChange={setShowPairingDialog}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              <ShieldCheck size={20} className="text-[var(--accent)]" />
+              <DialogTitle>{t('pairing.title')}</DialogTitle>
+            </div>
+            <DialogDescription className="pt-2">
+              {t('pairing.description')}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 pt-2">
+            <div className={cn(
+              'rounded-lg p-3 text-sm',
+              'bg-[var(--bg-tertiary)] border border-[var(--border)]',
+              'text-[var(--text-secondary)]',
+            )}>
+              {t('pairing.instructions')}
+            </div>
+            <div className="flex items-center gap-2 text-sm text-[var(--text-muted)]">
+              <Loader2 size={14} className="animate-spin" />
+              {t('pairing.waiting')}
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={() => setShowPairingDialog(false)}>
+                {t('common.cancel')}
+              </Button>
+              <Button variant="default" size="sm" onClick={handlePairingRetry} disabled={pairingRetrying} className="gap-1.5">
+                {pairingRetrying ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+                {t('pairing.retry')}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/packages/desktop/test/settings-handlers.test.ts
+++ b/packages/desktop/test/settings-handlers.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+let connected = false;
+const connectMock = vi.fn(() => {
+  connected = true;
+});
+const destroyMock = vi.fn();
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handleMap.set(channel, handler);
+    }),
+  },
+}));
+
+vi.mock('../src/main/workspace/config.js', () => ({
+  readConfig: vi.fn(() => null),
+  updateConfig: vi.fn(),
+  writeConfig: vi.fn(),
+  buildGatewayAuth: vi.fn(),
+}));
+
+vi.mock('../src/main/ws/index.js', () => ({
+  getGatewayClient: vi.fn(() => null),
+  getAllGatewayClients: vi.fn(() => new Map()),
+  addGateway: vi.fn(),
+  removeGateway: vi.fn(),
+}));
+
+vi.mock('../src/main/ws/gateway-client.js', () => ({
+  GatewayClient: vi.fn().mockImplementation(() => ({
+    connect: connectMock,
+    destroy: destroyMock,
+    get isConnected() {
+      return connected;
+    },
+  })),
+}));
+
+describe('registerSettingsHandlers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    handleMap.clear();
+    connected = false;
+    connectMock.mockReset();
+    connectMock.mockImplementation(() => {
+      connected = true;
+    });
+    destroyMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts a connection attempt when testing a gateway', async () => {
+    const { registerSettingsHandlers } = await import('../src/main/ipc/settings-handlers.js');
+
+    registerSettingsHandlers();
+
+    const handler = handleMap.get('settings:test-gateway');
+    expect(handler).toBeTypeOf('function');
+
+    const pending = handler?.({}, 'wss://gateway.example.com', { token: 'secret' }) as Promise<{ ok: boolean }>;
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    await expect(pending).resolves.toEqual({ ok: true });
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns timeout when the connection never becomes ready', async () => {
+    connectMock.mockImplementationOnce(() => {});
+
+    const { registerSettingsHandlers } = await import('../src/main/ipc/settings-handlers.js');
+
+    registerSettingsHandlers();
+
+    const handler = handleMap.get('settings:test-gateway');
+    expect(handler).toBeTypeOf('function');
+
+    const pending = handler?.({}, 'wss://gateway.example.com', { token: 'secret' }) as Promise<{ ok: boolean; error: string }>;
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(pending).resolves.toEqual({ ok: false, error: 'timeout' });
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/gateway-protocol.ts
+++ b/packages/shared/src/gateway-protocol.ts
@@ -15,7 +15,7 @@ export interface GatewayResFrame {
   id: string;
   ok: boolean;
   payload?: Record<string, unknown>;
-  error?: { code: string; message: string };
+  error?: { code: string; message: string; details?: Record<string, unknown> };
 }
 
 export interface GatewayEventFrame {


### PR DESCRIPTION
## Summary

Fix three bugs preventing WSS (remote) Gateway connections from working, add proper error propagation from the Gateway handshake to the UI, and implement a device pairing dialog so users can approve new devices through the OpenClaw WebUI when connecting to a remote Gateway for the first time.

## Type of change

- [x] `[Fix]` bug fix
- [x] `[UI]` UI or UX change

## Why is this needed?

Connecting to a remote Gateway via WSS showed only cryptic "timeout" errors because: (1) `test-gateway` never called `connect()`, (2) the test handler only reported "timeout" regardless of the actual error, and (3) `ws.on('error')` didn't forward errors to the UI. Additionally, remote Gateways require device pairing on first connect, but the app had no UX for this — users saw an unhelpful error with no guidance on how to approve the device.

## What changed?

- **Connection bug fixes**: `test-gateway` IPC handler now calls `connect()`, propagates actual error messages instead of always returning "timeout", and forwards WebSocket errors to the renderer via `sendToWindow`
- **Error propagation**: `GatewayResFrame` type extended with `details` field; `handleResponse()` attaches error details to rejected promises; `handleChallenge()` stores `lastErrorCode` for detection of `PAIRING_REQUIRED`
- **WebSocket cleanup crash fix**: Added no-op error handler after `removeAllListeners()` in `cleanup()` to prevent uncaught exception when closing a CONNECTING-state WebSocket
- **Device pairing UX**: New pairing dialog in Settings with ShieldCheck icon, instructions to approve via OpenClaw WebUI Devices page, "Waiting for approval" spinner, Retry and Cancel buttons
- **Gateway status improvements**: Status map includes `error` field; `useGatewayDispatcher` uses it to distinguish `disconnected` vs `connecting` states
- **Code simplification**: Replaced polling loop in `test-gateway` with simple `while`/`await` loop; eliminated conditional spread patterns; extracted shared auth object in Settings
- **i18n**: Added `pairing.*` key group in both `en.json` and `zh.json`
- **Tests**: Added test coverage for `test-gateway` handler (connection success + timeout scenarios)

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passes clean (0 errors)
```

## Screenshots or recordings

N/A

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fix WSS connection errors when connecting to remote Gateways. Add device pairing dialog that guides users through the approval process on first remote connection.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate