### PR TITLE
[Build] Add smoke and gateway e2e coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,99 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared package
+        run: pnpm --filter @clawwork/desktop exec tsc -b ../../packages/shared/tsconfig.json
+
+      - name: Build Electron app
+        run: pnpm --filter @clawwork/desktop exec electron-vite build
+
+      - name: Install Xvfb
+        run: sudo apt-get install -y xvfb
+
+      - name: Diagnose Electron environment
+        working-directory: packages/desktop
+        shell: bash {0}
+        run: |
+          echo "=== node / electron versions ==="
+          node -v
+          ELECTRON_BIN=$(node -e "console.log(require('electron'))" 2>&1) || true
+          echo "electron binary: $ELECTRON_BIN"
+          if [ -f "$ELECTRON_BIN" ]; then
+            ls -la "$ELECTRON_BIN"
+            echo "=== ldd missing libs ==="
+            ldd "$ELECTRON_BIN" 2>&1 | grep "not found" || echo "(none missing)"
+          else
+            echo "WARN: electron binary not resolved, searching..."
+            find ../../node_modules/.pnpm -name electron -type f 2>/dev/null | head -5 || true
+            find node_modules -name electron -type f 2>/dev/null | head -5 || true
+          fi
+          echo "=== build output ==="
+          ls -R out/ 2>/dev/null | head -40 || echo "out/ not found"
+          echo "=== DISPLAY ==="
+          echo "${DISPLAY:-unset}"
+
+      - name: Pull OpenClaw image
+        run: docker pull ghcr.io/openclaw/openclaw:$OPENCLAW_VERSION
+        env:
+          OPENCLAW_VERSION: latest
+
+      - name: Start OpenClaw Gateway
+        run: docker compose -f e2e/docker-compose.yml up -d --wait
+
+      - name: Layer 1 — Smoke tests
+        id: smoke
+        continue-on-error: true
+        run: xvfb-run --auto-servernum -- npx playwright test --config=e2e/playwright.config.ts --project=smoke
+
+      - name: Layer 2 — Gateway integration tests
+        id: gateway
+        continue-on-error: true
+        run: xvfb-run --auto-servernum -- npx playwright test --config=e2e/playwright.config.ts --project=gateway
+
+      - name: Stop OpenClaw Gateway
+        if: always()
+        run: docker compose -f e2e/docker-compose.yml down
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Check results
+        if: steps.smoke.outcome == 'failure' || steps.gateway.outcome == 'failure'
+        run: |
+          echo "::error::E2E tests failed — smoke=${{ steps.smoke.outcome }} gateway=${{ steps.gateway.outcome }}"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ package-lock.json
 
 # OS
 Thumbs.db
+
+# test
+test-results/
+playwright-report/

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  openclaw-gateway:
+    image: ghcr.io/openclaw/openclaw:${OPENCLAW_VERSION:-latest}
+    ports:
+      - "28789:18789"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:18789/healthz').then(r=>{if(!r.ok)throw 1})"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    entrypoint:
+      - sh
+      - -lc
+      - mkdir -p /tmp/openclaw-state && cp /fixtures/openclaw-config.json /tmp/openclaw-state/openclaw.json && exec node dist/index.js gateway --bind lan --port 18789 --token "$$OPENCLAW_GATEWAY_TOKEN" --allow-unconfigured
+    volumes:
+      - ./fixtures/openclaw-config.json:/fixtures/openclaw-config.json:ro
+    environment:
+      OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: "1"
+      OPENCLAW_GATEWAY_TOKEN: e2e-test-token-123
+      OPENCLAW_STATE_DIR: /tmp/openclaw-state

--- a/e2e/fixtures/openclaw-config.json
+++ b/e2e/fixtures/openclaw-config.json
@@ -1,0 +1,7 @@
+{
+  "gateway": {
+    "controlUi": {
+      "dangerouslyAllowHostHeaderOriginFallback": true
+    }
+  }
+}

--- a/e2e/gateway/integration.spec.ts
+++ b/e2e/gateway/integration.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from 'playwright';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { launchApp } from '../helpers/electron-app';
+import { waitForGateway } from '../helpers/gateway';
+import { approvePendingPairing, getDeviceIdFromUserData, getDeviceTokenFromUserData } from '../helpers/pairing';
+import { GATEWAY_ID, CONNECTION_TIMEOUT_MS, GATEWAY_WS_URL, buildSessionKey } from '../helpers/constants';
+
+let app: ElectronApplication;
+let page: Page;
+let cleanup: () => void;
+let userDataDir: string;
+let workspaceDir: string;
+
+async function waitForGatewayConnected(targetPage: Page): Promise<void> {
+  await expect(async () => {
+    const status = await targetPage.evaluate(() => window.clawwork.gatewayStatus());
+    expect(status[GATEWAY_ID]?.connected).toBe(true);
+  }).toPass({ timeout: CONNECTION_TIMEOUT_MS });
+}
+
+test.beforeAll(async () => {
+  await waitForGateway();
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-e2e-userdata-'));
+  workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-e2e-ws-'));
+  ({ app, page, cleanup } = await launchApp({ gateway: true, userDataDir, workspaceDir }));
+
+  expect(getDeviceTokenFromUserData(userDataDir, GATEWAY_ID)).toBeNull();
+  await expect(async () => {
+    const status = await page.evaluate(() => window.clawwork.gatewayStatus());
+    expect(status[GATEWAY_ID]?.error).toBe('pairing required');
+  }).toPass({ timeout: 15_000 });
+
+  const deviceId = getDeviceIdFromUserData(userDataDir);
+  approvePendingPairing(deviceId);
+  expect(getDeviceTokenFromUserData(userDataDir, GATEWAY_ID)).toBeNull();
+
+  await page.evaluate(([gwId]) => window.clawwork.updateGateway(gwId, {}), [GATEWAY_ID] as const);
+  await waitForGatewayConnected(page);
+
+  const issuedToken = getDeviceTokenFromUserData(userDataDir, GATEWAY_ID);
+  expect(issuedToken).toBeTruthy();
+
+  await app.close();
+
+  ({ app, page } = await launchApp({ gateway: true, userDataDir, workspaceDir }));
+
+  await waitForGatewayConnected(page);
+  expect(getDeviceTokenFromUserData(userDataDir, GATEWAY_ID)).toBe(issuedToken);
+});
+
+test('P1: first-time device pairing persists across restart', async () => {
+  await waitForGatewayConnected(page);
+  expect(getDeviceTokenFromUserData(userDataDir, GATEWAY_ID)).toBeTruthy();
+});
+
+test.afterAll(async () => {
+  if (app) await app.close().catch(() => {});
+  cleanup?.();
+});
+
+test.describe('Layer 2: Gateway Integration', () => {
+  test('G1: gateway connection established with token auth', async () => {
+    const status = await page.evaluate(() => window.clawwork.gatewayStatus());
+    expect(status[GATEWAY_ID]?.connected).toBe(true);
+  });
+
+  test('G2: gateway status reflected in renderer', async () => {
+    const status = await page.evaluate(([gwId]) => {
+      return window.clawwork.gatewayStatus().then((s) => s[gwId]);
+    }, [GATEWAY_ID] as const);
+
+    expect(status?.error).toBeUndefined();
+    expect(status?.connected).toBe(true);
+  });
+
+  test('G3: list sessions via gateway', async () => {
+    const result = await page.evaluate(([gwId]) => {
+      return window.clawwork.listSessions(gwId);
+    }, [GATEWAY_ID] as const);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test('G4: send message via gateway', async () => {
+    const sessionKey = buildSessionKey();
+
+    const result = await page.evaluate(
+      ([gwId, sk]) => {
+        return window.clawwork.sendMessage(gwId, sk, 'hello from e2e');
+      },
+      [GATEWAY_ID, sessionKey] as const,
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  test('G5: chat history returns after send', async () => {
+    const sessionKey = buildSessionKey();
+
+    await page.evaluate(
+      ([gwId, sk]) => window.clawwork.sendMessage(gwId, sk, 'e2e history test'),
+      [GATEWAY_ID, sessionKey] as const,
+    );
+
+    await page.waitForTimeout(1000);
+
+    const result = await page.evaluate(
+      ([gwId, sk]) => window.clawwork.chatHistory(gwId, sk),
+      [GATEWAY_ID, sessionKey] as const,
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  test('G6: gateway events reach renderer', async () => {
+    const sessionKey = buildSessionKey();
+
+    const received = await page.evaluate(
+      ([gwId, sk]) => {
+        return new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => resolve(false), 10_000);
+          const unsub = window.clawwork.onGatewayEvent((evt) => {
+            if (evt.gatewayId === gwId) {
+              clearTimeout(timer);
+              unsub();
+              resolve(true);
+            }
+          });
+          window.clawwork.sendMessage(gwId, sk, 'e2e event test');
+        });
+      },
+      [GATEWAY_ID, sessionKey] as const,
+    );
+
+    expect(received).toBe(true);
+  });
+
+  test('G7: multiple sessions are independent', async () => {
+    const sk1 = buildSessionKey();
+    const sk2 = buildSessionKey();
+
+    await page.evaluate(
+      ([gwId, s1, s2]) => {
+        return Promise.all([
+          window.clawwork.sendMessage(gwId, s1, 'session-1-msg'),
+          window.clawwork.sendMessage(gwId, s2, 'session-2-msg'),
+        ]);
+      },
+      [GATEWAY_ID, sk1, sk2] as const,
+    );
+
+    await page.waitForTimeout(1000);
+
+    const [h1, h2] = await page.evaluate(
+      ([gwId, s1, s2]) => {
+        return Promise.all([
+          window.clawwork.chatHistory(gwId, s1),
+          window.clawwork.chatHistory(gwId, s2),
+        ]);
+      },
+      [GATEWAY_ID, sk1, sk2] as const,
+    );
+
+    expect(h1.ok).toBe(true);
+    expect(h2.ok).toBe(true);
+  });
+
+  test('A1: wrong token is rejected', async () => {
+    const result = await page.evaluate(([url]) => {
+      return window.clawwork.testGateway(url, {
+        token: 'wrong-token-xxx',
+      });
+    }, [GATEWAY_WS_URL] as const);
+
+    expect(result.ok).toBe(false);
+  });
+
+  test('A2: empty token is rejected', async () => {
+    const result = await page.evaluate(([url]) => {
+      return window.clawwork.testGateway(url, {});
+    }, [GATEWAY_WS_URL] as const);
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/e2e/helpers/constants.ts
+++ b/e2e/helpers/constants.ts
@@ -1,0 +1,15 @@
+import { randomUUID } from 'crypto';
+
+export const GATEWAY_TOKEN = 'e2e-test-token-123';
+export const GATEWAY_ID = 'e2e-gateway';
+export const GATEWAY_PORT = 28789;
+export const GATEWAY_WS_URL = `ws://127.0.0.1:${GATEWAY_PORT}`;
+export const GATEWAY_HTTP_URL = `http://127.0.0.1:${GATEWAY_PORT}`;
+export const HEALTH_TIMEOUT_MS = 30_000;
+export const POLL_INTERVAL_MS = 500;
+export const CONNECTION_TIMEOUT_MS = 15_000;
+
+export function buildSessionKey(taskId?: string): string {
+  const id = taskId ?? randomUUID();
+  return `agent:main:clawwork:task:${id}`;
+}

--- a/e2e/helpers/electron-app.ts
+++ b/e2e/helpers/electron-app.ts
@@ -1,0 +1,119 @@
+import { _electron as electron } from 'playwright';
+import type { ElectronApplication, Page } from 'playwright';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { GATEWAY_ID, GATEWAY_WS_URL, GATEWAY_TOKEN } from './constants';
+
+const CONFIG_FILE_NAME = 'clawwork-config.json';
+const DESKTOP_PKG = path.resolve(__dirname, '../../packages/desktop');
+const APP_ENTRY = path.join(DESKTOP_PKG, 'out/main/index.js');
+
+function resolveElectronBinary(): string {
+  const electronMain = require.resolve('electron', { paths: [DESKTOP_PKG] });
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const electronBin = require(electronMain) as unknown as string;
+  return electronBin;
+}
+
+export interface LaunchResult {
+  app: ElectronApplication;
+  page: Page;
+  cleanup: () => void;
+  userDataDir: string;
+  workspaceDir: string;
+}
+
+function dumpDiagnostics(electronBin: string): void {
+  console.log('[e2e-diag] APP_ENTRY:', APP_ENTRY, 'exists:', fs.existsSync(APP_ENTRY));
+  console.log('[e2e-diag] electron binary:', electronBin, 'exists:', fs.existsSync(electronBin));
+  console.log('[e2e-diag] platform:', process.platform, 'arch:', process.arch);
+  console.log('[e2e-diag] CI:', process.env.CI ?? 'false');
+  console.log('[e2e-diag] DISPLAY:', process.env.DISPLAY ?? 'unset');
+
+  const outDir = path.join(DESKTOP_PKG, 'out');
+  if (fs.existsSync(outDir)) {
+    const files = fs.readdirSync(outDir, { recursive: true }) as string[];
+    console.log('[e2e-diag] out/ files:', files.slice(0, 20).join(', '));
+  } else {
+    console.log('[e2e-diag] out/ directory DOES NOT EXIST');
+  }
+}
+
+export async function launchApp(options?: {
+  gateway?: boolean;
+  userDataDir?: string;
+  workspaceDir?: string;
+}): Promise<LaunchResult> {
+  const electronBin = resolveElectronBinary();
+  dumpDiagnostics(electronBin);
+
+  const userDataDir = options?.userDataDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-e2e-userdata-'));
+  const workspaceDir = options?.workspaceDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-e2e-ws-'));
+
+  const config: Record<string, unknown> = {
+    workspacePath: workspaceDir,
+    trayEnabled: false,
+    quickLaunch: {
+      enabled: false,
+      shortcut: 'Alt+Space',
+    },
+    gateways: options?.gateway
+      ? [
+          {
+            id: GATEWAY_ID,
+            name: 'E2E Test Gateway',
+            url: GATEWAY_WS_URL,
+            token: GATEWAY_TOKEN,
+            isDefault: true,
+          },
+        ]
+      : [],
+    defaultGatewayId: options?.gateway ? GATEWAY_ID : undefined,
+  };
+
+  fs.writeFileSync(path.join(userDataDir, CONFIG_FILE_NAME), JSON.stringify(config, null, 2));
+
+  const launchArgs = [APP_ENTRY, `--user-data-dir=${userDataDir}`];
+  if (process.env.CI) {
+    launchArgs.push('--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage');
+  }
+
+  console.log('[e2e-diag] launch args:', launchArgs);
+
+  let app: ElectronApplication;
+  try {
+    app = await electron.launch({
+      executablePath: electronBin,
+      args: launchArgs,
+      env: { ...process.env, NODE_ENV: 'test', ELECTRON_DISABLE_SANDBOX: '1' },
+    });
+  } catch (err) {
+    console.error('[e2e-diag] electron.launch() FAILED:', err);
+    throw err;
+  }
+
+  console.log('[e2e-diag] electron launched, pid:', app.process().pid);
+
+  app.process().stderr?.on('data', (chunk: Buffer) => {
+    console.log('[electron-stderr]', chunk.toString().trimEnd());
+  });
+
+  const page = await app.firstWindow();
+  console.log('[e2e-diag] first window obtained, url:', page.url());
+
+  const cleanup = (): void => {
+    try {
+      fs.rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+    try {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  };
+
+  return { app, page, cleanup, userDataDir, workspaceDir };
+}

--- a/e2e/helpers/gateway.ts
+++ b/e2e/helpers/gateway.ts
@@ -1,0 +1,15 @@
+import { GATEWAY_HTTP_URL, HEALTH_TIMEOUT_MS, POLL_INTERVAL_MS } from './constants';
+
+export async function waitForGateway(): Promise<void> {
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${GATEWAY_HTTP_URL}/healthz`);
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`Gateway not ready after ${HEALTH_TIMEOUT_MS}ms`);
+}

--- a/e2e/helpers/pairing.ts
+++ b/e2e/helpers/pairing.ts
@@ -1,0 +1,66 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { GATEWAY_TOKEN } from './constants';
+
+const DEVICE_IDENTITY_FILE = 'device-identity.json';
+
+interface StoredIdentity {
+  version: 1;
+  deviceId: string;
+}
+
+interface PairingListResult {
+  pending?: Array<{ requestId?: string; deviceId?: string }>;
+}
+
+interface DeviceTokenStore {
+  version: 1;
+  tokens?: Record<string, { token?: string; role?: string; issuedAtMs?: number }>;
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+function runGatewayCall(method: string, params: Record<string, unknown>): unknown {
+  const composeFile = path.resolve(__dirname, '../docker-compose.yml');
+  const innerCommand = [
+    'mkdir -p /tmp/e2e-approver',
+    `OPENCLAW_STATE_DIR=/tmp/e2e-approver node dist/index.js gateway call ${method} --url ws://127.0.0.1:18789 --token ${GATEWAY_TOKEN} --params '${JSON.stringify(params)}' --json`,
+  ].join(' && ');
+  const stdout = execFileSync(
+    'docker',
+    ['compose', '-f', composeFile, 'exec', '-T', 'openclaw-gateway', 'sh', '-lc', innerCommand],
+    { encoding: 'utf8' },
+  );
+  return JSON.parse(stdout);
+}
+
+export function getDeviceIdFromUserData(userDataDir: string): string {
+  const parsed = readJsonFile<StoredIdentity>(path.join(userDataDir, DEVICE_IDENTITY_FILE));
+  if (!parsed?.deviceId || typeof parsed.deviceId !== 'string') {
+    throw new Error('missing deviceId in device identity file');
+  }
+  return parsed.deviceId;
+}
+
+export function getDeviceTokenFromUserData(userDataDir: string, gatewayId: string): string | null {
+  const tokenStorePath = path.join(userDataDir, 'device-tokens.json');
+  if (!fs.existsSync(tokenStorePath)) {
+    return null;
+  }
+  const parsed = readJsonFile<DeviceTokenStore>(tokenStorePath);
+  const token = parsed?.tokens?.[gatewayId]?.token;
+  return typeof token === 'string' && token ? token : null;
+}
+
+export function approvePendingPairing(deviceId: string): void {
+  const list = runGatewayCall('device.pair.list', {}) as PairingListResult;
+  const pending = Array.isArray(list.pending) ? list.pending : [];
+  const match = pending.find((item) => item?.deviceId === deviceId);
+  if (!match?.requestId) {
+    throw new Error(`pending pairing request not found for device ${deviceId}`);
+  }
+  runGatewayCall('device.pair.approve', { requestId: match.requestId });
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  reporter: [['html', { open: 'never', outputFolder: '../playwright-report' }]],
+  projects: [
+    {
+      name: 'smoke',
+      testMatch: 'smoke/**/*.spec.ts',
+    },
+    {
+      name: 'gateway',
+      testMatch: 'gateway/**/*.spec.ts',
+    },
+  ],
+});

--- a/e2e/smoke/app-launch.spec.ts
+++ b/e2e/smoke/app-launch.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from 'playwright';
+import { launchApp } from '../helpers/electron-app';
+
+let app: ElectronApplication;
+let page: Page;
+let cleanup: () => void;
+
+test.beforeAll(async () => {
+  ({ app, page, cleanup } = await launchApp());
+});
+
+test.afterAll(async () => {
+  if (app) await app.close().catch(() => {});
+  cleanup?.();
+});
+
+test.describe('Layer 1: Smoke Tests', () => {
+  test('S1: app launches without crash', async () => {
+    expect(app.process().exitCode).toBeNull();
+  });
+
+  test('S2: main window is created and visible', async () => {
+    const windows = app.windows();
+    expect(windows.length).toBeGreaterThanOrEqual(1);
+
+    await expect(async () => {
+      const visible = await app.evaluate(({ BrowserWindow }) => {
+        const wins = BrowserWindow.getAllWindows();
+        return wins.some((w) => w.isVisible());
+      });
+      expect(visible).toBe(true);
+    }).toPass({ timeout: 10_000 });
+  });
+
+  test('S3: renderer loads without uncaught errors', async () => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(2000);
+
+    const bodyLength = await page.evaluate(() => document.body.innerHTML.length);
+    expect(bodyLength).toBeGreaterThan(0);
+    expect(errors).toEqual([]);
+  });
+
+  test('S4: preload API is exposed', async () => {
+    const apiType = await page.evaluate(() => typeof (window as Record<string, unknown>).clawwork);
+    expect(apiType).toBe('object');
+
+    const methods = await page.evaluate(() =>
+      Object.keys((window as Record<string, unknown>).clawwork as object),
+    );
+    expect(methods).toContain('sendMessage');
+    expect(methods).toContain('gatewayStatus');
+    expect(methods).toContain('listGateways');
+    expect(methods).toContain('loadTasks');
+    expect(methods).toContain('onGatewayEvent');
+    expect(methods).toContain('onGatewayStatus');
+  });
+
+  test('S5: app process is healthy', async () => {
+    expect(app.process().pid).toBeGreaterThan(0);
+    expect(app.process().exitCode).toBeNull();
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,16 @@
     "build": "pnpm -r build",
     "typecheck": "packages/desktop/node_modules/.bin/tsc -b packages/shared/tsconfig.json && packages/desktop/node_modules/.bin/tsc --noEmit -p packages/desktop/tsconfig.json",
     "lint": "pnpm -r lint",
-    "test": "pnpm -r test"
+    "test": "pnpm -r test",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
+    "test:e2e:smoke": "playwright test --config=e2e/playwright.config.ts --project=smoke",
+    "test:e2e:gateway": "playwright test --config=e2e/playwright.config.ts --project=gateway"
   },
   "engines": {
     "node": ">=20.0.0",
     "pnpm": ">=9.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
 
   packages/desktop:
     dependencies:
@@ -584,6 +588,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2081,6 +2090,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2892,6 +2906,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -4056,6 +4080,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5546,6 +5574,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6594,6 +6625,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

Add a dedicated Playwright-based e2e layer for the desktop app and wire it into CI so smoke coverage and gateway integration coverage run automatically.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [x] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The desktop app did not have automated end-to-end coverage for basic launch behavior or gateway integration behavior. That made auth regressions, connection regressions, and pairing flow regressions easy to miss until manual testing.

## What changed?

- add Playwright e2e projects for smoke and gateway coverage
- add Electron launch and gateway/pairing helpers for local test setup
- add Docker-based OpenClaw gateway fixture for integration tests
- add CI workflow to run smoke tests first and gateway tests second
- add root e2e scripts and Playwright dependency

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
pnpm run test:e2e:gateway
```

## Screenshots or recordings

If the change affects the UI, add screenshots or a short recording.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate