### PR TITLE
[Fix] Drop gateway events for unknown local tasks

### DIFF
--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
@@ -108,6 +108,12 @@ export function useGatewayEventDispatcher(): void {
         return;
       }
 
+      const localTasks = useTaskStore.getState().tasks;
+      if (!localTasks.some((t) => t.id === taskId)) {
+        debugEvent('renderer.event.dropped.unknown_task', { taskId, sessionKey, state });
+        return;
+      }
+
       if (taskId !== activeTaskIdRef.current) {
         useUiStore.getState().markUnread(taskId);
       }
@@ -174,6 +180,12 @@ export function useGatewayEventDispatcher(): void {
       }
 
       if (!data.name || !data.toolCallId) return;
+
+      const localTasks = useTaskStore.getState().tasks;
+      if (!localTasks.some((t) => t.id === taskId)) {
+        debugEvent('renderer.agent.dropped.unknown_task', { taskId, sessionKey, stream });
+        return;
+      }
 
       if (taskId !== activeTaskIdRef.current) {
         useUiStore.getState().markUnread(taskId);


### PR DESCRIPTION
## Problem

Gateway broadcasts all session events without filtering ([known issue](https://github.com/openclaw/openclaw/issues/32579)). When multiple users share one Gateway, the client receives `chat` and `agent` events for sessions it never created. This causes:

1. **`SQLITE_CONSTRAINT_FOREIGNKEY` errors** — `persistMessage` tries to insert a message row referencing a `taskId` that doesn't exist in the local `tasks` table
2. **Cross-user session leakage** — messages from other users' sessions get written into the local Zustand store, polluting the UI

Discovered via E2E CI stderr output: 5x `create-message failed: SqliteError: FOREIGN KEY constraint failed`.

## Changes

**`packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts`**

- `handleChatEvent`: after parsing `taskId` from `sessionKey`, check if the task exists in the local `taskStore`. If not, drop the event with a `renderer.event.dropped.unknown_task` debug log.
- `handleAgentEvent`: same guard — drop tool-call events for tasks not in the local store (`renderer.agent.dropped.unknown_task`).

## Test Plan

- [x] `pnpm typecheck` passes
- [ ] E2E CI: `SQLITE_CONSTRAINT_FOREIGNKEY` errors no longer appear in stderr
- [ ] Manual: connect two ClawWork instances to the same Gateway, send messages in each — verify no cross-contamination