### PR TITLE
[Build] Add dev release workflow for continuous builds on main

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -14,15 +14,17 @@ permissions:
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/main'
+
     strategy:
       matrix:
         include:
           - os: macos-latest
             platform: mac
-            build_args: "--mac --universal"
+            build_args: '--mac --universal'
           - os: windows-latest
             platform: win
-            build_args: "--win --x64"
+            build_args: '--win --x64'
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -64,33 +66,47 @@ jobs:
             packages/desktop/dist/*.zip
             packages/desktop/dist/*.exe
             packages/desktop/dist/*.blockmap
+          if-no-files-found: error
           retention-days: 5
 
   release:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Force-update dev tag to current commit
+        run: |
+          git tag -f dev
+          git push -f origin dev
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true
 
-      - name: Get short SHA
+      - name: Get commit metadata
         id: meta
-        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "date=$(git log -1 --format=%ci)" >> "$GITHUB_OUTPUT"
+          echo "message<<MSGEOF" >> "$GITHUB_OUTPUT"
+          git log -1 --format=%s >> "$GITHUB_OUTPUT"
+          echo "MSGEOF" >> "$GITHUB_OUTPUT"
 
       - name: Update dev release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: dev
-          name: "Dev Build (main@${{ steps.meta.outputs.short_sha }})"
+          name: 'Dev Build (main@${{ steps.meta.outputs.short_sha }})'
           body: |
             Automated dev build from `main` branch.
 
             **Commit:** ${{ github.sha }}
-            **Date:** ${{ github.event.head_commit.timestamp }}
-            **Message:** ${{ github.event.head_commit.message }}
+            **Date:** ${{ steps.meta.outputs.date }}
+            **Message:** ${{ steps.meta.outputs.message }}
 
             > This is a development build and may be unstable. For stable releases, see the [latest release](../../releases/latest).
           files: artifacts/*


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically builds and publishes a dev pre-release on every push to `main`. Gives developers and testers immediate access to the latest builds without waiting for a tagged release.

## Type of change

- [x] `[Build]` CI, packaging, or tooling change

## Why is this needed?

Development and bug fixes are frequent — waiting for a manual tag release slows down the feedback loop. A rolling dev release lets users always grab the latest main build from a stable URL (`releases/tag/dev`).

## What changed?

- Added `.github/workflows/dev-release.yml`
- Triggers on push to `main` and `workflow_dispatch` (guarded by `if: github.ref == 'refs/heads/main'` to prevent non-main branches from polluting the dev release)
- Builds mac (universal) and win (x64) in parallel
- Force-updates the `dev` tag to the latest commit before publishing, ensuring the tag always points to the correct commit
- Uploads artifacts with `if-no-files-found: error` so a missing platform package fails the build instead of silently publishing an incomplete release
- Reads commit metadata via `git log` instead of `github.event.head_commit` fields, which are unavailable under `workflow_dispatch`
- `make_latest: false` ensures the official tagged release remains the "Latest" on GitHub

## Linked issues

N/A

## Validation

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
CI workflow — validation will happen when the workflow runs on first merge.
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate