### PR TITLE
[UI] Polish left nav sidebar design, archived tasks, and traffic light handling

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -84,6 +84,12 @@ function createWindow(): BrowserWindow {
     },
   });
 
+  ipcMain.on('ui:set-window-button-visibility', (_event, visible: boolean) => {
+    if (process.platform === 'darwin') {
+      mainWindow.setWindowButtonVisibility(visible);
+    }
+  });
+
   mainWindow.on('ready-to-show', () => {
     mainWindow.show();
   });

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -335,6 +335,8 @@ export interface ClawWorkAPI {
   onTrayNavigateTask: (callback: (taskId: string) => void) => () => void;
   onTrayOpenSettings: (callback: () => void) => () => void;
 
+  setWindowButtonVisibility: (visible: boolean) => void;
+
   selectContextFolder: () => Promise<IpcResult>;
   listContextFiles: (folders: string[], query?: string) => Promise<IpcResult>;
   readContextFile: (absolutePath: string, folders: string[]) => Promise<IpcResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -208,6 +208,8 @@ function buildApi(): ClawWorkAPI {
       };
     },
 
+    setWindowButtonVisibility: (visible: boolean) => ipcRenderer.send('ui:set-window-button-visibility', visible),
+
     selectContextFolder: () => ipcRenderer.invoke('context:select-folder'),
     listContextFiles: (folders: string[], query?: string) =>
       ipcRenderer.invoke('context:list-files', { folders, query }),

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -157,6 +157,10 @@ export default function App() {
   }, [handleGlobalKeyDown]);
 
   useEffect(() => {
+    window.clawwork.setWindowButtonVisibility(!leftNavCollapsed);
+  }, [leftNavCollapsed]);
+
+  useEffect(() => {
     return window.clawwork.onQuickLaunchSubmit((message) => {
       const task = createTask();
       const title = message.slice(0, 30).replace(/\n/g, ' ').trim();

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -11,7 +11,9 @@
     "noTitle": "(Untitled)",
     "cancel": "Cancel",
     "save": "Save",
-    "close": "Close"
+    "close": "Close",
+    "task": "Task",
+    "time": "Time"
   },
   "leftNav": {
     "searchTasks": "Search tasks\u2026",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -11,7 +11,9 @@
     "noTitle": "(无标题)",
     "cancel": "取消",
     "save": "保存",
-    "close": "关闭"
+    "close": "关闭",
+    "task": "任务",
+    "time": "时间"
   },
   "leftNav": {
     "searchTasks": "搜索任务…",

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -2,8 +2,7 @@ import { type MouseEvent } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { MessageSquare, Circle, Loader2, Server, Cpu, Bot } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { cn } from '@/lib/utils';
-import { formatRelativeTime } from '@/lib/utils';
+import { cn, formatRelativeTime } from '@/lib/utils';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
 import { useUiStore } from '@/stores/uiStore';
@@ -18,9 +17,10 @@ interface TaskItemProps {
   active: boolean;
   onContextMenu: (e: MouseEvent) => void;
   collapsed?: boolean;
+  multiGateway?: boolean;
 }
 
-export default function TaskItem({ task, active, onContextMenu, collapsed }: TaskItemProps) {
+export default function TaskItem({ task, active, onContextMenu, collapsed, multiGateway }: TaskItemProps) {
   const { t } = useTranslation();
   const reduced = useReducedMotion();
   const setActiveTask = useTaskStore((s) => s.setActiveTask);
@@ -29,7 +29,6 @@ export default function TaskItem({ task, active, onContextMenu, collapsed }: Tas
   const setMainView = useUiStore((s) => s.setMainView);
   const isStreaming = useMessageStore((s) => !!s.streamingByTask[task.id]);
   const gwInfo = useUiStore((s) => s.gatewayInfoMap[task.gatewayId]);
-  const multiGateway = useUiStore((s) => Object.keys(s.gatewayInfoMap).length > 1);
   const agentInfo = useUiStore((s) =>
     task.agentId && task.agentId !== 'main'
       ? s.agentCatalogByGateway[task.gatewayId]?.agents.find((a) => a.id === task.agentId)
@@ -50,14 +49,15 @@ export default function TaskItem({ task, active, onContextMenu, collapsed }: Tas
         <TooltipTrigger asChild>
           <motion.button
             {...motionPresets.listItem}
+            whileTap={reduced ? undefined : { scale: 0.95 }}
             onClick={handleClick}
             onContextMenu={onContextMenu}
-            className="titlebar-no-drag w-full flex justify-center py-1.5 relative"
+            className="titlebar-no-drag w-full flex justify-center py-1.5 relative rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-accent)]"
           >
             {active && <span className="absolute left-0 top-1 bottom-1 w-[3px] rounded-full bg-[var(--accent)]" />}
             <span
               className={cn(
-                'w-8 h-8 rounded-lg flex items-center justify-center text-xs font-medium',
+                'w-8 h-8 rounded-md flex items-center justify-center text-xs font-medium transition-colors',
                 active
                   ? 'bg-[var(--accent-dim)] text-[var(--accent)]'
                   : 'bg-[var(--bg-tertiary)] text-[var(--text-secondary)]',
@@ -80,30 +80,33 @@ export default function TaskItem({ task, active, onContextMenu, collapsed }: Tas
     <motion.button
       {...motionPresets.listItem}
       whileHover={reduced ? undefined : { x: 2 }}
+      whileTap={reduced ? undefined : { scale: 0.98 }}
       transition={{ duration: 0.15, ease: 'easeOut' }}
       onClick={handleClick}
       onContextMenu={onContextMenu}
       className={cn(
-        'titlebar-no-drag w-full flex items-start gap-3 px-3 py-2.5 rounded-lg text-left transition-colors relative',
+        'titlebar-no-drag w-full flex items-start gap-3 px-3 py-2.5 rounded-md text-left transition-all relative',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-accent)]',
         active
-          ? 'bg-[var(--accent-soft)] text-[var(--text-primary)]'
+          ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
           : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
       )}
+      style={active ? { boxShadow: 'var(--shadow-card)' } : undefined}
     >
       {active && <span className="absolute left-0 top-2 bottom-2 w-[3px] rounded-full bg-[var(--accent)]" />}
       <MessageSquare size={16} className="mt-0.5 flex-shrink-0 opacity-50" />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          <p className="font-medium truncate flex-1">{task.title || t('common.newTask')}</p>
+          <span className="font-medium truncate flex-1">{task.title || t('common.newTask')}</span>
           {isStreaming ? (
             <Loader2 size={12} className="flex-shrink-0 animate-spin text-[var(--accent)]" />
           ) : hasUnread ? (
             <Circle size={6} className="flex-shrink-0 fill-[var(--accent)] text-[var(--accent)]" />
           ) : null}
         </div>
-        <div className="flex items-center gap-1.5 mt-0.5">
+        <div className="flex items-center gap-x-1.5 gap-y-1 mt-1 flex-wrap">
           {task.status === 'completed' && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)]">
+            <span className="text-[11px] leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)]">
               {t('common.completed')}
             </span>
           )}
@@ -111,7 +114,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed }: Tas
             <Tooltip>
               <TooltipTrigger asChild>
                 <span
-                  className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate"
+                  className="inline-flex items-center gap-1 text-[11px] leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate"
                   style={gwInfo.color ? { borderLeft: `2px solid ${gwInfo.color}` } : undefined}
                 >
                   <Server size={9} className="flex-shrink-0 opacity-60" />
@@ -124,7 +127,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed }: Tas
           {agentInfo && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate">
+                <span className="inline-flex items-center gap-1 text-[11px] leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate">
                   {agentInfo.identity?.emoji ? (
                     <span className="text-xs leading-none">{agentInfo.identity.emoji}</span>
                   ) : (
@@ -139,7 +142,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed }: Tas
           {modelLabel && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate">
+                <span className="inline-flex items-center gap-1 text-[11px] leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate">
                   <Cpu size={9} className="flex-shrink-0 opacity-60" />
                   {modelLabel}
                 </span>
@@ -147,7 +150,9 @@ export default function TaskItem({ task, active, onContextMenu, collapsed }: Tas
               <TooltipContent>{modelTooltip}</TooltipContent>
             </Tooltip>
           )}
-          <p className="text-xs text-[var(--text-muted)]">{formatRelativeTime(new Date(task.updatedAt))}</p>
+          <span className="text-[11px] leading-tight text-[var(--text-muted)]">
+            {formatRelativeTime(new Date(task.updatedAt))}
+          </span>
         </div>
       </div>
     </motion.button>

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -1,4 +1,13 @@
-import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent } from 'react';
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  type MouseEvent,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
   Plus,
@@ -41,6 +50,74 @@ import type { TaskStatus } from '@clawwork/shared';
 
 type ConfirmAction = 'reset' | 'delete' | null;
 
+function IconButton({
+  icon: Icon,
+  tooltip,
+  onClick,
+  className,
+  badge,
+  tooltipSide = 'right',
+}: {
+  icon: ComponentType<{ size: number; className?: string }>;
+  tooltip: string;
+  onClick: () => void;
+  className?: string;
+  badge?: ReactNode;
+  tooltipSide?: 'right' | 'top' | 'bottom' | 'left';
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={onClick}
+          className={cn(
+            'titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-md transition-colors relative',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-accent)]',
+            'active:scale-95',
+            className,
+          )}
+        >
+          <Icon size={16} />
+          {badge}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side={tooltipSide}>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function NavButton({
+  icon: Icon,
+  label,
+  active,
+  onClick,
+  badge,
+}: {
+  icon: ComponentType<{ size: number; className?: string }>;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  badge?: ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'titlebar-no-drag w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors relative',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-accent)]',
+        'active:scale-[0.98]',
+        active
+          ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+          : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
+      )}
+    >
+      <Icon size={16} className="opacity-60 flex-shrink-0" />
+      {label}
+      {badge}
+    </button>
+  );
+}
+
 export default function LeftNav() {
   const { t } = useTranslation();
   const tasks = useTaskStore((s) => s.tasks);
@@ -51,6 +128,7 @@ export default function LeftNav() {
   const removeTask = useTaskStore((s) => s.removeTask);
   const clearMessages = useMessageStore((s) => s.clearMessages);
   const addMessage = useMessageStore((s) => s.addMessage);
+  const setHighlightedMessage = useMessageStore((s) => s.setHighlightedMessage);
   const mainView = useUiStore((s) => s.mainView);
   const setMainView = useUiStore((s) => s.setMainView);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
@@ -171,9 +249,10 @@ export default function LeftNav() {
     if (result.type === 'artifact') {
       setMainView('files');
     } else {
-      setMainView('chat');
       const targetId = result.type === 'task' ? result.id : result.taskId;
       if (targetId) setActiveTask(targetId);
+      if (result.type === 'message') setHighlightedMessage(result.id);
+      setMainView('chat');
     }
   };
 
@@ -182,16 +261,16 @@ export default function LeftNav() {
     openMenu(e, taskId, status);
   };
 
-  const visibleTasks = tasks.filter((t) => t.status !== 'archived');
-  const activeTasks = visibleTasks.filter((t) => t.status === 'active');
-  const completedTasks = visibleTasks.filter((t) => t.status === 'completed');
+  const visibleTasks = useMemo(() => tasks.filter((t) => t.status !== 'archived'), [tasks]);
+  const activeTasks = useMemo(() => visibleTasks.filter((t) => t.status === 'active'), [visibleTasks]);
+  const completedTasks = useMemo(() => visibleTasks.filter((t) => t.status === 'completed'), [visibleTasks]);
 
   const CollapseToggleButton = (
     <Tooltip>
       <TooltipTrigger asChild>
         <button
           onClick={toggleLeftNavCollapsed}
-          className="titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors"
+          className="titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-md text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-accent)] active:scale-95"
         >
           {leftNavCollapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
         </button>
@@ -202,335 +281,8 @@ export default function LeftNav() {
     </Tooltip>
   );
 
-  if (leftNavCollapsed) {
-    return (
-      <div className="flex flex-col h-full pt-14 items-center py-2 gap-1 overflow-hidden">
-        {CollapseToggleButton}
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => startNewTask()}
-              className="titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--accent-dim)] text-[var(--accent)] hover:opacity-80 transition-opacity"
-            >
-              <Plus size={16} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">{t('common.newTask')}</TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => {
-                toggleLeftNavCollapsed();
-                focusSearch();
-              }}
-              className="titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors"
-            >
-              <Search size={16} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">{t('leftNav.searchTasks')}</TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => setMainView('files')}
-              className={cn(
-                'titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
-                mainView === 'files'
-                  ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
-                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
-              )}
-            >
-              <FolderOpen size={16} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">{t('common.fileManager')}</TooltipContent>
-        </Tooltip>
-
-        <div className="w-6 h-px bg-[var(--border)] my-1" />
-
-        <ScrollArea className="flex-1 w-full">
-          <div className="flex flex-col items-center gap-0.5 px-1.5">
-            {activeTasks.map((task) => (
-              <TaskItem
-                key={task.id}
-                task={task}
-                active={task.id === activeTaskId}
-                onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
-                collapsed
-              />
-            ))}
-            {completedTasks.length > 0 && activeTasks.length > 0 && (
-              <div className="w-6 h-px bg-[var(--border)] my-0.5" />
-            )}
-            {completedTasks.map((task) => (
-              <TaskItem
-                key={task.id}
-                task={task}
-                active={task.id === activeTaskId}
-                onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
-                collapsed
-              />
-            ))}
-          </div>
-        </ScrollArea>
-
-        <div className="w-6 h-px bg-[var(--border)] my-1" />
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => setMainView('archived')}
-              className={cn(
-                'titlebar-no-drag flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
-                mainView === 'archived'
-                  ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
-                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
-              )}
-            >
-              <Archive size={16} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">{t('leftNav.archivedChats')}</TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => setSettingsOpen(!settingsOpen)}
-              className={cn(
-                'titlebar-no-drag relative flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
-                settingsOpen
-                  ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
-                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
-              )}
-            >
-              <Settings size={16} />
-              {hasUpdate && <span className="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-[var(--accent)]" />}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">
-            {hasUpdate ? t('leftNav.updateAvailable') : t('leftNav.appSettings')}
-          </TooltipContent>
-        </Tooltip>
-
-        <ConnectionStatus gatewayStatus={aggregatedGwStatus} collapsed />
-
-        <DropdownMenu
-          open={isOpen}
-          onOpenChange={(open) => {
-            if (!open) closeMenu();
-          }}
-        >
-          <DropdownMenuTrigger className="sr-only" />
-          <DropdownMenuContent style={menuPos ? { position: 'fixed', left: menuPos.x, top: menuPos.y } : undefined}>
-            {items.map((item) => (
-              <DropdownMenuItem
-                key={item.label}
-                danger={item.danger}
-                disabled={item.disabled}
-                onClick={() => {
-                  item.action();
-                  closeMenu();
-                }}
-              >
-                {item.label}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        <Dialog
-          open={confirmAction !== null}
-          onOpenChange={(open) => {
-            if (!open) setConfirmAction(null);
-          }}
-        >
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {confirmAction === 'reset' ? t('dialog.resetSessionTitle') : t('dialog.deleteTaskTitle')}
-              </DialogTitle>
-              <DialogDescription>
-                {confirmAction === 'reset' ? t('dialog.resetSessionDesc') : t('dialog.deleteTaskDesc')}
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter className="mt-4">
-              <Button variant="outline" onClick={() => setConfirmAction(null)}>
-                {t('common.cancel')}
-              </Button>
-              <Button
-                variant={confirmAction === 'delete' ? 'danger' : 'default'}
-                onClick={confirmAction === 'reset' ? handleResetConfirm : handleDeleteConfirm}
-              >
-                {t('dialog.confirm')}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col h-full pt-14 relative">
-      <div className="absolute top-[8px] right-2 z-[51]">{CollapseToggleButton}</div>
-      <div className="px-4 pb-3 space-y-2 flex-shrink-0">
-        {hasMultipleGateways ? (
-          <div className="titlebar-no-drag flex items-center gap-0.5">
-            <Button variant="soft" onClick={() => startNewTask()} className="flex-1 gap-2 rounded-r-none">
-              <Plus size={16} /> {t('common.newTask')}
-            </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="soft" className="px-1.5 rounded-l-none border-l border-[var(--border)]">
-                  <ChevronDown size={14} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-[160px]">
-                {connectedGateways.map((gw) => (
-                  <DropdownMenuItem key={gw.id} onClick={() => startNewTask(gw.id)}>
-                    {gw.color ? (
-                      <span className="mr-2 w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: gw.color }} />
-                    ) : (
-                      <Server size={12} className="mr-2 flex-shrink-0 opacity-60" />
-                    )}
-                    {gw.name}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        ) : (
-          <Button variant="soft" onClick={() => startNewTask()} className="titlebar-no-drag w-full gap-2">
-            <Plus size={16} /> {t('common.newTask')}
-          </Button>
-        )}
-        <div className="titlebar-no-drag relative">
-          <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
-          <input
-            ref={searchInputRef}
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder={t('leftNav.searchTasks')}
-            className="w-full h-9 pl-9 pr-3 rounded-lg bg-[var(--bg-tertiary)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--border-accent)] transition-colors"
-          />
-        </div>
-      </div>
-
-      <div className="relative flex-1 min-h-0">
-        <AnimatePresence>
-          {searchQuery.trim() && (
-            <motion.div
-              initial={{ opacity: 0, y: -4 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.15 }}
-              className="absolute inset-0 z-10 bg-[var(--bg-elevated)] border-t border-[var(--border)]"
-            >
-              <SearchResults results={searchResults} onSelect={handleSelectResult} />
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        <div className="flex flex-col h-full">
-          <div className="px-4 pb-2 flex-shrink-0">
-            <button
-              onClick={() => setMainView('files')}
-              className={cn(
-                'titlebar-no-drag w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
-                mainView === 'files'
-                  ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
-                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
-              )}
-            >
-              <FolderOpen size={16} className="opacity-60" /> {t('common.fileManager')}
-            </button>
-          </div>
-
-          <ScrollArea className="flex-1 px-4">
-            <div className="space-y-0.5">
-              {visibleTasks.length === 0 && (
-                <p className="text-xs text-[var(--text-muted)] text-center py-8">{t('leftNav.emptyHint')}</p>
-              )}
-              {activeTasks.length > 0 && (
-                <>
-                  <p className="text-xs uppercase tracking-wider text-[var(--text-muted)] px-3 py-2">
-                    {t('common.inProgress')} ({activeTasks.length})
-                  </p>
-                  {activeTasks.map((task) => (
-                    <TaskItem
-                      key={task.id}
-                      task={task}
-                      active={task.id === activeTaskId}
-                      onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
-                    />
-                  ))}
-                </>
-              )}
-              {completedTasks.length > 0 && (
-                <>
-                  <p className="text-xs uppercase tracking-wider text-[var(--text-muted)] px-3 py-2 mt-3">
-                    {t('common.completed')} ({completedTasks.length})
-                  </p>
-                  {completedTasks.map((task) => (
-                    <TaskItem
-                      key={task.id}
-                      task={task}
-                      active={task.id === activeTaskId}
-                      onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
-                    />
-                  ))}
-                </>
-              )}
-            </div>
-          </ScrollArea>
-        </div>
-      </div>
-
-      <div className="flex-shrink-0 px-4 py-3 border-t border-[var(--border)] space-y-1">
-        <button
-          onClick={() => setMainView('archived')}
-          className={cn(
-            'titlebar-no-drag w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
-            mainView === 'archived'
-              ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
-              : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
-          )}
-        >
-          <Archive size={16} className="opacity-60" /> {t('leftNav.archivedChats')}
-        </button>
-        <div className="flex items-center gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={() => setSettingsOpen(!settingsOpen)}
-                className={cn(
-                  'titlebar-no-drag relative flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
-                  settingsOpen
-                    ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
-                    : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]',
-                )}
-              >
-                <Settings size={16} className="opacity-60" /> {t('common.settings')}
-                {hasUpdate && <span className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-[var(--accent)]" />}
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              {hasUpdate ? t('leftNav.updateAvailable') : t('leftNav.appSettings')}
-            </TooltipContent>
-          </Tooltip>
-          <div className="ml-auto">
-            <ConnectionStatus gatewayStatus={aggregatedGwStatus} />
-          </div>
-        </div>
-      </div>
-
+  const overlays = (
+    <>
       <DropdownMenu
         open={isOpen}
         onOpenChange={(open) => {
@@ -583,6 +335,255 @@ export default function LeftNav() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </>
+  );
+
+  if (leftNavCollapsed) {
+    return (
+      <div className="flex flex-col h-full items-center py-2 gap-1 overflow-hidden">
+        <div className="flex-shrink-0 flex items-center justify-center w-full h-12">{CollapseToggleButton}</div>
+
+        <IconButton
+          icon={Plus}
+          tooltip={t('common.newTask')}
+          onClick={() => startNewTask()}
+          className="bg-[var(--accent-dim)] text-[var(--accent)] hover:opacity-80"
+        />
+
+        <IconButton
+          icon={Search}
+          tooltip={t('leftNav.searchTasks')}
+          onClick={() => {
+            toggleLeftNavCollapsed();
+            focusSearch();
+          }}
+          className="text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+        />
+
+        <IconButton
+          icon={FolderOpen}
+          tooltip={t('common.fileManager')}
+          onClick={() => setMainView('files')}
+          className={
+            mainView === 'files'
+              ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+              : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+          }
+        />
+
+        <div className="w-6 h-px bg-[var(--border)] my-1" />
+
+        <ScrollArea className="flex-1 w-full">
+          <div className="flex flex-col items-center gap-0.5 px-1.5">
+            {activeTasks.map((task) => (
+              <TaskItem
+                key={task.id}
+                task={task}
+                active={task.id === activeTaskId}
+                onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
+                collapsed
+              />
+            ))}
+            {completedTasks.length > 0 && activeTasks.length > 0 && (
+              <div className="w-6 h-px bg-[var(--border)] my-0.5" />
+            )}
+            {completedTasks.map((task) => (
+              <TaskItem
+                key={task.id}
+                task={task}
+                active={task.id === activeTaskId}
+                onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
+                collapsed
+              />
+            ))}
+          </div>
+        </ScrollArea>
+
+        <div className="w-6 h-px bg-[var(--border)] my-1" />
+
+        <IconButton
+          icon={Archive}
+          tooltip={t('leftNav.archivedChats')}
+          onClick={() => setMainView('archived')}
+          className={
+            mainView === 'archived'
+              ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+              : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+          }
+        />
+
+        <IconButton
+          icon={Settings}
+          tooltip={hasUpdate ? t('leftNav.updateAvailable') : t('leftNav.appSettings')}
+          onClick={() => setSettingsOpen(!settingsOpen)}
+          className={
+            settingsOpen
+              ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+              : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+          }
+          badge={
+            hasUpdate ? (
+              <span className="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-[var(--accent)]" />
+            ) : undefined
+          }
+        />
+
+        <ConnectionStatus gatewayStatus={aggregatedGwStatus} collapsed />
+
+        {overlays}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full pt-14 relative">
+      <div className="absolute top-[8px] right-2 z-[51]">{CollapseToggleButton}</div>
+      <div className="px-4 pb-3 space-y-2 flex-shrink-0">
+        {hasMultipleGateways ? (
+          <div className="titlebar-no-drag flex items-center gap-0.5">
+            <Button variant="soft" onClick={() => startNewTask()} className="flex-1 gap-2 rounded-r-none">
+              <Plus size={16} /> {t('common.newTask')}
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="soft" className="px-1.5 rounded-l-none border-l border-[var(--border)]">
+                  <ChevronDown size={14} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[160px]">
+                {connectedGateways.map((gw) => (
+                  <DropdownMenuItem key={gw.id} onClick={() => startNewTask(gw.id)}>
+                    {gw.color ? (
+                      <span className="mr-2 w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: gw.color }} />
+                    ) : (
+                      <Server size={12} className="mr-2 flex-shrink-0 opacity-60" />
+                    )}
+                    {gw.name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        ) : (
+          <Button variant="soft" onClick={() => startNewTask()} className="titlebar-no-drag w-full gap-2">
+            <Plus size={16} /> {t('common.newTask')}
+          </Button>
+        )}
+        <div className="titlebar-no-drag relative">
+          <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={t('leftNav.searchTasks')}
+            className="w-full h-9 pl-9 pr-3 rounded-md bg-[var(--bg-primary)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus:ring-2 focus:ring-[var(--ring-accent)] focus:border-transparent transition-all"
+          />
+        </div>
+      </div>
+
+      <div className="relative flex-1 min-h-0">
+        <AnimatePresence>
+          {searchQuery.trim() && (
+            <motion.div
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -4 }}
+              transition={{ duration: 0.15 }}
+              className="absolute inset-0 z-10 bg-[var(--bg-elevated)] border-t border-[var(--border)]"
+            >
+              <SearchResults results={searchResults} onSelect={handleSelectResult} />
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <div className="flex flex-col h-full">
+          <div className="px-4 pb-2 flex-shrink-0">
+            <NavButton
+              icon={FolderOpen}
+              label={t('common.fileManager')}
+              active={mainView === 'files'}
+              onClick={() => setMainView('files')}
+            />
+          </div>
+
+          <ScrollArea className="flex-1 px-4">
+            <div className="space-y-0.5">
+              {visibleTasks.length === 0 && (
+                <p className="text-xs text-[var(--text-muted)] text-center py-8">{t('leftNav.emptyHint')}</p>
+              )}
+              {activeTasks.length > 0 && (
+                <>
+                  <p className="text-xs font-medium uppercase tracking-wider text-[var(--text-secondary)] px-3 py-2">
+                    {t('common.inProgress')} ({activeTasks.length})
+                  </p>
+                  {activeTasks.map((task) => (
+                    <TaskItem
+                      key={task.id}
+                      task={task}
+                      active={task.id === activeTaskId}
+                      onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
+                      multiGateway={hasMultipleGateways}
+                    />
+                  ))}
+                </>
+              )}
+              {completedTasks.length > 0 && (
+                <>
+                  <p className="text-xs font-medium uppercase tracking-wider text-[var(--text-secondary)] px-3 py-2 mt-3">
+                    {t('common.completed')} ({completedTasks.length})
+                  </p>
+                  {completedTasks.map((task) => (
+                    <TaskItem
+                      key={task.id}
+                      task={task}
+                      active={task.id === activeTaskId}
+                      onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
+                      multiGateway={hasMultipleGateways}
+                    />
+                  ))}
+                </>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+      </div>
+
+      <div className="flex-shrink-0 px-4 py-2 border-t border-[var(--border)]">
+        <div className="flex items-center">
+          <IconButton
+            icon={Archive}
+            tooltip={t('leftNav.archivedChats')}
+            onClick={() => setMainView('archived')}
+            tooltipSide="top"
+            className={
+              mainView === 'archived'
+                ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+            }
+          />
+          <div className="flex-1" />
+          <ConnectionStatus gatewayStatus={aggregatedGwStatus} collapsed className="mr-1.5" />
+          <IconButton
+            icon={Settings}
+            tooltip={hasUpdate ? t('leftNav.updateAvailable') : t('leftNav.appSettings')}
+            onClick={() => setSettingsOpen(true)}
+            tooltipSide="top"
+            className={
+              settingsOpen
+                ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+            }
+            badge={
+              hasUpdate ? (
+                <span className="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-[var(--accent)]" />
+              ) : undefined
+            }
+          />
+        </div>
+      </div>
+
+      {overlays}
     </div>
   );
 }

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -3,8 +3,10 @@ import { motion, AnimatePresence } from 'framer-motion';
 import {
   PanelRightOpen,
   PanelRightClose,
-  RotateCcw,
   Archive,
+  ArchiveRestore,
+  Search,
+  MessageSquare,
   Server,
   Bot,
   Cpu,
@@ -578,8 +580,21 @@ function ArchivedTasks() {
   const setActiveTask = useTaskStore((s) => s.setActiveTask);
   const updateTaskStatus = useTaskStore((s) => s.updateTaskStatus);
   const setMainView = useUiStore((s) => s.setMainView);
+  const gwInfoMap = useUiStore((s) => s.gatewayInfoMap);
+  const [searchQuery, setSearchQuery] = useState('');
 
-  const archivedTasks = useMemo(() => tasks.filter((task) => task.status === 'archived'), [tasks]);
+  const archivedTasks = useMemo(() => {
+    const archived = tasks.filter((task) => task.status === 'archived');
+    if (!searchQuery.trim()) return archived;
+    const q = searchQuery.toLowerCase();
+    return archived.filter((task) => {
+      const title = (task.title || '').toLowerCase();
+      const gwName = (gwInfoMap[task.gatewayId]?.name || '').toLowerCase();
+      return title.includes(q) || gwName.includes(q);
+    });
+  }, [tasks, searchQuery, gwInfoMap]);
+
+  const totalArchived = useMemo(() => tasks.filter((task) => task.status === 'archived').length, [tasks]);
 
   const handleReactivate = (taskId: string): void => {
     updateTaskStatus(taskId, 'active');
@@ -595,53 +610,82 @@ function ArchivedTasks() {
       <header className="flex items-center gap-2.5 h-12 px-5 border-b border-[var(--border)] flex-shrink-0">
         <Archive size={18} className="text-[var(--text-muted)]" />
         <h2 className="font-medium text-[var(--text-primary)]">{t('leftNav.archivedChats')}</h2>
-        <span className="text-xs text-[var(--text-muted)]">({archivedTasks.length})</span>
+        <span className="text-xs text-[var(--text-muted)]">({totalArchived})</span>
       </header>
-      <ScrollArea className="flex-1 px-6 py-4">
-        <div className="max-w-3xl mx-auto">
+      {totalArchived > 0 && (
+        <div className="px-5 py-3 flex-shrink-0">
+          <div className="relative max-w-md">
+            <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t('leftNav.searchTasks')}
+              className="w-full h-9 pl-9 pr-3 rounded-md bg-[var(--bg-primary)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus:ring-2 focus:ring-[var(--ring-accent)] focus:border-transparent transition-all"
+            />
+          </div>
+        </div>
+      )}
+      <ScrollArea className="flex-1 px-5">
+        <div className="max-w-3xl">
           {archivedTasks.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 text-center">
               <Archive size={40} className="text-[var(--text-muted)] opacity-40 mb-4" />
-              <p className="text-sm text-[var(--text-muted)]">{t('archived.empty')}</p>
+              <p className="text-sm text-[var(--text-muted)]">
+                {searchQuery.trim() ? t('search.noResults') : t('archived.empty')}
+              </p>
             </div>
           ) : (
-            <AnimatePresence>
-              {archivedTasks.map((task) => (
-                <motion.div
-                  key={task.id}
-                  {...motionPresets.listItem}
-                  exit={{ opacity: 0, x: -8 }}
-                  layout
-                  className="flex items-center gap-3 px-4 py-3 mb-2 rounded-lg bg-[var(--bg-secondary)] border border-[var(--border)] hover:border-[var(--border-accent)] transition-colors cursor-pointer group"
-                  onClick={() => handleOpenTask(task.id)}
-                >
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-[var(--text-primary)] truncate">
-                      {task.title || t('common.noTitle')}
-                    </p>
-                    <p className="text-xs text-[var(--text-muted)] mt-0.5">
-                      {formatRelativeTime(new Date(task.updatedAt))}
-                    </p>
-                  </div>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleReactivate(task.id);
-                        }}
-                      >
-                        <RotateCcw size={14} />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>{t('contextMenu.reactivate')}</TooltipContent>
-                  </Tooltip>
-                </motion.div>
-              ))}
-            </AnimatePresence>
+            <>
+              <div className="grid grid-cols-[1fr_minmax(80px,120px)_80px_32px] gap-x-3 items-center px-3 py-1.5 text-[11px] uppercase tracking-wider text-[var(--text-muted)]">
+                <span>{t('common.task')}</span>
+                <span>Gateway</span>
+                <span>{t('common.time')}</span>
+                <span />
+              </div>
+              <AnimatePresence>
+                {archivedTasks.map((task) => {
+                  const gwName = gwInfoMap[task.gatewayId]?.name;
+                  return (
+                    <motion.div
+                      key={task.id}
+                      {...motionPresets.listItem}
+                      exit={{ opacity: 0, x: -8 }}
+                      layout
+                      className="grid grid-cols-[1fr_minmax(80px,120px)_80px_32px] gap-x-3 items-center px-3 py-2 rounded-md hover:bg-[var(--bg-hover)] transition-colors cursor-pointer group"
+                      onClick={() => handleOpenTask(task.id)}
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <MessageSquare size={14} className="flex-shrink-0 text-[var(--text-muted)] opacity-50" />
+                        <span className="text-sm text-[var(--text-primary)] truncate">
+                          {task.title || t('common.noTitle')}
+                        </span>
+                      </div>
+                      <span className="text-xs text-[var(--text-muted)] truncate">{gwName || '-'}</span>
+                      <span className="text-xs text-[var(--text-muted)] whitespace-nowrap">
+                        {formatRelativeTime(new Date(task.updatedAt))}
+                      </span>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="opacity-0 group-hover:opacity-100 transition-opacity w-7 h-7"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleReactivate(task.id);
+                            }}
+                          >
+                            <ArchiveRestore size={14} />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>{t('contextMenu.reactivate')}</TooltipContent>
+                      </Tooltip>
+                    </motion.div>
+                  );
+                })}
+              </AnimatePresence>
+            </>
           )}
         </div>
       </ScrollArea>


### PR DESCRIPTION
## Summary

Comprehensive UI polish pass on the left sidebar navigation. Fixes design system compliance (hover/press/focus states, border radius, active depth), restructures the bottom toolbar, adds search + grid layout to archived tasks, hides macOS traffic lights when sidebar is collapsed, and adds message highlight on search result navigation.

## Type of change

- [x] `[UI]` UI or UX change

## Why is this needed?

The left sidebar had multiple design system violations (missing press/focus states, wrong border radius, weak active indicator), a cramped bottom bar, no search for archived tasks, and macOS traffic lights overflowed when the sidebar was collapsed to 52px.

## What changed?

- **TaskItem**: active state uses `bg-elevated` + `shadow-card` for depth; added `whileTap` press feedback and `focus-visible` ring; fixed `rounded-lg` (8px) to `rounded-md` (6px); bumped metadata tags from 10px to 11px; added `flex-wrap` on metadata row; fixed `<p>` inside `<button>` (semantic); moved `multiGateway` selector to parent prop
- **LeftNav**: extracted `IconButton` and `NavButton` components to replace duplicated raw buttons; deduplicated context menu + confirm dialog (~50 lines); added `useMemo` for task filtering; search input uses `bg-primary` (inset) + focus ring; section headers use `text-secondary` + `font-medium`; bottom bar compressed to icon row (Archive left, Settings right, connection dot between)
- **LeftNav search**: message results now call `setHighlightedMessage` to scroll-to + highlight the matched message
- **ArchivedTasks**: added search input; switched from card layout to CSS Grid table (Task / Gateway / Time / Restore columns); replaced `RotateCcw` icon with `ArchiveRestore`
- **Traffic lights**: added `ui:set-window-button-visibility` IPC (main + preload); App.tsx hides macOS traffic lights when collapsed, expand button moves to traffic light position
- **i18n**: added `common.task` and `common.time` keys to en.json / zh.json

## Architecture impact

- Owning layer: renderer (primary), main + preload (IPC addition)
- Cross-layer impact: yes — new `ui:set-window-button-visibility` IPC channel from renderer to main for macOS `setWindowButtonVisibility()`
- Invariants touched: none — new IPC is fire-and-forget, platform-gated to darwin only
- Why those invariants remain protected: single-purpose IPC with no state mutation beyond native window chrome

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm lint` (via pre-commit hook)
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm typecheck → EXIT: 0
git commit (lint-staged + eslint + prettier + architecture check) → passed
```

## Screenshots or recordings

N/A — requires running Electron app to verify

Design system tokens preserved: `--bg-elevated`, `--shadow-card`, `--ring-accent`, `--accent-dim`, `--border`. Border radius unified to `rounded-md` (6px) matching `--radius` variable. All interactive elements now implement hover + press + focus states per design system spec.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Polish left sidebar: stronger active task indicator, press/focus feedback on all buttons, compressed bottom toolbar, archived task search with grid layout, hide macOS traffic lights when sidebar collapsed.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate