### PR TITLE
[Fix] Remove native menu bar on Windows

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain, globalShortcut, dialog } from 'electron';
+import { app, shell, BrowserWindow, Menu, ipcMain, globalShortcut, dialog } from 'electron';
 import { join } from 'path';
 import { writeFileSync } from 'fs';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
@@ -59,6 +59,9 @@ function setupDevScreenshot(win: BrowserWindow): void {
 
 function createWindow(): BrowserWindow {
   getDebugLogger().info({ domain: 'app', event: 'app.window.create' });
+  if (process.platform !== 'darwin') {
+    Menu.setApplicationMenu(null);
+  }
   const mainWindow = new BrowserWindow({
     width: 1280,
     height: 800,


### PR DESCRIPTION
## Summary

On Windows, the Electron app displays a native menu bar (File, Edit, View, Window, Help) because `titleBarStyle: 'hiddenInset'` is macOS-only. This PR removes it by calling `Menu.setApplicationMenu(null)` on non-macOS platforms.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The Windows build shows an unwanted native menu bar that clutters the header and is inconsistent with the custom title bar design used on macOS. Users see File/Edit/View/Window/Help options that serve no purpose in this app.

## What changed?

- Import `Menu` from `electron` in the main process entry
- Call `Menu.setApplicationMenu(null)` for non-darwin platforms before creating the main window

## Linked issues

N/A

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
node_modules not available in worktree; typecheck not run locally.
Change is minimal (import + 3-line platform guard) — needs Windows smoke test.
```

## Screenshots or recordings

N/A — requires Windows build to verify.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Remove native menu bar (File, Edit, View, Window, Help) from Windows builds.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [ ] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate