### PR TITLE
[Fix] Ensure workspace directory exists before opening database on Windows

### DIFF
--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { mkdirSync } from 'fs';
 import { DB_FILE_NAME } from '@clawwork/shared';
 import * as schema from './schema.js';
 import { initFTS } from './fts.js';
@@ -55,6 +56,7 @@ export function initDatabase(workspacePath: string): void {
   if (db) return;
 
   const dbPath = join(workspacePath, DB_FILE_NAME);
+  mkdirSync(dirname(dbPath), { recursive: true });
   sqlite = new Database(dbPath);
   sqlite.pragma('journal_mode = WAL');
   sqlite.pragma('foreign_keys = ON');


### PR DESCRIPTION
## Summary

On Windows, first launch crashes with "Database Error: Cannot open database because the directory does not exist" because `better-sqlite3` does not create parent directories automatically. This PR adds `mkdirSync` before opening the database to ensure the workspace directory exists.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Windows users cannot start the app if the workspace directory hasn't been created yet. The `better-sqlite3` `new Database(path)` call throws when the parent directory is missing. On macOS this rarely triggers because the directory typically already exists, but on Windows first launch it's a guaranteed crash.

## What changed?

- Added `mkdirSync(dirname(dbPath), { recursive: true })` before `new Database(dbPath)` in `packages/desktop/src/main/db/index.ts`
- Added `dirname` from `path` and `mkdirSync` from `fs` imports

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
$ pnpm typecheck
# passes clean
```

## Screenshots or recordings

N/A

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fix Windows startup crash "Cannot open database because the directory does not exist" by ensuring the workspace directory is created before opening the database.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate