### PR TITLE
[Feat] Add artifact storage, auto-extraction, FTS content search, and file preview

### DIFF
--- a/packages/desktop/src/main/artifact/auto-extract.ts
+++ b/packages/desktop/src/main/artifact/auto-extract.ts
@@ -1,0 +1,90 @@
+import { net, BrowserWindow } from 'electron';
+import { readFileSync } from 'fs';
+import { extractImagesFromMarkdown, extractCodeBlocksFromMarkdown } from './extract.js';
+import { saveArtifactFromBuffer } from './save.js';
+import { commitArtifactBatch } from './git.js';
+import { getDb } from '../db/index.js';
+import { artifacts } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+import type { Artifact } from '@clawwork/shared';
+
+interface AutoExtractParams {
+  workspacePath: string;
+  taskId: string;
+  messageId: string;
+  content: string;
+}
+
+async function fetchToBuffer(url: string): Promise<Buffer> {
+  const res = await net.fetch(url);
+  if (!res.ok) throw new Error(`fetch ${url} failed: ${res.status}`);
+  const ab = await res.arrayBuffer();
+  return Buffer.from(ab);
+}
+
+export async function autoExtractArtifacts(params: AutoExtractParams): Promise<void> {
+  const { workspacePath, taskId, messageId, content } = params;
+
+  const db = getDb();
+  const existingForMsg = db.select().from(artifacts).where(eq(artifacts.messageId, messageId)).all();
+  if (existingForMsg.length > 0) return;
+
+  const images = extractImagesFromMarkdown(content);
+  const codeBlocks = extractCodeBlocksFromMarkdown(content);
+
+  const saved: Artifact[] = [];
+
+  for (const img of images) {
+    try {
+      let buffer: Buffer;
+      if (img.isRemote) {
+        buffer = await fetchToBuffer(img.src);
+      } else if (img.src.startsWith('clawwork-media://')) {
+        buffer = readFileSync(img.src.replace('clawwork-media://', ''));
+      } else {
+        continue;
+      }
+      const ext = img.src.split('.').pop()?.split('?')[0]?.toLowerCase() ?? 'png';
+      const fileName = img.alt ? `${img.alt.replace(/[^a-zA-Z0-9_-]/g, '_')}.${ext}` : `image.${ext}`;
+      saved.push(
+        await saveArtifactFromBuffer({ workspacePath, taskId, messageId, fileName, buffer, artifactType: 'image' }),
+      );
+    } catch {}
+  }
+
+  for (const block of codeBlocks) {
+    try {
+      saved.push(
+        await saveArtifactFromBuffer({
+          workspacePath,
+          taskId,
+          messageId,
+          fileName: block.fileName,
+          buffer: Buffer.from(block.content, 'utf-8'),
+          artifactType: 'code',
+          contentText: block.content,
+        }),
+      );
+    } catch {}
+  }
+
+  if (saved.length === 0) return;
+
+  const sha = await commitArtifactBatch(
+    workspacePath,
+    saved.map((a) => a.localPath),
+  );
+  if (sha) {
+    for (const artifact of saved) {
+      db.update(artifacts).set({ gitSha: sha }).where(eq(artifacts.id, artifact.id)).run();
+      artifact.gitSha = sha;
+    }
+  }
+
+  const win = BrowserWindow.getAllWindows()[0];
+  if (win) {
+    for (const artifact of saved) {
+      win.webContents.send('artifact:saved', artifact);
+    }
+  }
+}

--- a/packages/desktop/src/main/artifact/extract.ts
+++ b/packages/desktop/src/main/artifact/extract.ts
@@ -1,0 +1,60 @@
+import { createHash } from 'crypto';
+
+const LANG_EXT: Record<string, string> = {
+  typescript: 'ts',
+  javascript: 'js',
+  python: 'py',
+  rust: 'rs',
+  go: 'go',
+  java: 'java',
+  css: 'css',
+  html: 'html',
+  json: 'json',
+  yaml: 'yml',
+  yml: 'yml',
+  toml: 'toml',
+  sql: 'sql',
+  sh: 'sh',
+  bash: 'sh',
+  shell: 'sh',
+  ruby: 'rb',
+  tsx: 'tsx',
+  jsx: 'jsx',
+  markdown: 'md',
+  md: 'md',
+};
+
+export interface ExtractedImage {
+  src: string;
+  alt: string;
+  isRemote: boolean;
+}
+
+export interface ExtractedCodeBlock {
+  language: string;
+  content: string;
+  fileName: string;
+  lineCount: number;
+}
+
+export function extractImagesFromMarkdown(content: string): ExtractedImage[] {
+  return [...content.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g)].map(([, alt, src]) => ({
+    src,
+    alt,
+    isRemote: /^https?:\/\//.test(src),
+  }));
+}
+
+export function extractCodeBlocksFromMarkdown(content: string): ExtractedCodeBlock[] {
+  return [...content.matchAll(/^```(\S*)\n([\s\S]*?)\n```/gm)]
+    .map(([, lang, body]) => {
+      const lineCount = body.split('\n').length;
+      const hasDot = lang.includes('.');
+      if (lineCount <= 10 && !hasDot) return null;
+      const fileName = hasDot
+        ? lang
+        : `snippet-${createHash('sha1').update(body).digest('hex').slice(0, 6)}.${LANG_EXT[lang.toLowerCase()] ?? 'txt'}`;
+      return { language: lang, content: body, fileName, lineCount };
+    })
+    .filter((b): b is ExtractedCodeBlock => b !== null);
+}

--- a/packages/desktop/src/main/artifact/git.ts
+++ b/packages/desktop/src/main/artifact/git.ts
@@ -17,3 +17,14 @@ export async function commitArtifact(workspacePath: string, localPath: string, m
 
   return result.commit || '';
 }
+
+export async function commitArtifactBatch(workspacePath: string, localPaths: string[]): Promise<string> {
+  const git = simpleGit(workspacePath);
+  for (const p of localPaths) {
+    await git.add(p);
+  }
+  const status = await git.status();
+  if (status.staged.length === 0) return '';
+  const result = await git.commit(`auto: extract ${localPaths.length} files from message`);
+  return result.commit || '';
+}

--- a/packages/desktop/src/main/artifact/save.ts
+++ b/packages/desktop/src/main/artifact/save.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, statSync } from 'fs';
+import { copyFileSync, existsSync, statSync, writeFileSync } from 'fs';
 import { basename, extname, join } from 'path';
 import { randomUUID } from 'crypto';
 import type { Artifact } from '@clawwork/shared';
@@ -97,6 +97,66 @@ export async function saveArtifact(params: SaveArtifactParams): Promise<Artifact
       size: artifact.size,
       gitSha: artifact.gitSha,
       createdAt: artifact.createdAt,
+    })
+    .run();
+
+  return artifact;
+}
+
+interface SaveArtifactFromBufferParams {
+  workspacePath: string;
+  taskId: string;
+  messageId: string;
+  fileName: string;
+  buffer: Buffer;
+  artifactType: 'code' | 'image' | 'file';
+  contentText?: string;
+}
+
+export async function saveArtifactFromBuffer(params: SaveArtifactFromBufferParams): Promise<Artifact> {
+  const { workspacePath, taskId, messageId, fileName, buffer, artifactType, contentText } = params;
+
+  const taskDir = ensureTaskDir(workspacePath, taskId);
+  const finalName = uniqueFileName(taskDir, fileName);
+  const destPath = join(taskDir, finalName);
+
+  writeFileSync(destPath, buffer);
+
+  const localPath = `${taskId}/${finalName}`;
+  const mimeType = detectMimeType(finalName);
+  const now = new Date().toISOString();
+  const id = randomUUID();
+
+  const artifact: Artifact = {
+    id,
+    taskId,
+    messageId,
+    type: artifactType,
+    name: finalName,
+    filePath: '',
+    localPath,
+    mimeType,
+    size: buffer.length,
+    gitSha: '',
+    contentText: contentText ?? '',
+    createdAt: now,
+  };
+
+  const db = getDb();
+  db.insert(artifacts)
+    .values({
+      id: artifact.id,
+      taskId: artifact.taskId,
+      messageId: artifact.messageId,
+      type: artifact.type,
+      name: artifact.name,
+      filePath: artifact.filePath,
+      localPath: artifact.localPath,
+      mimeType: artifact.mimeType,
+      size: artifact.size,
+      gitSha: artifact.gitSha,
+      createdAt: artifact.createdAt,
+      contentText: contentText ?? '',
     })
     .run();
 

--- a/packages/desktop/src/main/db/fts.ts
+++ b/packages/desktop/src/main/db/fts.ts
@@ -3,7 +3,6 @@ import type Database from 'better-sqlite3';
 const FTS_DDL = `
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(content, tokenize='unicode61');
 CREATE VIRTUAL TABLE IF NOT EXISTS tasks_fts USING fts5(title, tokenize='unicode61');
-CREATE VIRTUAL TABLE IF NOT EXISTS artifacts_fts USING fts5(name, tokenize='unicode61');
 
 -- messages triggers
 CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
@@ -28,14 +27,17 @@ END;
 CREATE TRIGGER IF NOT EXISTS tasks_ad AFTER DELETE ON tasks BEGIN
   DELETE FROM tasks_fts WHERE rowid = old.rowid;
 END;
+`;
 
--- artifacts triggers
+const ARTIFACTS_FTS_DDL = `
+CREATE VIRTUAL TABLE IF NOT EXISTS artifacts_fts USING fts5(name, content_text, tokenize='unicode61');
+
 CREATE TRIGGER IF NOT EXISTS artifacts_ai AFTER INSERT ON artifacts BEGIN
-  INSERT INTO artifacts_fts(rowid, name) VALUES (new.rowid, new.name);
+  INSERT INTO artifacts_fts(rowid, name, content_text) VALUES (new.rowid, new.name, new.content_text);
 END;
 CREATE TRIGGER IF NOT EXISTS artifacts_au AFTER UPDATE ON artifacts BEGIN
   DELETE FROM artifacts_fts WHERE rowid = old.rowid;
-  INSERT INTO artifacts_fts(rowid, name) VALUES (new.rowid, new.name);
+  INSERT INTO artifacts_fts(rowid, name, content_text) VALUES (new.rowid, new.name, new.content_text);
 END;
 CREATE TRIGGER IF NOT EXISTS artifacts_ad AFTER DELETE ON artifacts BEGIN
   DELETE FROM artifacts_fts WHERE rowid = old.rowid;
@@ -45,11 +47,25 @@ END;
 const BACKFILL_SQL = `
 INSERT OR IGNORE INTO messages_fts(rowid, content) SELECT rowid, content FROM messages;
 INSERT OR IGNORE INTO tasks_fts(rowid, title) SELECT rowid, title FROM tasks;
-INSERT OR IGNORE INTO artifacts_fts(rowid, name) SELECT rowid, name FROM artifacts;
+INSERT OR IGNORE INTO artifacts_fts(rowid, name, content_text) SELECT rowid, name, content_text FROM artifacts;
 `;
 
 export function initFTS(db: Database.Database): void {
   db.exec(FTS_DDL);
+
+  try {
+    const cols = db.prepare('SELECT * FROM artifacts_fts LIMIT 0').columns();
+    if (!cols.some((c) => c.name === 'content_text')) throw new Error('schema mismatch');
+  } catch {
+    db.exec(`
+      DROP TABLE IF EXISTS artifacts_fts;
+      DROP TRIGGER IF EXISTS artifacts_ai;
+      DROP TRIGGER IF EXISTS artifacts_au;
+      DROP TRIGGER IF EXISTS artifacts_ad;
+    `);
+    db.exec(ARTIFACTS_FTS_DDL);
+  }
+
   db.exec(BACKFILL_SQL);
   console.log('[fts] FTS5 virtual tables initialized');
 }

--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -86,6 +86,10 @@ export function initDatabase(workspacePath: string): void {
     sqlite.exec('ALTER TABLE messages ADD COLUMN image_attachments TEXT');
   } catch {}
 
+  try {
+    sqlite.exec("ALTER TABLE artifacts ADD COLUMN content_text TEXT NOT NULL DEFAULT ''");
+  } catch {}
+
   initFTS(sqlite);
 
   db = drizzle(sqlite, { schema });

--- a/packages/desktop/src/main/db/schema.ts
+++ b/packages/desktop/src/main/db/schema.ts
@@ -45,5 +45,6 @@ export const artifacts = sqliteTable('artifacts', {
   mimeType: text('mime_type').notNull().default(''),
   size: integer('size').notNull().default(0),
   gitSha: text('git_sha').notNull().default(''),
+  contentText: text('content_text').notNull().default(''),
   createdAt: text('created_at').notNull(),
 });

--- a/packages/desktop/src/main/db/search.ts
+++ b/packages/desktop/src/main/db/search.ts
@@ -56,3 +56,66 @@ export function globalSearch(db: Database.Database, query: string): SearchResult
     taskId: r.task_id ?? undefined,
   }));
 }
+
+const ARTIFACT_SEARCH_SQL = `
+SELECT a.id, a.task_id, a.name, a.type, a.local_path, a.mime_type, a.size, a.created_at, a.git_sha, a.file_path, a.message_id,
+  snippet(artifacts_fts, 0, '<mark>', '</mark>', '…', 20) AS name_snippet,
+  snippet(artifacts_fts, 1, '<mark>', '</mark>', '…', 32) AS content_snippet
+FROM artifacts_fts
+JOIN artifacts a ON a.rowid = artifacts_fts.rowid
+WHERE artifacts_fts MATCH ?
+ORDER BY artifacts_fts.rank
+LIMIT 50;
+`;
+
+export interface ArtifactSearchResult {
+  id: string;
+  taskId: string;
+  name: string;
+  type: string;
+  localPath: string;
+  mimeType: string;
+  size: number;
+  createdAt: string;
+  gitSha: string;
+  filePath: string;
+  messageId: string;
+  contentSnippet?: string;
+}
+
+export function searchArtifacts(db: Database.Database, query: string): ArtifactSearchResult[] {
+  const q = query.trim();
+  if (!q) return [];
+  const ftsQuery = q.replace(/[^\w\u4e00-\u9fff]/g, ' ').trim() + '*';
+  if (ftsQuery === '*') return [];
+  const stmt = db.prepare(ARTIFACT_SEARCH_SQL);
+  const rows = stmt.all(ftsQuery) as Array<{
+    id: string;
+    task_id: string;
+    name: string;
+    type: string;
+    local_path: string;
+    mime_type: string;
+    size: number;
+    created_at: string;
+    git_sha: string;
+    file_path: string;
+    message_id: string;
+    name_snippet: string;
+    content_snippet: string;
+  }>;
+  return rows.map((r) => ({
+    id: r.id,
+    taskId: r.task_id,
+    name: r.name,
+    type: r.type,
+    localPath: r.local_path,
+    mimeType: r.mime_type,
+    size: r.size,
+    createdAt: r.created_at,
+    gitSha: r.git_sha,
+    filePath: r.file_path,
+    messageId: r.message_id,
+    contentSnippet: r.content_snippet || r.name_snippet || undefined,
+  }));
+}

--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,12 +1,13 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain, BrowserWindow, net } from 'electron';
 import { readFileSync } from 'fs';
 import { resolve, sep } from 'path';
 import { eq } from 'drizzle-orm';
-import { getDb } from '../db/index.js';
+import { getDb, getSqlite } from '../db/index.js';
 import { artifacts } from '../db/schema.js';
-import { saveArtifact } from '../artifact/save.js';
+import { saveArtifact, saveArtifactFromBuffer } from '../artifact/save.js';
 import { commitArtifact } from '../artifact/git.js';
 import { getWorkspacePath } from '../workspace/config.js';
+import { searchArtifacts } from '../db/search.js';
 
 interface SaveParams {
   taskId: string;
@@ -93,6 +94,119 @@ export function registerArtifactHandlers(): void {
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'unknown error';
       return { ok: false, error: msg };
+    }
+  });
+
+  ipcMain.handle(
+    'artifact:save-content',
+    async (
+      _event,
+      params: { taskId: string; messageId: string; content: string; language?: string; fileName?: string },
+    ) => {
+      const workspacePath = getWorkspacePath();
+      if (!workspacePath) return { ok: false, error: 'workspace not configured' };
+      try {
+        const LANG_EXT: Record<string, string> = {
+          typescript: 'ts',
+          javascript: 'js',
+          python: 'py',
+          rust: 'rs',
+          go: 'go',
+          java: 'java',
+          md: 'md',
+          markdown: 'md',
+          tsx: 'tsx',
+          jsx: 'jsx',
+          json: 'json',
+          css: 'css',
+          html: 'html',
+          sh: 'sh',
+          bash: 'sh',
+          sql: 'sql',
+          yaml: 'yml',
+          yml: 'yml',
+        };
+        const fileName =
+          params.fileName ??
+          (() => {
+            const ext = (params.language && LANG_EXT[params.language.toLowerCase()]) ?? params.language ?? 'txt';
+            return `snippet.${ext}`;
+          })();
+        const buffer = Buffer.from(params.content, 'utf-8');
+        const artifact = await saveArtifactFromBuffer({
+          workspacePath,
+          taskId: params.taskId,
+          messageId: params.messageId,
+          fileName,
+          buffer,
+          artifactType: 'code',
+          contentText: params.content,
+        });
+        const sha = await commitArtifact(workspacePath, artifact.localPath, `save: ${artifact.name}`);
+        if (sha) {
+          const db = getDb();
+          db.update(artifacts).set({ gitSha: sha }).where(eq(artifacts.id, artifact.id)).run();
+          artifact.gitSha = sha;
+        }
+        const win = BrowserWindow.getAllWindows()[0];
+        if (win) win.webContents.send('artifact:saved', artifact);
+        return { ok: true, result: artifact };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'artifact:save-image-url',
+    async (_event, params: { taskId: string; messageId: string; url: string; alt?: string }) => {
+      const workspacePath = getWorkspacePath();
+      if (!workspacePath) return { ok: false, error: 'workspace not configured' };
+      try {
+        let buffer: Buffer;
+        const url = params.url;
+        if (/^https?:\/\//.test(url)) {
+          const res = await net.fetch(url);
+          if (!res.ok) return { ok: false, error: `fetch failed: ${res.status}` };
+          buffer = Buffer.from(await res.arrayBuffer());
+        } else if (url.startsWith('file://')) {
+          buffer = readFileSync(url.replace('file://', ''));
+        } else {
+          return { ok: false, error: 'unsupported url scheme' };
+        }
+        const ext = url.split('.').pop()?.split('?')[0]?.toLowerCase() ?? 'png';
+        const baseName = params.alt ? `${params.alt.replace(/[^a-zA-Z0-9_-]/g, '_')}.${ext}` : `image.${ext}`;
+        const artifact = await saveArtifactFromBuffer({
+          workspacePath,
+          taskId: params.taskId,
+          messageId: params.messageId,
+          fileName: baseName,
+          buffer,
+          artifactType: 'image',
+        });
+        const sha = await commitArtifact(workspacePath, artifact.localPath, `save: ${artifact.name}`);
+        if (sha) {
+          const db = getDb();
+          db.update(artifacts).set({ gitSha: sha }).where(eq(artifacts.id, artifact.id)).run();
+          artifact.gitSha = sha;
+        }
+        const win = BrowserWindow.getAllWindows()[0];
+        if (win) win.webContents.send('artifact:saved', artifact);
+        return { ok: true, result: artifact };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
+      }
+    },
+  );
+
+  ipcMain.handle('artifact:search', async (_event, params: { query: string }) => {
+    const sqlite = getSqlite();
+    if (!sqlite) return { ok: false, error: 'db not ready' };
+    try {
+      const results = searchArtifacts(sqlite, params.query);
+      return { ok: true, result: results };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
     }
   });
 }

--- a/packages/desktop/src/main/ipc/data-handlers.ts
+++ b/packages/desktop/src/main/ipc/data-handlers.ts
@@ -2,6 +2,8 @@ import { ipcMain } from 'electron';
 import { eq, desc } from 'drizzle-orm';
 import { getDb, isDbReady } from '../db/index.js';
 import { tasks, messages, artifacts } from '../db/schema.js';
+import { autoExtractArtifacts } from '../artifact/auto-extract.js';
+import { getWorkspacePath } from '../workspace/config.js';
 
 function ipcError(err: unknown): { ok: false; error: string } {
   return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
@@ -126,6 +128,14 @@ export function registerDataHandlers(): void {
             imageAttachments: msg.imageAttachments?.length ? JSON.stringify(msg.imageAttachments) : null,
           })
           .run();
+        if (msg.role === 'assistant' && msg.content.length > 0) {
+          const workspacePath = getWorkspacePath();
+          if (workspacePath) {
+            autoExtractArtifacts({ workspacePath, taskId: msg.taskId, messageId: msg.id, content: msg.content }).catch(
+              (err: unknown) => console.error('[auto-extract]', err),
+            );
+          }
+        }
         return { ok: true };
       } catch (err) {
         console.error('[data] create-message failed:', err);

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -226,6 +226,15 @@ export interface ClawWorkAPI {
   getArtifact: (id: string) => Promise<IpcResult>;
   readArtifactFile: (localPath: string) => Promise<IpcResult>;
   onArtifactSaved: (callback: (artifact: unknown) => void) => void;
+  saveCodeBlock: (params: {
+    taskId: string;
+    messageId: string;
+    content: string;
+    language?: string;
+    fileName?: string;
+  }) => Promise<IpcResult>;
+  saveImageFromUrl: (params: { taskId: string; messageId: string; url: string; alt?: string }) => Promise<IpcResult>;
+  searchArtifacts: (query: string) => Promise<IpcResult>;
 
   // Workspace
   isWorkspaceConfigured: () => Promise<boolean>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -79,6 +79,9 @@ function buildApi(): ClawWorkAPI {
     onArtifactSaved: (callback: (artifact: unknown) => void) => {
       ipcRenderer.on('artifact:saved', (_event, artifact) => callback(artifact));
     },
+    saveCodeBlock: (params) => ipcRenderer.invoke('artifact:save-content', params),
+    saveImageFromUrl: (params) => ipcRenderer.invoke('artifact:save-image-url', params),
+    searchArtifacts: (query: string) => ipcRenderer.invoke('artifact:search', { query }),
 
     isWorkspaceConfigured: () => ipcRenderer.invoke('workspace:is-configured') as Promise<boolean>,
     getWorkspacePath: () => ipcRenderer.invoke('workspace:get-path') as Promise<string | null>,

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import ApprovalDialog from './components/ApprovalDialog';
 import { useUiStore } from './stores/uiStore';
 import { useTaskStore } from './stores/taskStore';
 import { useMessageStore } from './stores/messageStore';
+import { useFileStore } from './stores/fileStore';
 import { useGatewayEventDispatcher } from './hooks/useGatewayDispatcher';
 import { useTheme } from './hooks/useTheme';
 import { useUpdateCheck } from './hooks/useUpdateCheck';
@@ -23,7 +24,6 @@ export default function App() {
 
   const rightPanelOpen = useUiStore((s) => s.rightPanelOpen);
   const toggleRightPanel = useUiStore((s) => s.toggleRightPanel);
-  const setRightPanelOpen = useUiStore((s) => s.setRightPanelOpen);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
   const theme = useUiStore((s) => s.theme);
@@ -68,6 +68,12 @@ export default function App() {
     },
     [],
   );
+
+  useEffect(() => {
+    window.clawwork.onArtifactSaved((artifact) => {
+      useFileStore.getState().addArtifactIfNew(artifact as import('@clawwork/shared').Artifact);
+    });
+  }, []);
 
   useEffect(() => {
     window.clawwork.isWorkspaceConfigured().then((configured) => {
@@ -136,6 +142,7 @@ export default function App() {
       startNewTask,
       setMainView,
       focusSearch,
+      leftNavCollapsed,
       leftNavShortcut,
       rightPanelShortcut,
       toggleLeftNavCollapsed,
@@ -252,7 +259,7 @@ export default function App() {
                 transition={{ duration: 0.2, ease: [0.2, 0, 0, 1] }}
                 className={cn('flex-shrink-0 border-l border-[var(--border)] bg-[var(--bg-secondary)] overflow-hidden')}
               >
-                <RightPanel onClose={() => setRightPanelOpen(false)} />
+                <RightPanel />
               </motion.aside>
             </>
           )}

--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -576,6 +576,7 @@ export default function ChatInput() {
     contextFolders,
     stopVoiceInput,
     commitPendingTask,
+    updateTaskMetadata,
     t,
   ]);
 

--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -171,7 +171,13 @@ const ChatMessage = memo(function ChatMessage({
           </div>
         ) : message.content || !images?.length ? (
           <div className="inline-block leading-relaxed rounded-2xl px-4 py-3 text-[var(--text-primary)]">
-            <MarkdownContent content={message.content} onImageClick={onImageClick} showMessageCopy />
+            <MarkdownContent
+              content={message.content}
+              onImageClick={onImageClick}
+              showMessageCopy
+              taskId={message.taskId}
+              messageId={message.id}
+            />
           </div>
         ) : null}
         {isUser && images?.length ? (

--- a/packages/desktop/src/renderer/components/FileCard.tsx
+++ b/packages/desktop/src/renderer/components/FileCard.tsx
@@ -11,42 +11,55 @@ interface FileCardProps {
   onClick: () => void;
 }
 
-function getIcon(type: ArtifactType, name: string) {
-  if (type === 'image') return Image;
-  if (type === 'code') return FileCode;
-  if (name.endsWith('.md') || name.endsWith('.txt')) return FileText;
-  return File;
+function getTypeConfig(type: ArtifactType, name: string) {
+  if (type === 'image') return { Icon: Image, color: 'text-purple-400', bg: 'bg-purple-400/10' };
+  if (type === 'code') return { Icon: FileCode, color: 'text-[var(--accent)]', bg: 'bg-[var(--accent-dim)]' };
+  if (name.endsWith('.md') || name.endsWith('.txt'))
+    return { Icon: FileText, color: 'text-blue-400', bg: 'bg-blue-400/10' };
+  return { Icon: File, color: 'text-[var(--text-muted)]', bg: 'bg-[var(--bg-tertiary)]' };
+}
+
+function extBadge(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot !== -1 ? name.slice(dot + 1).toUpperCase() : '';
 }
 
 export default function FileCard({ artifact, taskTitle, selected, onClick }: FileCardProps) {
-  const Icon = getIcon(artifact.type, artifact.name);
+  const { Icon, color, bg } = getTypeConfig(artifact.type, artifact.name);
+  const ext = extBadge(artifact.name);
 
   return (
     <motion.button
       onClick={onClick}
       {...motionPresets.scale}
       className={cn(
-        'w-full text-left rounded-lg border p-3 transition-colors',
+        'w-full text-left rounded-xl border transition-all duration-150 overflow-hidden group',
         selected
-          ? 'border-[var(--border-accent)] bg-[var(--accent-dim)]'
-          : 'border-[var(--border)] hover:bg-[var(--bg-hover)]',
+          ? 'border-[var(--border-accent)] bg-[var(--accent-dim)] shadow-sm shadow-[var(--accent)]/10'
+          : 'border-[var(--border)] bg-[var(--bg-secondary)] hover:border-[var(--border-accent)]/50 hover:bg-[var(--bg-hover)]',
       )}
     >
-      <div className="flex items-start gap-3">
-        <div className="flex-shrink-0 w-9 h-9 rounded-md bg-[var(--bg-tertiary)] flex items-center justify-center">
-          <Icon size={18} className="text-[var(--text-muted)]" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-[var(--text-primary)] truncate">{artifact.name}</p>
-          <p className="text-xs text-[var(--text-muted)] mt-0.5">{formatFileSize(artifact.size)}</p>
-          <div className="flex items-center gap-2 mt-1.5">
-            <span className="text-[10px] text-[var(--text-muted)] truncate max-w-[120px]">{taskTitle}</span>
-            <span className="text-[10px] text-[var(--text-muted)]">·</span>
-            <span className="text-[10px] text-[var(--text-muted)]">
-              {formatRelativeTime(new Date(artifact.createdAt))}
-            </span>
+      <div className="p-3">
+        <div className="flex items-start gap-2.5">
+          <div className={cn('flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center', bg)}>
+            <Icon size={18} className={color} />
           </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-[var(--text-primary)] truncate leading-snug">{artifact.name}</p>
+            <p className="text-xs text-[var(--text-muted)] mt-0.5">{formatFileSize(artifact.size)}</p>
+          </div>
+          {ext && (
+            <span className="flex-shrink-0 text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] leading-none">
+              {ext}
+            </span>
+          )}
         </div>
+      </div>
+      <div className="px-3 pb-2.5 flex items-center gap-1.5">
+        <span className="text-[10px] text-[var(--text-muted)] truncate flex-1">{taskTitle}</span>
+        <span className="text-[10px] text-[var(--text-muted)] flex-shrink-0">
+          {formatRelativeTime(new Date(artifact.createdAt))}
+        </span>
       </div>
     </motion.button>
   );

--- a/packages/desktop/src/renderer/components/FilePreview.tsx
+++ b/packages/desktop/src/renderer/components/FilePreview.tsx
@@ -1,9 +1,8 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { X, ExternalLink, Loader2 } from 'lucide-react';
+import { ExternalLink, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Artifact } from '@clawwork/shared';
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { motion as motionPresets } from '@/styles/design-tokens';
@@ -11,7 +10,6 @@ import MarkdownContent from './MarkdownContent';
 
 interface FilePreviewProps {
   artifact: Artifact;
-  onClose: () => void;
   onNavigateToTask: (taskId: string, messageId: string) => void;
 }
 
@@ -19,17 +17,12 @@ function isImage(mime: string): boolean {
   return mime.startsWith('image/');
 }
 
-function isMarkdown(mime: string, name: string): boolean {
-  return mime === 'text/markdown' || name.endsWith('.md');
-}
-
-function isCode(mime: string): boolean {
-  const codeMimes = ['text/typescript', 'text/javascript', 'application/json', 'text/html', 'text/css', 'text/plain'];
-  return codeMimes.includes(mime);
+function isMarkdown(name: string): boolean {
+  return name.endsWith('.md');
 }
 
 function langFromName(name: string): string {
-  const ext = name.slice(name.lastIndexOf('.') + 1);
+  const ext = name.slice(name.lastIndexOf('.') + 1).toLowerCase();
   const map: Record<string, string> = {
     ts: 'typescript',
     tsx: 'typescript',
@@ -45,15 +38,17 @@ function langFromName(name: string): string {
     rs: 'rust',
     java: 'java',
     sh: 'bash',
+    bash: 'bash',
     yaml: 'yaml',
     yml: 'yaml',
     xml: 'xml',
     toml: 'toml',
+    txt: '',
   };
   return map[ext] ?? '';
 }
 
-export default function FilePreview({ artifact, onClose, onNavigateToTask }: FilePreviewProps) {
+export default function FilePreview({ artifact, onNavigateToTask }: FilePreviewProps) {
   const { t } = useTranslation();
   const [content, setContent] = useState<string | null>(null);
   const [encoding, setEncoding] = useState<'utf-8' | 'base64'>('utf-8');
@@ -78,38 +73,33 @@ export default function FilePreview({ artifact, onClose, onNavigateToTask }: Fil
 
   return (
     <motion.div className="flex flex-col h-full" {...motionPresets.slideIn}>
-      <header
-        className={cn('flex items-center justify-between px-4 h-11 border-b border-[var(--border)] flex-shrink-0')}
-      >
-        <div className="flex items-center gap-2 min-w-0">
-          <h3 className="text-sm font-medium text-[var(--text-primary)] truncate">{artifact.name}</h3>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => onNavigateToTask(artifact.taskId, artifact.messageId)}
-            title={t('filePreview.goToSource')}
-          >
-            <ExternalLink size={14} />
-          </Button>
-        </div>
-        <Button variant="ghost" size="icon-sm" onClick={onClose}>
-          <X size={16} />
-        </Button>
+      <header className="flex items-center px-4 h-11 border-b border-[var(--border)] flex-shrink-0">
+        <h3 className="text-sm font-medium text-[var(--text-primary)] truncate min-w-0">{artifact.name}</h3>
       </header>
 
       <ScrollArea className="flex-1">
-        <div className="p-4">
-          {loading && (
-            <div className="flex items-center justify-center h-full">
-              <Loader2 size={20} className="animate-spin text-[var(--text-muted)]" />
-            </div>
-          )}
-          {error && <p className="text-sm text-[var(--danger)] text-center py-8">{error}</p>}
-          {!loading && !error && content !== null && (
-            <PreviewContent content={content} encoding={encoding} mimeType={artifact.mimeType} name={artifact.name} />
-          )}
-        </div>
+        {loading && (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 size={20} className="animate-spin text-[var(--text-muted)]" />
+          </div>
+        )}
+        {error && <p className="text-sm text-[var(--danger)] text-center py-8 px-4">{error}</p>}
+        {!loading && !error && content !== null && (
+          <PreviewContent content={content} encoding={encoding} mimeType={artifact.mimeType} name={artifact.name} />
+        )}
       </ScrollArea>
+
+      <div className="flex-shrink-0 border-t border-[var(--border)] px-4 py-2.5">
+        <Button
+          variant="soft"
+          size="sm"
+          onClick={() => onNavigateToTask(artifact.taskId, artifact.messageId)}
+          className="w-full gap-2"
+        >
+          <ExternalLink size={13} />
+          <span className="text-xs">{t('filePreview.goToSource')}</span>
+        </Button>
+      </div>
     </motion.div>
   );
 }
@@ -129,7 +119,7 @@ function PreviewContent({
 
   if (isImage(mimeType) && encoding === 'base64') {
     return (
-      <div className="flex items-center justify-center">
+      <div className="flex items-center justify-center p-4">
         <img
           src={`data:${mimeType};base64,${content}`}
           alt={name}
@@ -139,30 +129,22 @@ function PreviewContent({
     );
   }
 
-  if (isMarkdown(mimeType, name)) {
+  if (isMarkdown(name)) {
     return (
-      <div className="max-w-none">
+      <div className="p-4">
         <MarkdownContent content={content} />
       </div>
     );
   }
 
-  if (isCode(mimeType)) {
+  if (encoding === 'utf-8') {
     const lang = langFromName(name);
     const fenced = lang ? `\`\`\`${lang}\n${content}\n\`\`\`` : `\`\`\`\n${content}\n\`\`\``;
-    return (
-      <div className="max-w-none">
-        <MarkdownContent content={fenced} />
-      </div>
-    );
-  }
-
-  if (encoding === 'utf-8') {
-    return <pre className="text-sm text-[var(--text-secondary)] whitespace-pre-wrap break-words">{content}</pre>;
+    return <MarkdownContent content={fenced} />;
   }
 
   return (
-    <p className="text-sm text-[var(--text-muted)] text-center py-8">
+    <p className="text-sm text-[var(--text-muted)] text-center py-8 px-4">
       {t('filePreview.cannotPreview')} ({mimeType})
     </p>
   );

--- a/packages/desktop/src/renderer/components/MarkdownContent.tsx
+++ b/packages/desktop/src/renderer/components/MarkdownContent.tsx
@@ -2,7 +2,7 @@ import { isValidElement, type ReactNode, useEffect, useState, type ComponentProp
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
-import { Check, Copy } from 'lucide-react';
+import { Check, Copy, Save, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -13,21 +13,20 @@ interface MarkdownContentProps {
   onImageClick?: (src: string) => void;
   showMessageCopy?: boolean;
   showCursor?: boolean;
+  taskId?: string;
+  messageId?: string;
 }
 
 function flattenTextContent(node: ReactNode): string {
   if (typeof node === 'string' || typeof node === 'number') {
     return String(node);
   }
-
   if (Array.isArray(node)) {
     return node.map(flattenTextContent).join('');
   }
-
   if (isValidElement<{ children?: ReactNode }>(node)) {
     return flattenTextContent(node.props.children);
   }
-
   return '';
 }
 
@@ -81,6 +80,62 @@ function CopyActionButton({ label, copiedLabel, text, className }: CopyActionBut
   );
 }
 
+type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+interface SaveActionButtonProps {
+  className?: string;
+  onSave: () => Promise<void>;
+}
+
+function SaveActionButton({ className, onSave }: SaveActionButtonProps) {
+  const [state, setSaveState] = useState<SaveState>('idle');
+
+  useEffect(() => {
+    if (state !== 'saved' && state !== 'error') return;
+    const timer = window.setTimeout(() => setSaveState('idle'), 2000);
+    return () => window.clearTimeout(timer);
+  }, [state]);
+
+  const handleSave = async (): Promise<void> => {
+    if (state === 'saving') return;
+    setSaveState('saving');
+    try {
+      await onSave();
+      setSaveState('saved');
+    } catch {
+      setSaveState('error');
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      disabled={state === 'saving'}
+      className={cn(
+        'h-7 w-7 rounded-md border border-[var(--border)] bg-[var(--bg-secondary)]/90 backdrop-blur-sm',
+        'text-[var(--text-secondary)] hover:text-[var(--text-primary)]',
+        state === 'saved' && 'text-[var(--accent)]',
+        state === 'error' && 'text-red-400',
+        className,
+      )}
+      onClick={(event) => {
+        event.stopPropagation();
+        void handleSave();
+      }}
+    >
+      {state === 'saving' ? (
+        <Loader2 size={14} className="animate-spin" />
+      ) : state === 'saved' ? (
+        <Check size={14} />
+      ) : (
+        <Save size={14} />
+      )}
+    </Button>
+  );
+}
+
 const REMARK_PLUGINS = [remarkGfm] as const;
 const REHYPE_PLUGINS = [rehypeHighlight] as const;
 
@@ -89,6 +144,8 @@ export default function MarkdownContent({
   onImageClick,
   showMessageCopy = false,
   showCursor = false,
+  taskId,
+  messageId,
 }: MarkdownContentProps) {
   const { t } = useTranslation();
   const copyMessageLabel = t('chatMessage.copyMessage');
@@ -127,34 +184,57 @@ export default function MarkdownContent({
                   ? `file://${src.replace('clawwork-media://', '')}`
                   : src;
                 return (
-                  <img
-                    src={actualSrc}
-                    alt={alt ?? ''}
-                    loading="lazy"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).style.display = 'none';
-                    }}
-                    className="max-w-full max-h-80 rounded-lg mt-2 cursor-pointer"
-                    onClick={() => actualSrc && onImageClick?.(actualSrc)}
-                  />
+                  <span className="group/img relative inline-block">
+                    <img
+                      src={actualSrc}
+                      alt={alt ?? ''}
+                      loading="lazy"
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).style.display = 'none';
+                      }}
+                      className="max-w-full max-h-80 rounded-lg mt-2 cursor-pointer"
+                      onClick={() => actualSrc && onImageClick?.(actualSrc)}
+                    />
+                    {taskId && messageId && actualSrc && (
+                      <span className="absolute top-3 right-2 opacity-0 transition-opacity group-hover/img:opacity-100">
+                        <SaveActionButton
+                          onSave={() =>
+                            window.clawwork
+                              .saveImageFromUrl({ taskId, messageId, url: src ?? '', alt: alt ?? '' })
+                              .then((r) => {
+                                if (!r.ok) throw new Error(r.error);
+                              })
+                          }
+                        />
+                      </span>
+                    )}
+                  </span>
                 );
               },
               pre: ({ children }: ComponentPropsWithoutRef<'pre'>) => {
                 const code = flattenTextContent(children).replace(/\n$/, '');
                 const lang = extractLang(children);
                 return (
-                  <div className="group/code relative">
+                  <div className="group/code relative max-w-full">
                     {lang && (
                       <span className="absolute left-3 top-2.5 text-xs text-[var(--text-muted)] select-none pointer-events-none">
                         {lang}
                       </span>
                     )}
-                    <CopyActionButton
-                      label={copyCodeLabel}
-                      copiedLabel={copiedLabel}
-                      text={code}
-                      className="absolute right-2 top-2 z-10 opacity-0 transition-opacity group-hover/code:opacity-100 focus-visible:opacity-100"
-                    />
+                    <div className="absolute right-2 top-2 z-10 flex gap-1 opacity-0 transition-opacity group-hover/code:opacity-100 focus-within:opacity-100">
+                      {taskId && messageId && (
+                        <SaveActionButton
+                          onSave={() =>
+                            window.clawwork
+                              .saveCodeBlock({ taskId, messageId, content: code, language: lang || undefined })
+                              .then((r) => {
+                                if (!r.ok) throw new Error(r.error);
+                              })
+                          }
+                        />
+                      )}
+                      <CopyActionButton label={copyCodeLabel} copiedLabel={copiedLabel} text={code} />
+                    </div>
                     <pre className="pt-10">{children}</pre>
                   </div>
                 );

--- a/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
+++ b/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Search } from 'lucide-react';
+import { Search, Loader2, ChevronRight, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useFileStore } from '@/stores/fileStore';
 import { useTaskStore } from '@/stores/taskStore';
@@ -12,6 +12,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import FileCard from '@/components/FileCard';
 import FilePreview from '@/components/FilePreview';
 import type { Artifact } from '@clawwork/shared';
+import type { ArtifactSearchResult } from '@/stores/fileStore';
 
 function sortArtifacts(list: Artifact[], sortBy: 'date' | 'name' | 'type'): Artifact[] {
   const sorted = [...list];
@@ -25,6 +26,23 @@ function sortArtifacts(list: Artifact[], sortBy: 'date' | 'name' | 'type'): Arti
   }
 }
 
+function SnippetHighlight({ snippet }: { snippet: string }) {
+  const parts = snippet.split(/(<mark>[^<]*<\/mark>)/g);
+  return (
+    <span className="text-xs text-[var(--text-muted)] line-clamp-1">
+      {parts.map((part, i) =>
+        part.startsWith('<mark>') ? (
+          <mark key={i} className="bg-[var(--accent-dim)] text-[var(--accent)] not-italic rounded px-0.5">
+            {part.replace(/<\/?mark>/g, '')}
+          </mark>
+        ) : (
+          <span key={i}>{part}</span>
+        ),
+      )}
+    </span>
+  );
+}
+
 export default function FileBrowser() {
   const { t } = useTranslation();
   const artifacts = useFileStore((s) => s.artifacts);
@@ -32,16 +50,22 @@ export default function FileBrowser() {
   const sortBy = useFileStore((s) => s.sortBy);
   const selectedId = useFileStore((s) => s.selectedArtifactId);
   const searchQuery = useFileStore((s) => s.searchQuery);
+  const searchResults = useFileStore((s) => s.searchResults);
+  const isSearching = useFileStore((s) => s.isSearching);
   const setArtifacts = useFileStore((s) => s.setArtifacts);
   const setFilterTaskId = useFileStore((s) => s.setFilterTaskId);
   const setSortBy = useFileStore((s) => s.setSortBy);
   const setSelectedArtifact = useFileStore((s) => s.setSelectedArtifact);
   const setSearchQuery = useFileStore((s) => s.setSearchQuery);
+  const setSearchResults = useFileStore((s) => s.setSearchResults);
+  const setIsSearching = useFileStore((s) => s.setIsSearching);
 
   const tasks = useTaskStore((s) => s.tasks);
   const setActiveTask = useTaskStore((s) => s.setActiveTask);
   const setMainView = useUiStore((s) => s.setMainView);
   const setHighlightedMessage = useMessageStore((s) => s.setHighlightedMessage);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     window.clawwork.listArtifacts().then((res) => {
@@ -51,22 +75,48 @@ export default function FileBrowser() {
     });
   }, [setArtifacts]);
 
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!searchQuery.trim()) {
+      setSearchResults(null);
+      setIsSearching(false);
+      return;
+    }
+    setIsSearching(true);
+    debounceRef.current = setTimeout(() => {
+      window.clawwork
+        .searchArtifacts(searchQuery)
+        .then((res) => {
+          setIsSearching(false);
+          if (res.ok && res.result) {
+            setSearchResults(res.result as unknown as ArtifactSearchResult[]);
+          } else {
+            setSearchResults([]);
+          }
+        })
+        .catch(() => {
+          setIsSearching(false);
+          setSearchResults([]);
+        });
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchQuery, setSearchResults, setIsSearching]);
+
   const taskMap = useMemo(() => {
     const m = new Map<string, string>();
     for (const task of tasks) m.set(task.id, task.title || t('common.newTask'));
     return m;
   }, [tasks, t]);
 
-  const filtered = useMemo(() => {
-    let list = filterTaskId ? artifacts.filter((a) => a.taskId === filterTaskId) : artifacts;
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase();
-      list = list.filter((a) => a.name.toLowerCase().includes(q));
-    }
-    return list;
-  }, [artifacts, filterTaskId, searchQuery]);
+  const filteredArtifacts = useMemo(() => {
+    if (filterTaskId) return artifacts.filter((a) => a.taskId === filterTaskId);
+    return artifacts;
+  }, [artifacts, filterTaskId]);
 
-  const sorted = useMemo(() => sortArtifacts(filtered, sortBy), [filtered, sortBy]);
+  const sorted = useMemo(() => sortArtifacts(filteredArtifacts, sortBy), [filteredArtifacts, sortBy]);
+
   const selectedArtifact = useMemo(
     () => (selectedId ? (artifacts.find((a) => a.id === selectedId) ?? null) : null),
     [selectedId, artifacts],
@@ -87,58 +137,112 @@ export default function FileBrowser() {
     [setActiveTask, setHighlightedMessage, setMainView],
   );
 
+  const isSearchMode = searchQuery.trim().length > 0;
+
   return (
     <div className="flex h-full">
       <div className="flex flex-col flex-1 min-w-0">
-        <header className="flex items-center gap-3 px-6 py-3 border-b border-[var(--border)] flex-shrink-0">
-          <h2 className="text-sm font-medium text-[var(--text-primary)]">{t('common.fileManager')}</h2>
+        <header className="titlebar-no-drag flex items-center justify-between px-6 py-3 border-b border-[var(--border)] flex-shrink-0">
+          <h2 className="text-sm font-semibold text-[var(--text-primary)]">{t('common.fileManager')}</h2>
+          <div className="flex items-center gap-2">
+            <select
+              value={filterTaskId ?? ''}
+              onChange={(e) => setFilterTaskId(e.target.value || null)}
+              className={cn(
+                'h-7 px-2 rounded-md bg-[var(--bg-tertiary)] border border-[var(--border)]',
+                'text-xs text-[var(--text-secondary)] outline-none cursor-pointer',
+              )}
+            >
+              <option value="">{t('fileBrowser.allTasks')}</option>
+              {taskIdsWithArtifacts.map((id) => (
+                <option key={id} value={id}>
+                  {taskMap.get(id) ?? id}
+                </option>
+              ))}
+            </select>
+            <select
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as 'date' | 'name' | 'type')}
+              className={cn(
+                'h-7 px-2 rounded-md bg-[var(--bg-tertiary)] border border-[var(--border)]',
+                'text-xs text-[var(--text-secondary)] outline-none cursor-pointer',
+              )}
+            >
+              <option value="date">{t('fileBrowser.sortByDate')}</option>
+              <option value="name">{t('fileBrowser.sortByName')}</option>
+              <option value="type">{t('fileBrowser.sortByType')}</option>
+            </select>
+          </div>
+        </header>
+
+        <div className="titlebar-no-drag px-6 py-3 border-b border-[var(--border)] flex-shrink-0">
           <div className="relative">
-            <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[var(--text-muted)]" />
+            <div className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none">
+              {isSearching ? (
+                <Loader2 className="w-4 h-4 text-[var(--text-muted)] animate-spin" />
+              ) : (
+                <Search className="w-4 h-4 text-[var(--text-muted)]" />
+              )}
+            </div>
             <input
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder={t('fileBrowser.searchFiles')}
               className={cn(
-                'h-7 pl-8 pr-3 rounded-md bg-[var(--bg-tertiary)] border border-[var(--border)]',
-                'text-xs text-[var(--text-secondary)] outline-none',
-                'focus:border-[var(--border-accent)] placeholder:text-[var(--text-muted)] transition-colors',
+                'w-full h-9 pl-10 pr-9 rounded-lg',
+                'bg-[var(--bg-tertiary)] border border-[var(--border)]',
+                'text-sm text-[var(--text-secondary)] outline-none',
+                'focus:border-[var(--border-accent)] focus:bg-[var(--bg-secondary)]',
+                'placeholder:text-[var(--text-muted)] transition-all duration-150',
               )}
             />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+              >
+                <X size={14} />
+              </button>
+            )}
           </div>
-          <select
-            value={filterTaskId ?? ''}
-            onChange={(e) => setFilterTaskId(e.target.value || null)}
-            className={cn(
-              'h-7 px-2 rounded-md bg-[var(--bg-tertiary)] border border-[var(--border)]',
-              'text-xs text-[var(--text-secondary)] outline-none',
-            )}
-          >
-            <option value="">{t('fileBrowser.allTasks')}</option>
-            {taskIdsWithArtifacts.map((id) => (
-              <option key={id} value={id}>
-                {taskMap.get(id) ?? id}
-              </option>
-            ))}
-          </select>
-          <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as 'date' | 'name' | 'type')}
-            className={cn(
-              'h-7 px-2 rounded-md bg-[var(--bg-tertiary)] border border-[var(--border)]',
-              'text-xs text-[var(--text-secondary)] outline-none',
-            )}
-          >
-            <option value="date">{t('fileBrowser.sortByDate')}</option>
-            <option value="name">{t('fileBrowser.sortByName')}</option>
-            <option value="type">{t('fileBrowser.sortByType')}</option>
-          </select>
-        </header>
+        </div>
 
         <ScrollArea className="flex-1">
           <div className="px-6 py-4">
-            {sorted.length === 0 ? (
-              <div className="flex items-center justify-center h-full">
+            {isSearchMode ? (
+              searchResults === null || isSearching ? (
+                <div className="flex items-center justify-center h-32">
+                  <Loader2 className="w-5 h-5 animate-spin text-[var(--text-muted)]" />
+                </div>
+              ) : searchResults.length === 0 ? (
+                <p className="text-sm text-[var(--text-muted)] text-center py-8">{t('common.noFiles')}</p>
+              ) : (
+                <div className="space-y-1.5">
+                  {searchResults.map((r) => (
+                    <button
+                      key={r.id}
+                      onClick={() => setSelectedArtifact(r.id === selectedId ? null : r.id)}
+                      className={cn(
+                        'w-full flex flex-col gap-0.5 px-3 py-2.5 rounded-xl text-left transition-colors',
+                        'bg-[var(--bg-secondary)] border hover:bg-[var(--bg-hover)]',
+                        r.id === selectedId
+                          ? 'border-[var(--border-accent)] bg-[var(--accent-dim)]'
+                          : 'border-[var(--border)]',
+                      )}
+                    >
+                      <span className="text-sm text-[var(--text-primary)] font-medium truncate">{r.name}</span>
+                      {r.contentSnippet && <SnippetHighlight snippet={r.contentSnippet} />}
+                      <span className="text-xs text-[var(--text-muted)]">{taskMap.get(r.taskId) ?? r.taskId}</span>
+                    </button>
+                  ))}
+                </div>
+              )
+            ) : sorted.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+                <div className="w-12 h-12 rounded-2xl bg-[var(--bg-tertiary)] flex items-center justify-center">
+                  <Search size={20} className="text-[var(--text-muted)]" />
+                </div>
                 <p className="text-sm text-[var(--text-muted)]">{t('common.noFiles')}</p>
               </div>
             ) : (
@@ -164,13 +268,23 @@ export default function FileBrowser() {
             {...motionPresets.slideIn}
             initial={{ opacity: 0, x: 16 }}
             exit={{ opacity: 0, x: 16 }}
-            className="w-[360px] flex-shrink-0 border-l border-[var(--border)] bg-[var(--bg-secondary)]"
+            className="relative w-[360px] flex-shrink-0 border-l border-[var(--border)] bg-[var(--bg-secondary)]"
           >
-            <FilePreview
-              artifact={selectedArtifact}
-              onClose={() => setSelectedArtifact(null)}
-              onNavigateToTask={handleNavigateToTask}
-            />
+            <button
+              onClick={() => setSelectedArtifact(null)}
+              title="Close preview"
+              className={cn(
+                'absolute left-0 top-1/2 -translate-x-full -translate-y-1/2 z-10',
+                'flex items-center justify-center w-5 h-12',
+                'bg-[var(--bg-secondary)] border border-r-0 border-[var(--border)]',
+                'rounded-l-lg cursor-pointer',
+                'text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)]',
+                'transition-colors duration-150',
+              )}
+            >
+              <ChevronRight size={13} />
+            </button>
+            <FilePreview artifact={selectedArtifact} onNavigateToTask={handleNavigateToTask} />
           </motion.div>
         )}
       </AnimatePresence>

--- a/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
+++ b/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
@@ -1,18 +1,14 @@
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { X, FileText, GitBranch, CheckSquare, Square, Loader2, Cpu, ArrowUp, ArrowDown, Brain } from 'lucide-react';
+import { FileText, GitBranch, CheckSquare, Square, Loader2, Cpu, ArrowUp, ArrowDown, Brain } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore, EMPTY_MESSAGES } from '@/stores/messageStore';
 import { cn, formatTokenCount } from '@/lib/utils';
 import { motion as motionPresets } from '@/styles/design-tokens';
-import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import type { ProgressStep, Artifact } from '@clawwork/shared';
-
-interface RightPanelProps {
-  onClose: () => void;
-}
 
 function extractProgressSteps(messages: { role: string; content: string }[]): ProgressStep[] {
   const steps: ProgressStep[] = [];
@@ -39,10 +35,6 @@ function extractProgressSteps(messages: { role: string; content: string }[]): Pr
   return steps;
 }
 
-function collectArtifacts(messages: { artifacts: Artifact[] }[]): Artifact[] {
-  return messages.flatMap((m) => m.artifacts);
-}
-
 function StepIcon({ status }: { status: ProgressStep['status'] }) {
   switch (status) {
     case 'completed':
@@ -54,29 +46,49 @@ function StepIcon({ status }: { status: ProgressStep['status'] }) {
   }
 }
 
-export default function RightPanel({ onClose }: RightPanelProps) {
+export default function RightPanel() {
   const { t } = useTranslation();
   const activeTaskId = useTaskStore((s) => s.activeTaskId);
   const activeTask = useTaskStore((s) => s.tasks.find((task) => task.id === s.activeTaskId));
+  const setHighlightedMessage = useMessageStore((s) => s.setHighlightedMessage);
   const messages = useMessageStore((s) =>
     activeTaskId ? (s.messagesByTask[activeTaskId] ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
   );
 
   const steps = extractProgressSteps(messages);
-  const artifacts = collectArtifacts(messages);
   const doneCount = steps.filter((s) => s.status === 'completed').length;
 
-  return (
-    <div className="flex flex-col h-full pt-10">
-      <div className="flex items-center justify-between px-4 h-12 border-b border-[var(--border)] flex-shrink-0">
-        <h3 className="font-medium text-[var(--text-primary)]">{t('rightPanel.context')}</h3>
-        <Button variant="ghost" size="icon-sm" onClick={onClose}>
-          <X size={16} />
-        </Button>
-      </div>
+  const [taskArtifacts, setTaskArtifacts] = useState<Artifact[]>([]);
 
+  useEffect(() => {
+    if (!activeTaskId) {
+      setTaskArtifacts([]);
+      return;
+    }
+    window.clawwork.listArtifacts(activeTaskId).then((res) => {
+      if (res.ok && res.result) {
+        setTaskArtifacts(res.result as unknown as Artifact[]);
+      }
+    });
+
+    const handleArtifactSaved = (artifact: unknown) => {
+      const a = artifact as Artifact;
+      if (a.taskId !== activeTaskId) return;
+      setTaskArtifacts((prev) => {
+        if (prev.some((x) => x.id === a.id)) return prev;
+        return [a, ...prev];
+      });
+    };
+    window.clawwork.onArtifactSaved(handleArtifactSaved);
+    return () => {
+      window.clawwork.removeAllListeners('artifact:saved');
+    };
+  }, [activeTaskId]);
+
+  return (
+    <div className="flex flex-col h-full">
       <Tabs defaultValue="progress" className="flex flex-col flex-1 min-h-0">
-        <TabsList className="mx-4 mt-2">
+        <TabsList className="mx-4 mt-10">
           <TabsTrigger value="progress">{t('rightPanel.progress')}</TabsTrigger>
           <TabsTrigger value="artifacts">{t('rightPanel.artifacts')}</TabsTrigger>
           <TabsTrigger value="git">Git</TabsTrigger>
@@ -158,20 +170,21 @@ export default function RightPanel({ onClose }: RightPanelProps) {
 
           <TabsContent value="artifacts" className="p-4">
             <div className="space-y-1.5">
-              {artifacts.length === 0 ? (
+              {taskArtifacts.length === 0 ? (
                 <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--bg-tertiary)] text-sm text-[var(--text-secondary)]">
                   <FileText size={15} className="opacity-60" />
                   <span className="truncate">{t('common.noFiles')}</span>
                 </div>
               ) : (
-                artifacts.map((a) => (
+                taskArtifacts.map((a) => (
                   <button
                     key={a.id}
+                    onClick={() => setHighlightedMessage(a.messageId)}
                     className={cn(
                       'w-full flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--bg-tertiary)]',
                       'text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors text-left',
                     )}
-                    title={a.filePath}
+                    title={a.localPath}
                   >
                     <FileText size={15} className="opacity-60 flex-shrink-0" />
                     <span className="truncate flex-1">{a.name}</span>

--- a/packages/desktop/src/renderer/stores/fileStore.ts
+++ b/packages/desktop/src/renderer/stores/fileStore.ts
@@ -1,26 +1,44 @@
 import { create } from 'zustand';
 import type { Artifact } from '@clawwork/shared';
 
-/** Stable empty array — avoids new references on every selector call */
 const EMPTY_ARTIFACTS: Artifact[] = [];
 export { EMPTY_ARTIFACTS };
 
 type SortBy = 'date' | 'name' | 'type';
 
+export interface ArtifactSearchResult {
+  id: string;
+  taskId: string;
+  name: string;
+  type: string;
+  localPath: string;
+  mimeType: string;
+  size: number;
+  createdAt: string;
+  gitSha: string;
+  filePath: string;
+  messageId: string;
+  contentSnippet?: string;
+}
+
 interface FileState {
   artifacts: Artifact[];
-  /** null = all tasks, string = specific taskId */
   filterTaskId: string | null;
   sortBy: SortBy;
   selectedArtifactId: string | null;
   searchQuery: string;
+  searchResults: ArtifactSearchResult[] | null;
+  isSearching: boolean;
 
   setArtifacts: (artifacts: Artifact[]) => void;
   addArtifact: (artifact: Artifact) => void;
+  addArtifactIfNew: (artifact: Artifact) => void;
   setFilterTaskId: (taskId: string | null) => void;
   setSortBy: (sortBy: SortBy) => void;
   setSelectedArtifact: (id: string | null) => void;
   setSearchQuery: (query: string) => void;
+  setSearchResults: (results: ArtifactSearchResult[] | null) => void;
+  setIsSearching: (v: boolean) => void;
 }
 
 export const useFileStore = create<FileState>((set) => ({
@@ -29,10 +47,18 @@ export const useFileStore = create<FileState>((set) => ({
   sortBy: 'date',
   selectedArtifactId: null,
   searchQuery: '',
+  searchResults: null,
+  isSearching: false,
 
   setArtifacts: (artifacts) => set({ artifacts }),
 
   addArtifact: (artifact) => set((s) => ({ artifacts: [artifact, ...s.artifacts] })),
+
+  addArtifactIfNew: (artifact) =>
+    set((s) => {
+      if (s.artifacts.some((a) => a.id === artifact.id)) return s;
+      return { artifacts: [artifact, ...s.artifacts] };
+    }),
 
   setFilterTaskId: (taskId) => set({ filterTaskId: taskId }),
 
@@ -41,4 +67,8 @@ export const useFileStore = create<FileState>((set) => ({
   setSelectedArtifact: (id) => set({ selectedArtifactId: id }),
 
   setSearchQuery: (query) => set({ searchQuery: query }),
+
+  setSearchResults: (results) => set({ searchResults: results }),
+
+  setIsSearching: (v) => set({ isSearching: v }),
 }));

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -93,6 +93,7 @@ export interface Artifact {
   size: number;
   /** Git commit SHA from auto-commit, empty if not yet committed */
   gitSha: string;
+  contentText?: string;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

Adds a full artifact storage module: agent messages are automatically scanned for code blocks and images, which are persisted to the workspace git repo. A new FileBrowser layout with FTS5 full-text search, per-task filtering, and an inline file preview drawer replaces the placeholder file manager. The RightPanel Artifacts tab now loads from the DB and supports real-time updates.

## Type of change

- [x] `[Feat]` new feature

## Why is this needed?

AI-generated code and images were ephemeral — users had no way to find, review, or reference them after the conversation scrolled. This feature closes that gap by automatically persisting all notable artifacts and making them searchable.

## What changed?

- **Auto-extraction engine** (`artifact/extract.ts`, `artifact/auto-extract.ts`): parses markdown for images and code blocks (>10 lines or filename-annotated), saves each as a workspace artifact, commits in a single batched git commit
- **`saveArtifactFromBuffer()`** in `artifact/save.ts`: writes arbitrary buffers as artifacts with proper type (`code` | `image`) and optional `contentText` for FTS indexing
- **DB schema**: added `content_text TEXT NOT NULL DEFAULT ''` column to `artifacts` table with ALTER TABLE migration
- **FTS5 index**: recreated `artifacts_fts` with `name` + `content_text` columns; triggers and backfill updated; migration detects old schema and drops/recreates
- **`searchArtifacts()`** in `db/search.ts`: FTS5 MATCH with `snippet()` for result highlighting
- **Manual save IPC**: `artifact:save-content` and `artifact:save-image-url` handlers; save + copy buttons on code blocks and images in `MarkdownContent`
- **FileBrowser** (`layouts/FileBrowser/index.tsx`): FTS5 search with 300ms debounce, snippet highlighting, task filter, sort, animated preview drawer with collapse handle
- **FilePreview** (`components/FilePreview.tsx`): extension-based syntax highlighting via fenced markdown, edge-to-edge code display, `soft` variant footer CTA per design system
- **RightPanel** (`layouts/RightPanel/index.tsx`): loads artifacts from DB per active task, real-time updates via `artifact:saved` IPC event, artifact click scrolls to source message
- **Simplifications**: removed redundant `n` param from `commitArtifactBatch`, replaced `while(exec)` loops with `matchAll`, flattened `saved` wrapper object, consolidated FTS migration try/catch

## Architecture impact

- Owning layer: main (artifact/, db/), preload, renderer (stores/, layouts/, components/)
- Cross-layer impact: yes — new IPC channels `artifact:save-content`, `artifact:save-image-url`, `artifact:search` bridge main↔renderer; `artifact:saved` push event wires real-time updates
- Invariants touched: artifact persistence is fire-and-forget (never blocks message IPC response); preload exposes only typed, named methods via contextBridge
- Why those invariants remain protected: `autoExtractArtifacts` is called with `.catch()` after DB insert returns; all new preload entries follow the existing `ipcRenderer.invoke` pattern with typed parameters

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm check — ✓ 0 errors, 1 pre-existing warning (react-hooks/exhaustive-deps in unrelated file)
All 54 tests pass across shared + desktop packages
```

## Screenshots or recordings

- FileBrowser: grid of FileCards with search, task filter, sort; drawer opens on click with syntax-highlighted preview and "Go to source message" footer button
- RightPanel Artifacts tab: lists per-task artifacts, click scrolls to originating message
- MarkdownContent: save button on code blocks and images (3-state: idle → saving spinner → green check)

Design system compliance: "Go to source message" uses `soft` variant (secondary CTA per `design-system.md`); all colors via CSS variables; no hardcoded hex values added.

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Add file manager: AI-generated code and images are now automatically saved as workspace artifacts, searchable by content, and viewable in a new FileBrowser with syntax highlighting and source message navigation.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate