### PR TITLE
[UI] Polish file manager UX and fix titlebar click targets

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -24,6 +24,7 @@ export default function App() {
 
   const rightPanelOpen = useUiStore((s) => s.rightPanelOpen);
   const toggleRightPanel = useUiStore((s) => s.toggleRightPanel);
+  const mainView = useUiStore((s) => s.mainView);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
   const theme = useUiStore((s) => s.theme);
@@ -135,7 +136,7 @@ export default function App() {
 
       if (!e.shiftKey && e.code === rightCode) {
         e.preventDefault();
-        toggleRightPanel();
+        if (useUiStore.getState().mainView === 'chat') toggleRightPanel();
       }
     },
     [
@@ -246,7 +247,7 @@ export default function App() {
         </main>
 
         <AnimatePresence>
-          {rightPanelOpen && !settingsOpen && (
+          {rightPanelOpen && !settingsOpen && mainView === 'chat' && (
             <>
               <div
                 className="w-1.5 flex-shrink-0 cursor-col-resize hover:bg-[var(--accent)]/20 transition-colors z-10"

--- a/packages/desktop/src/renderer/components/FilePreview.tsx
+++ b/packages/desktop/src/renderer/components/FilePreview.tsx
@@ -1,11 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { ExternalLink, Loader2 } from 'lucide-react';
+import { ExternalLink, Loader2, Copy, Check } from 'lucide-react';
+import hljs from 'highlight.js';
 import { useTranslation } from 'react-i18next';
 import type { Artifact } from '@clawwork/shared';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { motion as motionPresets } from '@/styles/design-tokens';
+import { cn, formatFileSize } from '@/lib/utils';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import MarkdownContent from './MarkdownContent';
 
 interface FilePreviewProps {
@@ -48,12 +51,48 @@ function langFromName(name: string): string {
   return map[ext] ?? '';
 }
 
+function extFromName(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot !== -1 ? name.slice(dot + 1).toUpperCase() : '';
+}
+
+function CopyButton({ text }: { text: string }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <button
+      onClick={() => {
+        void copyTextToClipboard(text);
+        setCopied(true);
+      }}
+      title={copied ? t('chatMessage.copied') : t('chatMessage.copyCode')}
+      className={cn(
+        'flex items-center gap-1 px-2 py-1 rounded-md text-xs transition-colors',
+        'text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)]',
+        copied && 'text-[var(--accent)]',
+      )}
+    >
+      {copied ? <Check size={12} /> : <Copy size={12} />}
+    </button>
+  );
+}
+
 export default function FilePreview({ artifact, onNavigateToTask }: FilePreviewProps) {
   const { t } = useTranslation();
   const [content, setContent] = useState<string | null>(null);
   const [encoding, setEncoding] = useState<'utf-8' | 'base64'>('utf-8');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const ext = extFromName(artifact.name);
+  const isCode = encoding === 'utf-8' && !isMarkdown(artifact.name) && !isImage(artifact.mimeType);
 
   useEffect(() => {
     setLoading(true);
@@ -73,8 +112,19 @@ export default function FilePreview({ artifact, onNavigateToTask }: FilePreviewP
 
   return (
     <motion.div className="flex flex-col h-full" {...motionPresets.slideIn}>
-      <header className="flex items-center px-4 h-11 border-b border-[var(--border)] flex-shrink-0">
-        <h3 className="text-sm font-medium text-[var(--text-primary)] truncate min-w-0">{artifact.name}</h3>
+      <header className="flex items-center justify-between gap-2 px-4 h-11 border-b border-[var(--border)] flex-shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          {ext && (
+            <span className="flex-shrink-0 text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] leading-none">
+              {ext}
+            </span>
+          )}
+          <h3 className="text-sm font-medium text-[var(--text-primary)] truncate min-w-0">{artifact.name}</h3>
+        </div>
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          <span className="text-[10px] text-[var(--text-muted)]">{formatFileSize(artifact.size)}</span>
+          {isCode && content !== null && <CopyButton text={content} />}
+        </div>
       </header>
 
       <ScrollArea className="flex-1">
@@ -101,6 +151,27 @@ export default function FilePreview({ artifact, onNavigateToTask }: FilePreviewP
         </Button>
       </div>
     </motion.div>
+  );
+}
+
+function CodePreview({ content, lang }: { content: string; lang: string }) {
+  const highlighted = useMemo(() => {
+    if (lang && hljs.getLanguage(lang)) {
+      return hljs.highlight(content, { language: lang }).value;
+    }
+    return hljs.highlightAuto(content).value;
+  }, [content, lang]);
+
+  return (
+    <div className="overflow-x-auto">
+      <pre className="p-4 text-[0.82em] leading-relaxed font-mono">
+        <code
+          className={cn('hljs', lang && `language-${lang}`)}
+          style={{ background: 'none', padding: 0 }}
+          dangerouslySetInnerHTML={{ __html: highlighted }}
+        />
+      </pre>
+    </div>
   );
 }
 
@@ -139,8 +210,7 @@ function PreviewContent({
 
   if (encoding === 'utf-8') {
     const lang = langFromName(name);
-    const fenced = lang ? `\`\`\`${lang}\n${content}\n\`\`\`` : `\`\`\`\n${content}\n\`\`\``;
-    return <MarkdownContent content={fenced} />;
+    return <CodePreview content={content} lang={lang} />;
   }
 
   return (

--- a/packages/desktop/src/renderer/components/MarkdownContent.tsx
+++ b/packages/desktop/src/renderer/components/MarkdownContent.tsx
@@ -245,12 +245,18 @@ export default function MarkdownContent({
           </Markdown>
         </div>
         {showMessageCopy && content.trim() && (
-          <CopyActionButton
-            label={copyMessageLabel}
-            copiedLabel={copiedLabel}
-            text={content}
-            className="mt-0.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-          />
+          <div className="flex gap-1 mt-0.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100">
+            {taskId && messageId && (
+              <SaveActionButton
+                onSave={() =>
+                  window.clawwork.saveCodeBlock({ taskId, messageId, content, language: 'md' }).then((r) => {
+                    if (!r.ok) throw new Error(r.error);
+                  })
+                }
+              />
+            )}
+            <CopyActionButton label={copyMessageLabel} copiedLabel={copiedLabel} text={content} />
+          </div>
         )}
       </div>
       {showCursor && (

--- a/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
+++ b/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
@@ -68,6 +68,10 @@ export default function FileBrowser() {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    return () => setSelectedArtifact(null);
+  }, [setSelectedArtifact]);
+
+  useEffect(() => {
     window.clawwork.listArtifacts().then((res) => {
       if (res.ok && res.result) {
         setArtifacts(res.result as unknown as Artifact[]);
@@ -142,9 +146,9 @@ export default function FileBrowser() {
   return (
     <div className="flex h-full">
       <div className="flex flex-col flex-1 min-w-0">
-        <header className="titlebar-no-drag flex items-center justify-between px-6 py-3 border-b border-[var(--border)] flex-shrink-0">
+        <header className="titlebar-drag flex items-center justify-between px-6 py-3 border-b border-[var(--border)] flex-shrink-0 relative z-[51]">
           <h2 className="text-sm font-semibold text-[var(--text-primary)]">{t('common.fileManager')}</h2>
-          <div className="flex items-center gap-2">
+          <div className="titlebar-no-drag flex items-center gap-2">
             <select
               value={filterTaskId ?? ''}
               onChange={(e) => setFilterTaskId(e.target.value || null)}

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -378,7 +378,7 @@ export default function LeftNav() {
 
   return (
     <div className="flex flex-col h-full pt-14 relative">
-      <div className="absolute top-[8px] right-2 z-10">{CollapseToggleButton}</div>
+      <div className="absolute top-[8px] right-2 z-[51]">{CollapseToggleButton}</div>
       <div className="px-4 pb-3 space-y-2 flex-shrink-0">
         {hasMultipleGateways ? (
           <div className="titlebar-no-drag flex items-center gap-0.5">

--- a/packages/desktop/src/renderer/layouts/Settings/index.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/index.tsx
@@ -25,7 +25,7 @@ export default function Settings({ onClose }: { onClose: () => void }) {
 
   return (
     <motion.div {...motionPresets.fadeIn} className="flex flex-col h-full">
-      <header className="flex items-center justify-between h-12 px-4 border-b border-[var(--border)] flex-shrink-0">
+      <header className="titlebar-drag flex items-center justify-between h-12 px-4 border-b border-[var(--border)] flex-shrink-0 relative z-[51]">
         <h2 className="font-medium text-[var(--text-primary)]">{t('common.settings')}</h2>
         <Button
           variant="ghost"


### PR DESCRIPTION
## Summary

Multiple UX improvements to the file manager and related panels: better code preview rendering, message save support, context panel view isolation, drawer cleanup on navigation, and fix for titlebar overlay blocking clicks on top-of-window elements.

## Type of change

- [x] `[UI]` UI or UX change

## Why is this needed?

Several interaction issues degraded the file manager experience:
1. Code file preview wasted space with redundant language labels, lacked metadata, and had no horizontal scroll
2. Plain-text assistant messages had no save-to-artifact option (only code blocks did)
3. The RightPanel (context panel) persisted when switching away from chat view, and its toggle shortcut fired globally
4. File preview drawer stayed open when navigating away from file manager
5. Buttons near the window top (LeftNav collapse, FileBrowser selects, Settings close) were partially unclickable due to the macOS titlebar drag overlay

## What changed?

- **FilePreview.tsx**: Replace MarkdownContent wrapper with direct `highlight.js` rendering for code files; add extension badge, file size, and persistent copy button to header; proper padding and horizontal scroll
- **MarkdownContent.tsx**: Add `SaveActionButton` for plain-text messages alongside existing copy button when `taskId`/`messageId` are available
- **App.tsx**: Condition RightPanel rendering on `mainView === 'chat'`; guard toggle shortcut to only fire in chat view
- **FileBrowser/index.tsx**: Clear `selectedArtifactId` on unmount; elevate header to `z-[51]` with `titlebar-drag` and `titlebar-no-drag` on interactive children
- **LeftNav/index.tsx**: Raise collapse button container from `z-10` to `z-[51]`
- **Settings/index.tsx**: Add `titlebar-drag relative z-[51]` to header

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched: none
- Why those invariants remain protected: all changes are renderer-only CSS/component adjustments

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] ESLint + Prettier (via pre-commit hook)

Commands, screenshots, or notes:

```text
pnpm typecheck — passed
git commit — pre-commit hook (eslint + prettier + architecture check) passed
```

## Screenshots or recordings

N/A

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Improve file manager code preview (syntax highlighting, metadata, copy button), add message save support, fix context panel leaking across views, fix top-of-window buttons unclickable on macOS.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[UI]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate