### PR TITLE
[Fix] Fix logo and screenshot 404 on GitHub Pages subpath

### DIFF
--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -72,7 +72,7 @@ export function Footer() {
             gap: '12px',
           }}
         >
-          <img src="/logo.png" alt="ClawWork" style={{ width: '20px', height: '20px' }} />
+          <img src={`${import.meta.env.BASE_URL}logo.png`} alt="ClawWork" style={{ width: '20px', height: '20px' }} />
           <span
             style={{
               fontSize: '13px',

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -32,7 +32,7 @@ export function Header() {
         }}
       >
         <a href="#" style={{ display: 'flex', alignItems: 'center', gap: '10px', textDecoration: 'none' }}>
-          <img src="/logo.png" alt="ClawWork" style={{ width: '28px', height: '28px' }} />
+          <img src={`${import.meta.env.BASE_URL}logo.png`} alt="ClawWork" style={{ width: '28px', height: '28px' }} />
           <span
             style={{
               fontFamily: 'var(--font-mono, "JetBrains Mono Variable", monospace)',

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -130,7 +130,7 @@ export function Hero() {
 
       <div style={{ marginTop: '48px' }}>
         <img
-          src="/screenshot.png"
+          src={`${import.meta.env.BASE_URL}screenshot.png`}
           alt="ClawWork screenshot"
           style={{
             maxWidth: '100%',


### PR DESCRIPTION
## Summary

Image assets (`/logo.png`, `/screenshot.png`) were hardcoded with absolute root paths, causing 404s when the site is served under the `/ClawWork/` subpath. Replace with `import.meta.env.BASE_URL` so Vite injects the correct base at build time.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Live site at https://clawwork-ai.github.io/ClawWork/ showed logo and screenshot as broken images. JS/CSS loaded correctly (CI sets `VITE_BASE=/ClawWork/`), but image `src="/logo.png"` resolved to `https://clawwork-ai.github.io/logo.png` instead of `.../ClawWork/logo.png`.

## What changed?

- `Header.tsx`: `src="/logo.png"` → `src={\`${import.meta.env.BASE_URL}logo.png\`}`
- `Footer.tsx`: same fix for bottom logo
- `Hero.tsx`: `src="/screenshot.png"` → `src={\`${import.meta.env.BASE_URL}screenshot.png\`}`

## Architecture impact

- Owning layer: renderer (website only)
- Cross-layer impact: none
- Invariants touched: none

## Linked issues

N/A

## Validation

- [x] `pnpm build` with `VITE_BASE=/ClawWork/` — confirmed `dist/index.html` uses `/ClawWork/logo.png`
- [ ] `pnpm test`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
$ VITE_BASE=/ClawWork/ pnpm --filter @clawwork/website build
# dist/index.html: <link rel="icon" href="/ClawWork/logo.png" />
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate