### PR TITLE
[Feat] Responsive panel layout: drag-to-resize, collapsible left nav, panel shortcuts

### DIFF
--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -38,6 +38,8 @@ export interface AppConfig {
   voiceInput?: VoiceInputConfig;
   quickLaunch?: QuickLaunchConfig;
   trayEnabled?: boolean;
+  leftNavShortcut?: 'Comma' | 'BracketLeft';
+  rightPanelShortcut?: 'Period' | 'BracketRight';
 }
 
 function configFilePath(): string {

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -85,6 +85,8 @@ interface AppSettings {
   };
   quickLaunch?: QuickLaunchSettings;
   trayEnabled?: boolean;
+  leftNavShortcut?: 'Comma' | 'BracketLeft';
+  rightPanelShortcut?: 'Period' | 'BracketRight';
 }
 
 export type VoicePermissionStatus = 'granted' | 'not-determined' | 'denied' | 'unsupported';

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -36,10 +36,38 @@ export default function App() {
   const addMessage = useMessageStore((s) => s.addMessage);
   const setProcessing = useMessageStore((s) => s.setProcessing);
 
+  const leftNavCollapsed = useUiStore((s) => s.leftNavCollapsed);
+  const toggleLeftNavCollapsed = useUiStore((s) => s.toggleLeftNavCollapsed);
+  const leftNavWidth = useUiStore((s) => s.leftNavWidth);
+  const setLeftNavWidth = useUiStore((s) => s.setLeftNavWidth);
+  const rightPanelWidth = useUiStore((s) => s.rightPanelWidth);
+  const setRightPanelWidth = useUiStore((s) => s.setRightPanelWidth);
+  const leftNavShortcut = useUiStore((s) => s.leftNavShortcut);
+  const rightPanelShortcut = useUiStore((s) => s.rightPanelShortcut);
+
   useGatewayEventDispatcher();
   useTheme();
   useUpdateCheck();
   useTraySync();
+
+  const startPanelDrag = useCallback(
+    (e: React.MouseEvent, startWidth: number, setWidth: (w: number) => void, dir: 1 | -1) => {
+      e.preventDefault();
+      const ox = e.clientX;
+      document.body.style.userSelect = 'none';
+      document.body.style.cursor = 'col-resize';
+      const onMove = (ev: MouseEvent) => setWidth(startWidth + dir * (ev.clientX - ox));
+      const onUp = () => {
+        document.body.style.userSelect = '';
+        document.body.style.cursor = '';
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    [],
+  );
 
   useEffect(() => {
     window.clawwork.isWorkspaceConfigured().then((configured) => {
@@ -56,6 +84,12 @@ export default function App() {
     window.clawwork.getSettings().then((settings) => {
       if (settings?.sendShortcut) {
         useUiStore.setState({ sendShortcut: settings.sendShortcut });
+      }
+      if (settings?.leftNavShortcut) {
+        useUiStore.setState({ leftNavShortcut: settings.leftNavShortcut });
+      }
+      if (settings?.rightPanelShortcut) {
+        useUiStore.setState({ rightPanelShortcut: settings.rightPanelShortcut });
       }
     });
   }, [ready]);
@@ -79,10 +113,34 @@ export default function App() {
 
       if (!e.shiftKey && e.code === 'KeyK') {
         e.preventDefault();
+        if (leftNavCollapsed) toggleLeftNavCollapsed();
         focusSearch();
+        return;
+      }
+
+      const leftCode = leftNavShortcut;
+      const rightCode = rightPanelShortcut;
+
+      if (!e.shiftKey && e.code === leftCode) {
+        e.preventDefault();
+        toggleLeftNavCollapsed();
+        return;
+      }
+
+      if (!e.shiftKey && e.code === rightCode) {
+        e.preventDefault();
+        toggleRightPanel();
       }
     },
-    [startNewTask, setMainView, focusSearch],
+    [
+      startNewTask,
+      setMainView,
+      focusSearch,
+      leftNavShortcut,
+      rightPanelShortcut,
+      toggleLeftNavCollapsed,
+      toggleRightPanel,
+    ],
   );
 
   useEffect(() => {
@@ -156,12 +214,21 @@ export default function App() {
       <div className="flex h-screen overflow-hidden bg-[var(--bg-primary)]">
         <div className="titlebar-drag fixed top-0 left-0 right-0 h-8 z-50" />
 
-        <aside
-          className={cn('flex-shrink-0 border-r border-[var(--border)] bg-[var(--bg-secondary)]')}
-          style={{ width: 260 }}
+        <motion.aside
+          animate={{ width: leftNavCollapsed ? 52 : leftNavWidth }}
+          transition={{ duration: 0.2, ease: [0.2, 0, 0, 1] }}
+          className={cn('flex-shrink-0 border-r border-[var(--border)] bg-[var(--bg-secondary)] overflow-hidden')}
+          style={{ minWidth: leftNavCollapsed ? 52 : 180 }}
         >
           <LeftNav />
-        </aside>
+        </motion.aside>
+
+        {!leftNavCollapsed && (
+          <div
+            className="w-1.5 flex-shrink-0 cursor-col-resize hover:bg-[var(--accent)]/20 transition-colors z-10"
+            onMouseDown={(e) => startPanelDrag(e, leftNavWidth, setLeftNavWidth, 1)}
+          />
+        )}
 
         <main className="flex-1 min-w-0 flex flex-col">
           {settingsOpen ? (
@@ -173,15 +240,21 @@ export default function App() {
 
         <AnimatePresence>
           {rightPanelOpen && !settingsOpen && (
-            <motion.aside
-              initial={{ width: 0, opacity: 0 }}
-              animate={{ width: 320, opacity: 1 }}
-              exit={{ width: 0, opacity: 0 }}
-              transition={{ duration: 0.2, ease: [0.2, 0, 0, 1] }}
-              className={cn('flex-shrink-0 border-l border-[var(--border)] bg-[var(--bg-secondary)] overflow-hidden')}
-            >
-              <RightPanel onClose={() => setRightPanelOpen(false)} />
-            </motion.aside>
+            <>
+              <div
+                className="w-1.5 flex-shrink-0 cursor-col-resize hover:bg-[var(--accent)]/20 transition-colors z-10"
+                onMouseDown={(e) => startPanelDrag(e, rightPanelWidth, setRightPanelWidth, -1)}
+              />
+              <motion.aside
+                initial={{ width: 0, opacity: 0 }}
+                animate={{ width: rightPanelWidth, opacity: 1 }}
+                exit={{ width: 0, opacity: 0 }}
+                transition={{ duration: 0.2, ease: [0.2, 0, 0, 1] }}
+                className={cn('flex-shrink-0 border-l border-[var(--border)] bg-[var(--bg-secondary)] overflow-hidden')}
+              >
+                <RightPanel onClose={() => setRightPanelOpen(false)} />
+              </motion.aside>
+            </>
           )}
         </AnimatePresence>
         <Toaster

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -18,7 +18,9 @@
     "emptyHint": "Click \"New Task\" to start",
     "appSettings": "App Settings",
     "archivedChats": "Archived Chats",
-    "updateAvailable": "Update available"
+    "updateAvailable": "Update available",
+    "collapseNav": "Collapse sidebar",
+    "expandNav": "Expand sidebar"
   },
   "mainArea": {
     "welcomeSubtitle": "AI-powered task execution",
@@ -40,6 +42,8 @@
     "sendEnter": "Enter",
     "sendCmdEnter": "{{mod}} Enter",
     "shortcutUpdated": "Shortcut updated",
+    "leftNavShortcut": "Toggle sidebar",
+    "rightPanelShortcut": "Toggle context panel",
     "gateways": "Gateways",
     "addGateway": "Add Gateway",
     "editGateway": "Edit Gateway",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -18,7 +18,9 @@
     "emptyHint": "点击「新任务」开始",
     "appSettings": "应用设置",
     "archivedChats": "归档对话",
-    "updateAvailable": "有新版本可用"
+    "updateAvailable": "有新版本可用",
+    "collapseNav": "收起侧栏",
+    "expandNav": "展开侧栏"
   },
   "mainArea": {
     "welcomeSubtitle": "AI 驱动的任务执行",
@@ -40,6 +42,8 @@
     "sendEnter": "回车",
     "sendCmdEnter": "{{mod}} 回车",
     "shortcutUpdated": "快捷键已更新",
+    "leftNavShortcut": "切换侧栏",
+    "rightPanelShortcut": "切换上下文面板",
     "gateways": "网关",
     "addGateway": "添加网关",
     "editGateway": "编辑网关",

--- a/packages/desktop/src/renderer/layouts/LeftNav/ConnectionStatus.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/ConnectionStatus.tsx
@@ -1,6 +1,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
 type Status = 'connected' | 'connecting' | 'disconnected';
 
@@ -14,6 +15,7 @@ interface StatusConfig {
 interface ConnectionStatusProps {
   gatewayStatus: Status;
   className?: string;
+  collapsed?: boolean;
 }
 
 function computeConfig(status: Status): StatusConfig {
@@ -27,9 +29,20 @@ function computeConfig(status: Status): StatusConfig {
   }
 }
 
-export default function ConnectionStatus({ gatewayStatus, className }: ConnectionStatusProps) {
+export default function ConnectionStatus({ gatewayStatus, className, collapsed }: ConnectionStatusProps) {
   const { t } = useTranslation();
   const cfg = computeConfig(gatewayStatus);
+
+  if (collapsed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={cn('w-2.5 h-2.5 rounded-full flex-shrink-0', cfg.color, cfg.pulse && 'animate-pulse')} />
+        </TooltipTrigger>
+        <TooltipContent side="right">{t(cfg.labelKey)}</TooltipContent>
+      </Tooltip>
+    );
+  }
 
   return (
     <AnimatePresence mode="wait">

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -17,9 +17,10 @@ interface TaskItemProps {
   task: Task;
   active: boolean;
   onContextMenu: (e: MouseEvent) => void;
+  collapsed?: boolean;
 }
 
-export default function TaskItem({ task, active, onContextMenu }: TaskItemProps) {
+export default function TaskItem({ task, active, onContextMenu, collapsed }: TaskItemProps) {
   const { t } = useTranslation();
   const reduced = useReducedMotion();
   const setActiveTask = useTaskStore((s) => s.setActiveTask);
@@ -42,6 +43,38 @@ export default function TaskItem({ task, active, onContextMenu }: TaskItemProps)
     clearUnread(task.id);
     setMainView('chat');
   };
+
+  if (collapsed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <motion.button
+            {...motionPresets.listItem}
+            onClick={handleClick}
+            onContextMenu={onContextMenu}
+            className="titlebar-no-drag w-full flex justify-center py-1.5 relative"
+          >
+            {active && <span className="absolute left-0 top-1 bottom-1 w-[3px] rounded-full bg-[var(--accent)]" />}
+            <span
+              className={cn(
+                'w-8 h-8 rounded-lg flex items-center justify-center text-xs font-medium',
+                active
+                  ? 'bg-[var(--accent-dim)] text-[var(--accent)]'
+                  : 'bg-[var(--bg-tertiary)] text-[var(--text-secondary)]',
+              )}
+            >
+              {task.title ? task.title[0].toUpperCase() : <MessageSquare size={14} />}
+            </span>
+            {isStreaming && <Loader2 className="absolute top-0.5 right-1 w-3 h-3 animate-spin text-[var(--accent)]" />}
+            {hasUnread && !isStreaming && (
+              <span className="absolute top-0.5 right-1 w-2 h-2 rounded-full bg-[var(--accent)]" />
+            )}
+          </motion.button>
+        </TooltipTrigger>
+        <TooltipContent side="right">{task.title || t('common.newTask')}</TooltipContent>
+      </Tooltip>
+    );
+  }
 
   return (
     <motion.button

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -1,6 +1,16 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Plus, Search, FolderOpen, Settings, Archive, Server, ChevronDown } from 'lucide-react';
+import {
+  Plus,
+  Search,
+  FolderOpen,
+  Settings,
+  Archive,
+  Server,
+  ChevronDown,
+  PanelLeftClose,
+  PanelLeftOpen,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
@@ -48,6 +58,9 @@ export default function LeftNav() {
   const gwStatusMap = useUiStore((s) => s.gatewayStatusMap);
   const gwInfoMap = useUiStore((s) => s.gatewayInfoMap);
   const hasUpdate = useUiStore((s) => s.hasUpdate);
+  const leftNavCollapsed = useUiStore((s) => s.leftNavCollapsed);
+  const toggleLeftNavCollapsed = useUiStore((s) => s.toggleLeftNavCollapsed);
+  const focusSearch = useUiStore((s) => s.focusSearch);
   const connectedGateways = Object.values(gwInfoMap).filter((gw) => gwStatusMap[gw.id] === 'connected');
   const hasMultipleGateways = connectedGateways.length > 1;
   const searchFocusTrigger = useUiStore((s) => s.searchFocusTrigger);
@@ -134,9 +147,10 @@ export default function LeftNav() {
 
   useEffect(() => {
     if (searchFocusTrigger === 0) return;
+    if (leftNavCollapsed) return;
     searchInputRef.current?.focus();
     searchInputRef.current?.select();
-  }, [searchFocusTrigger]);
+  }, [searchFocusTrigger, leftNavCollapsed]);
 
   useEffect(() => {
     clearTimeout(timerRef.current);
@@ -172,8 +186,199 @@ export default function LeftNav() {
   const activeTasks = visibleTasks.filter((t) => t.status === 'active');
   const completedTasks = visibleTasks.filter((t) => t.status === 'completed');
 
+  const CollapseToggleButton = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={toggleLeftNavCollapsed}
+          className="titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors"
+        >
+          {leftNavCollapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        {leftNavCollapsed ? t('leftNav.expandNav') : t('leftNav.collapseNav')}
+      </TooltipContent>
+    </Tooltip>
+  );
+
+  if (leftNavCollapsed) {
+    return (
+      <div className="flex flex-col h-full pt-14 items-center py-2 gap-1 overflow-hidden">
+        {CollapseToggleButton}
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => startNewTask()}
+              className="titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--accent-dim)] text-[var(--accent)] hover:opacity-80 transition-opacity"
+            >
+              <Plus size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t('common.newTask')}</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => {
+                toggleLeftNavCollapsed();
+                focusSearch();
+              }}
+              className="titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors"
+            >
+              <Search size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t('leftNav.searchTasks')}</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setMainView('files')}
+              className={cn(
+                'titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
+                mainView === 'files'
+                  ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
+              )}
+            >
+              <FolderOpen size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t('common.fileManager')}</TooltipContent>
+        </Tooltip>
+
+        <div className="w-6 h-px bg-[var(--border)] my-1" />
+
+        <ScrollArea className="flex-1 w-full">
+          <div className="flex flex-col items-center gap-0.5 px-1.5">
+            {activeTasks.map((task) => (
+              <TaskItem
+                key={task.id}
+                task={task}
+                active={task.id === activeTaskId}
+                onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
+                collapsed
+              />
+            ))}
+            {completedTasks.length > 0 && activeTasks.length > 0 && (
+              <div className="w-6 h-px bg-[var(--border)] my-0.5" />
+            )}
+            {completedTasks.map((task) => (
+              <TaskItem
+                key={task.id}
+                task={task}
+                active={task.id === activeTaskId}
+                onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
+                collapsed
+              />
+            ))}
+          </div>
+        </ScrollArea>
+
+        <div className="w-6 h-px bg-[var(--border)] my-1" />
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setMainView('archived')}
+              className={cn(
+                'titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
+                mainView === 'archived'
+                  ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
+              )}
+            >
+              <Archive size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t('leftNav.archivedChats')}</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setSettingsOpen(!settingsOpen)}
+              className={cn(
+                'titlebar-no-drag relative flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
+                settingsOpen
+                  ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
+              )}
+            >
+              <Settings size={16} />
+              {hasUpdate && <span className="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-[var(--accent)]" />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            {hasUpdate ? t('leftNav.updateAvailable') : t('leftNav.appSettings')}
+          </TooltipContent>
+        </Tooltip>
+
+        <ConnectionStatus gatewayStatus={aggregatedGwStatus} collapsed />
+
+        <DropdownMenu
+          open={isOpen}
+          onOpenChange={(open) => {
+            if (!open) closeMenu();
+          }}
+        >
+          <DropdownMenuTrigger className="sr-only" />
+          <DropdownMenuContent style={menuPos ? { position: 'fixed', left: menuPos.x, top: menuPos.y } : undefined}>
+            {items.map((item) => (
+              <DropdownMenuItem
+                key={item.label}
+                danger={item.danger}
+                disabled={item.disabled}
+                onClick={() => {
+                  item.action();
+                  closeMenu();
+                }}
+              >
+                {item.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <Dialog
+          open={confirmAction !== null}
+          onOpenChange={(open) => {
+            if (!open) setConfirmAction(null);
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>
+                {confirmAction === 'reset' ? t('dialog.resetSessionTitle') : t('dialog.deleteTaskTitle')}
+              </DialogTitle>
+              <DialogDescription>
+                {confirmAction === 'reset' ? t('dialog.resetSessionDesc') : t('dialog.deleteTaskDesc')}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="mt-4">
+              <Button variant="outline" onClick={() => setConfirmAction(null)}>
+                {t('common.cancel')}
+              </Button>
+              <Button
+                variant={confirmAction === 'delete' ? 'danger' : 'default'}
+                onClick={confirmAction === 'reset' ? handleResetConfirm : handleDeleteConfirm}
+              >
+                {t('dialog.confirm')}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col h-full pt-14 relative">
+      <div className="absolute top-[8px] right-2 z-10">{CollapseToggleButton}</div>
       <div className="px-4 pb-3 space-y-2 flex-shrink-0">
         {hasMultipleGateways ? (
           <div className="titlebar-no-drag flex items-center gap-0.5">
@@ -300,7 +505,7 @@ export default function LeftNav() {
         >
           <Archive size={16} className="opacity-60" /> {t('leftNav.archivedChats')}
         </button>
-        <div className="flex items-center">
+        <div className="flex items-center gap-1">
           <Tooltip>
             <TooltipTrigger asChild>
               <button

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   PanelRightOpen,
+  PanelRightClose,
   RotateCcw,
   Archive,
   Server,
@@ -200,6 +201,7 @@ function WelcomeScreen() {
 function ChatHeader({ onTogglePanel }: { onTogglePanel: () => void }) {
   const { t } = useTranslation();
   const activeTask = useTaskStore((s) => s.tasks.find((task) => task.id === s.activeTaskId));
+  const rightPanelOpen = useUiStore((s) => s.rightPanelOpen);
   const gatewayInfoMap = useUiStore((s) => s.gatewayInfoMap);
   const hasMultipleGateways = Object.keys(gatewayInfoMap).length > 1;
   const gwInfo = activeTask ? gatewayInfoMap[activeTask.gatewayId] : undefined;
@@ -479,7 +481,7 @@ function ChatHeader({ onTogglePanel }: { onTogglePanel: () => void }) {
       <Tooltip>
         <TooltipTrigger asChild>
           <Button variant="ghost" size="icon" onClick={onTogglePanel} className="titlebar-no-drag">
-            <PanelRightOpen size={18} />
+            {rightPanelOpen ? <PanelRightClose size={18} /> : <PanelRightOpen size={18} />}
           </Button>
         </TooltipTrigger>
         <TooltipContent>{t('mainArea.toggleContextPanel')}</TooltipContent>

--- a/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
@@ -3,7 +3,14 @@ import { Moon, Sun, Monitor } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { modKey } from '@/lib/utils';
-import { useUiStore, type Theme, type Language, type SendShortcut } from '@/stores/uiStore';
+import {
+  useUiStore,
+  type Theme,
+  type Language,
+  type SendShortcut,
+  type PanelShortcutLeft,
+  type PanelShortcutRight,
+} from '@/stores/uiStore';
 import SettingRow from '../components/SettingRow';
 import SegmentedControl from '../components/SegmentedControl';
 
@@ -20,6 +27,10 @@ export default function GeneralSection() {
   const setLanguage = useUiStore((s) => s.setLanguage);
   const sendShortcut = useUiStore((s) => s.sendShortcut);
   const setSendShortcut = useUiStore((s) => s.setSendShortcut);
+  const leftNavShortcut = useUiStore((s) => s.leftNavShortcut);
+  const setLeftNavShortcut = useUiStore((s) => s.setLeftNavShortcut);
+  const rightPanelShortcut = useUiStore((s) => s.rightPanelShortcut);
+  const setRightPanelShortcut = useUiStore((s) => s.setRightPanelShortcut);
 
   const handleThemeToggle = useCallback(
     (next: Theme) => {
@@ -36,6 +47,24 @@ export default function GeneralSection() {
       toast.success(t('settings.shortcutUpdated'));
     },
     [sendShortcut, setSendShortcut, t],
+  );
+
+  const handleLeftNavShortcutChange = useCallback(
+    (next: PanelShortcutLeft) => {
+      if (next === leftNavShortcut) return;
+      setLeftNavShortcut(next);
+      toast.success(t('settings.shortcutUpdated'));
+    },
+    [leftNavShortcut, setLeftNavShortcut, t],
+  );
+
+  const handleRightPanelShortcutChange = useCallback(
+    (next: PanelShortcutRight) => {
+      if (next === rightPanelShortcut) return;
+      setRightPanelShortcut(next);
+      toast.success(t('settings.shortcutUpdated'));
+    },
+    [rightPanelShortcut, setRightPanelShortcut, t],
   );
 
   return (
@@ -100,6 +129,34 @@ export default function GeneralSection() {
               options={[
                 { value: 'enter' as const, label: t('settings.sendEnter') },
                 { value: 'cmdEnter' as const, label: t('settings.sendCmdEnter', { mod: modKey }) },
+              ]}
+            />
+          </SettingRow>
+        </div>
+        <div className="px-5 py-4">
+          <SettingRow label={t('settings.leftNavShortcut')}>
+            <SegmentedControl
+              layoutId="seg-left-nav"
+              value={leftNavShortcut}
+              onChange={handleLeftNavShortcutChange}
+              ariaLabel={t('settings.leftNavShortcut')}
+              options={[
+                { value: 'Comma' as const, label: `${modKey} ,` },
+                { value: 'BracketLeft' as const, label: `${modKey} [` },
+              ]}
+            />
+          </SettingRow>
+        </div>
+        <div className="px-5 py-4">
+          <SettingRow label={t('settings.rightPanelShortcut')}>
+            <SegmentedControl
+              layoutId="seg-right-panel"
+              value={rightPanelShortcut}
+              onChange={handleRightPanelShortcutChange}
+              ariaLabel={t('settings.rightPanelShortcut')}
+              options={[
+                { value: 'Period' as const, label: `${modKey} .` },
+                { value: 'BracketRight' as const, label: `${modKey} ]` },
               ]}
             />
           </SettingRow>

--- a/packages/desktop/src/renderer/stores/uiStore.ts
+++ b/packages/desktop/src/renderer/stores/uiStore.ts
@@ -10,12 +10,38 @@ export type Language = 'en' | 'zh';
 
 export type SendShortcut = 'enter' | 'cmdEnter';
 
+export type PanelShortcutLeft = 'Comma' | 'BracketLeft';
+export type PanelShortcutRight = 'Period' | 'BracketRight';
+
 export type GatewayConnectionStatus = 'connected' | 'connecting' | 'disconnected';
 
 export interface GatewayInfo {
   id: string;
   name: string;
   color?: string;
+}
+
+function ls(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function lsSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {}
+}
+
+function lsWidth(key: string, min: number, max: number, vwFraction: number): number {
+  const stored = ls(key);
+  if (stored) {
+    const n = Number(stored);
+    if (!isNaN(n) && n >= min && n <= max) return n;
+  }
+  return typeof window === 'undefined' ? min : Math.min(max, Math.max(min, window.innerWidth * vwFraction));
 }
 
 interface UiState {
@@ -35,36 +61,28 @@ interface UiState {
   language: Language;
   setLanguage: (lang: Language) => void;
 
-  /** Per-gateway connection status map */
   gatewayStatusMap: Record<string, GatewayConnectionStatus>;
   setGatewayStatusByGateway: (gatewayId: string, status: GatewayConnectionStatus) => void;
 
-  /** Default gateway for new tasks */
   defaultGatewayId: string | null;
   setDefaultGatewayId: (id: string | null) => void;
 
-  /** Cached gateway metadata for display (name, color) */
   gatewayInfoMap: Record<string, GatewayInfo>;
   setGatewayInfoMap: (map: Record<string, GatewayInfo>) => void;
 
-  /** taskIds with unread messages (background tasks that received new content) */
   unreadTaskIds: Set<string>;
   markUnread: (taskId: string) => void;
   clearUnread: (taskId: string) => void;
 
-  /** Whether a newer version is available (set by startup update check) */
   hasUpdate: boolean;
   setHasUpdate: (has: boolean) => void;
 
-  /** Per-gateway model catalogs */
   modelCatalogByGateway: Record<string, ModelCatalogEntry[]>;
   setModelCatalogForGateway: (gatewayId: string, models: ModelCatalogEntry[]) => void;
 
-  /** Per-gateway agent catalogs */
   agentCatalogByGateway: Record<string, { agents: AgentInfo[]; defaultId: string }>;
   setAgentCatalogForGateway: (gatewayId: string, agents: AgentInfo[], defaultId: string) => void;
 
-  /** Per-gateway tools catalogs */
   toolsCatalogByGateway: Record<string, ToolsCatalog>;
   setToolsCatalogForGateway: (gatewayId: string, catalog: ToolsCatalog) => void;
 
@@ -75,6 +93,21 @@ interface UiState {
   focusSearch: () => void;
 
   getAgentsForGateway: (gatewayId: string) => { agents: AgentInfo[]; defaultId: string };
+
+  leftNavCollapsed: boolean;
+  toggleLeftNavCollapsed: () => void;
+
+  leftNavWidth: number;
+  setLeftNavWidth: (w: number) => void;
+
+  rightPanelWidth: number;
+  setRightPanelWidth: (w: number) => void;
+
+  leftNavShortcut: PanelShortcutLeft;
+  setLeftNavShortcut: (s: PanelShortcutLeft) => void;
+
+  rightPanelShortcut: PanelShortcutRight;
+  setRightPanelShortcut: (s: PanelShortcutRight) => void;
 }
 
 const EMPTY_AGENT_CATALOG = { agents: [] as AgentInfo[], defaultId: 'main' };
@@ -168,5 +201,39 @@ export const useUiStore = create<UiState>((set, get) => ({
   getAgentsForGateway: (gatewayId: string) => {
     const entry = get().agentCatalogByGateway[gatewayId];
     return entry ?? EMPTY_AGENT_CATALOG;
+  },
+
+  leftNavCollapsed: ls('cw:leftNavCollapsed') === 'true',
+  toggleLeftNavCollapsed: () =>
+    set((s) => {
+      const next = !s.leftNavCollapsed;
+      lsSet('cw:leftNavCollapsed', String(next));
+      return { leftNavCollapsed: next };
+    }),
+
+  leftNavWidth: lsWidth('cw:leftNavWidth', 180, 400, 0.18),
+  setLeftNavWidth: (w) => {
+    const clamped = Math.min(400, Math.max(180, w));
+    lsSet('cw:leftNavWidth', String(clamped));
+    set({ leftNavWidth: clamped });
+  },
+
+  rightPanelWidth: lsWidth('cw:rightPanelWidth', 240, 500, 0.2),
+  setRightPanelWidth: (w) => {
+    const clamped = Math.min(500, Math.max(240, w));
+    lsSet('cw:rightPanelWidth', String(clamped));
+    set({ rightPanelWidth: clamped });
+  },
+
+  leftNavShortcut: 'Comma',
+  setLeftNavShortcut: (s) => {
+    set({ leftNavShortcut: s });
+    window.clawwork.updateSettings({ leftNavShortcut: s });
+  },
+
+  rightPanelShortcut: 'Period',
+  setRightPanelShortcut: (s) => {
+    set({ rightPanelShortcut: s });
+    window.clawwork.updateSettings({ rightPanelShortcut: s });
   },
 }));


### PR DESCRIPTION
## Summary

Adds responsive default panel widths, drag-to-resize handles for both panels, a collapsible left nav (52px icon rail), and configurable keyboard shortcuts for toggling each panel. Addresses the cramped three-column layout on wide screens.

## Type of change

- [x] `[Feat]` new feature
- [x] `[UI]` UI or UX change

## Why is this needed?

On 2560px displays the fixed 260px left / 320px right columns are disproportionately narrow and leave ~600px dead space on each side. Users have no way to reclaim that space or hide panels they don't need.

## What changed?

- **Responsive defaults**: left nav `clamp(220, 18vw, 300)`, right panel `clamp(280, 20vw, 380)` computed from `window.innerWidth` at store init
- **Drag-to-resize**: 6px handle on both panel borders; clamps left 180–400px, right 240–500px; widths persisted to `localStorage`
- **Collapsible left nav**: collapses to 52px icon rail; toggle button at top-right of nav mirrors `PanelRightClose/Open` on right side; collapse state in `localStorage`
- **Panel keyboard shortcuts**: `⌘,` toggles left nav, `⌘.` toggles right panel (configurable in Settings → General)
- **Search auto-expand**: clicking the search icon or pressing `⌘K` while nav is collapsed auto-expands before focusing the input
- **Right panel icon state**: `PanelRightOpen` ↔ `PanelRightClose` now tracks actual open state
- **Settings UI**: two new `SegmentedControl` rows for left/right shortcut keys; shortcuts persisted to config file
- **uiStore**: new state (`leftNavCollapsed`, `leftNavWidth`, `rightPanelWidth`, `leftNavShortcut`, `rightPanelShortcut`) with localStorage helpers `ls`/`lsSet`/`lsWidth`
- **Config types**: `AppConfig` and `AppSettings` extended with `leftNavShortcut`/`rightPanelShortcut`
- **Simplification**: drag handlers deduplicated into single `startPanelDrag(e, startWidth, setter, dir)` factory; width init IIFEs replaced with `lsWidth` helper

## Architecture impact

- Owning layer: renderer (stores, layouts), main/preload (config types)
- Cross-layer impact: yes — `AppConfig` (main) and `AppSettings` (preload) extended with two optional fields; renderer reads them via `getSettings()`
- Invariants touched: panel width state is now renderer-owned (localStorage) rather than config-file-owned, consistent with other ephemeral UI state
- Why those invariants remain protected: shortcut *keys* go to config file (cross-session preference); panel *sizes* go to localStorage (per-device layout preference); no IPC contract changed

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm --filter @clawwork/shared exec tsc -b && pnpm --filter @clawwork/desktop exec tsc --noEmit
# exit 0
```

## Screenshots or recordings

UI changes: left nav collapses to 52px icon rail with tooltips; drag handles appear on panel borders; collapse/expand icons mirror left↔right symmetry.

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Panels are now drag-resizable and remember their width. The left nav collapses to a compact icon rail (⌘,). Panel toggle shortcuts are configurable in Settings → General.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate