### PR TITLE
fix(mac): enable notarization for Gatekeeper trust

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -27,7 +27,7 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
-  notarize: false
+  notarize: true
   extendInfo:
     NSMicrophoneUsageDescription: ClawWork needs microphone access for voice dictation in chat input.
 dmg:


### PR DESCRIPTION
## Summary

Follow-up to #82. Enable Apple notarization so macOS Gatekeeper trusts the app.

Closes #13

## Changes

- **electron-builder.yml**: `notarize: false` → `notarize: true`

## Root Cause

Code signing alone is not enough — without notarization, Gatekeeper still flags the app as untrusted.