### PR TITLE
[Fix] Prevent electron-builder from creating duplicate draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,14 +68,14 @@ jobs:
         run: pnpm --filter @clawwork/desktop build
 
       - name: Package (${{ matrix.platform }})
-        run: pnpm --filter @clawwork/desktop exec electron-builder ${{ matrix.build_args }} -c.buildVersion="$BUILD_VERSION"
+        run: pnpm --filter @clawwork/desktop exec electron-builder ${{ matrix.build_args }} --publish never -c.buildVersion="$BUILD_VERSION"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_VERSION: ${{ github.run_number }}
 
       - name: Upload artifacts to release
         uses: softprops/action-gh-release@v2
         with:
+          name: ${{ env.RELEASE_TAG }}
           files: |
             packages/desktop/dist/*.dmg
             packages/desktop/dist/*.zip


### PR DESCRIPTION
## Summary

The release workflow had three overlapping problems causing duplicate/draft GitHub Releases and missing `v` prefix in release titles. This PR fixes all three by making electron-builder package-only (`--publish never`) and letting `softprops/action-gh-release` be the sole release publisher with an explicit `name` field.

## Type of change

- [x] `[Fix]` bug fix
- [x] `[Build]` CI, packaging, or tooling change

## Why is this needed?

Three issues were stacked:
1. `electron-builder` auto-publishes a **draft** GitHub Release when it detects `GH_TOKEN` in CI (default `onTagOrDraft` strategy), using the bare `package.json` version as the release name (e.g. `0.0.5` instead of `v0.0.5`).
2. `softprops/action-gh-release` then creates/updates a **second** formal release on the same tag, but without an explicit `name` it inherited whatever electron-builder created.
3. The matrix strategy (mac + win) made both jobs race through both publish paths.

This caused: ghost draft releases, release titles missing the `v` prefix, and type conflicts logged as `existing type not compatible with publishing type`.

## What changed?

- Added `--publish never` to the `electron-builder` invocation so it only produces local artifacts
- Removed `GH_TOKEN` from the Package step env (no longer needed)
- Added explicit `name: ${{ env.RELEASE_TAG }}` to `softprops/action-gh-release` so the release title matches the tag (e.g. `v0.0.5`)

## Linked issues

N/A

## Validation

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
CI-only change — requires a tag push to validate. No local build/test impact.
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate