### PR TITLE
fix(ui): align task context menu to click position

### DIFF
--- a/packages/desktop/src/renderer/components/ContextMenu.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu.tsx
@@ -1,5 +1,7 @@
-import { useState, useCallback, type MouseEvent } from 'react';
+import { useState, useCallback, useEffect, useLayoutEffect, useRef, type MouseEvent } from 'react';
+import { createPortal } from 'react-dom';
 import type { TaskStatus } from '@clawwork/shared';
+import { cn } from '@/lib/utils';
 import i18n from '../i18n';
 
 export interface MenuItem {
@@ -92,4 +94,128 @@ export function useTaskContextMenu(
     openMenu,
     closeMenu,
   };
+}
+
+interface TaskContextMenuPopoverProps {
+  open: boolean;
+  position: { x: number; y: number } | null;
+  items: MenuItem[];
+  onClose: () => void;
+}
+
+const VIEWPORT_PADDING = 8;
+
+export function TaskContextMenuPopover({ open, position, items, onClose }: TaskContextMenuPopoverProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [clamped, setClamped] = useState<{ x: number; y: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || !position) {
+      setClamped(null);
+      return;
+    }
+    const el = menuRef.current;
+    if (!el) return;
+    const { width, height } = el.getBoundingClientRect();
+    const x = Math.min(position.x, window.innerWidth - width - VIEWPORT_PADDING);
+    const y = Math.min(position.y, window.innerHeight - height - VIEWPORT_PADDING);
+    setClamped({ x: Math.max(VIEWPORT_PADDING, x), y: Math.max(VIEWPORT_PADDING, y) });
+  }, [open, position]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleDown = (e: globalThis.MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose();
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      const el = menuRef.current;
+      if (!el) return;
+      const focusable = Array.from(el.querySelectorAll<HTMLButtonElement>('button:not(:disabled)'));
+      if (focusable.length === 0) return;
+      const active = document.activeElement as HTMLElement;
+      const idx = focusable.indexOf(active as HTMLButtonElement);
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        focusable[(idx + 1) % focusable.length].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        focusable[(idx - 1 + focusable.length) % focusable.length].focus();
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        focusable[0].focus();
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        focusable[focusable.length - 1].focus();
+      }
+    };
+    const dismiss = () => onClose();
+
+    document.addEventListener('mousedown', handleDown, true);
+    document.addEventListener('keydown', handleKey, true);
+    window.addEventListener('blur', dismiss);
+    window.addEventListener('resize', dismiss);
+    document.addEventListener('contextmenu', dismiss, true);
+
+    return () => {
+      document.removeEventListener('mousedown', handleDown, true);
+      document.removeEventListener('keydown', handleKey, true);
+      window.removeEventListener('blur', dismiss);
+      window.removeEventListener('resize', dismiss);
+      document.removeEventListener('contextmenu', dismiss, true);
+    };
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() => {
+      const el = menuRef.current;
+      if (!el) return;
+      const first = el.querySelector<HTMLButtonElement>('button:not(:disabled)');
+      first?.focus();
+    });
+  }, [open]);
+
+  if (!open || !position) return null;
+
+  const pos = clamped ?? position;
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      style={{ position: 'fixed', left: pos.x, top: pos.y }}
+      className="z-50 min-w-[8rem] overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-1 text-[var(--text-primary)] shadow-[var(--shadow-elevated)] animate-in fade-in-0 zoom-in-95"
+    >
+      {items.map((item) => (
+        <button
+          key={item.label}
+          role="menuitem"
+          tabIndex={-1}
+          disabled={item.disabled}
+          onClick={() => {
+            item.action();
+            onClose();
+          }}
+          className={cn(
+            'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
+            'hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]',
+            'focus-visible:bg-[var(--bg-hover)] focus-visible:text-[var(--text-primary)] focus-visible:outline-none',
+            'disabled:pointer-events-none disabled:opacity-50',
+            item.danger
+              ? 'text-[var(--danger)] hover:bg-[var(--danger-bg)] hover:text-[var(--danger)] focus-visible:bg-[var(--danger-bg)] focus-visible:text-[var(--danger)]'
+              : 'text-[var(--text-secondary)]',
+          )}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>,
+    document.body,
+  );
 }

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
 import { useUiStore } from '@/stores/uiStore';
-import { useTaskContextMenu, type SessionActions } from '@/components/ContextMenu';
+import { useTaskContextMenu, TaskContextMenuPopover, type SessionActions } from '@/components/ContextMenu';
 import SearchResults, { type SearchResult } from '@/components/SearchResults';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -283,29 +283,7 @@ export default function LeftNav() {
 
   const overlays = (
     <>
-      <DropdownMenu
-        open={isOpen}
-        onOpenChange={(open) => {
-          if (!open) closeMenu();
-        }}
-      >
-        <DropdownMenuTrigger className="sr-only" />
-        <DropdownMenuContent style={menuPos ? { position: 'fixed', left: menuPos.x, top: menuPos.y } : undefined}>
-          {items.map((item) => (
-            <DropdownMenuItem
-              key={item.label}
-              danger={item.danger}
-              disabled={item.disabled}
-              onClick={() => {
-                item.action();
-                closeMenu();
-              }}
-            >
-              {item.label}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <TaskContextMenuPopover open={isOpen} position={menuPos} items={items} onClose={closeMenu} />
 
       <Dialog
         open={confirmAction !== null}


### PR DESCRIPTION
## Summary

Fix task context menu positioning by replacing Radix DropdownMenu with a portal-based TaskContextMenuPopover that renders at the exact click coordinates, with viewport clamping, keyboard navigation, and proper ARIA semantics.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Radix's internal Popper positioning applies CSS transforms relative to the hidden `sr-only` trigger element. When combined with manual `position: fixed` styling on the menu content, the menu consistently appears offset from the actual right-click location. This makes the context menu feel broken and misaligned.

## What changed?

- Replaced Radix `DropdownMenu` (with hidden sr-only trigger) in the `overlays` variable with a new `TaskContextMenuPopover` component
- `TaskContextMenuPopover` uses `createPortal` + `position: fixed` at click coordinates for precise placement
- Added viewport edge clamping via `useLayoutEffect` measurement so the menu never renders off-screen
- Added `role="menu"` / `role="menuitem"` ARIA semantics and `tabIndex={-1}` for proper accessibility
- Added keyboard navigation: auto-focus first item on open, Arrow Up/Down, Home/End key support
- Added `focus-visible` styling on menu items per `docs/design-system.md`
- Added dismiss on `window.blur`, `resize`, and secondary `contextmenu` events to prevent stranded menus

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: changes are entirely within the renderer UI layer; no protocol, IPC, or state management boundaries are crossed

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck` (shared + desktop)
- [ ] `pnpm build`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm --filter @clawwork/shared exec tsc -b && pnpm --filter @clawwork/desktop exec tsc --noEmit
# Architecture guardrails passed via pre-commit hook
```

## Screenshots or recordings

N/A — behavior change only (menu now appears at click position instead of offset).

Design tokens preserved: uses `--border-subtle`, `--bg-elevated`, `--text-primary`, `--shadow-elevated`, `--bg-hover`, `--text-secondary`, `--danger`, `--danger-bg` CSS variables. Focus state uses `focus-visible:bg-[var(--bg-hover)]` consistent with design system.

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Fixed right-click context menu in the task list appearing offset from the click position.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate