### PR TITLE
chore(desktop): bump version to 0.0.8

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawwork/desktop",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "description": "OpenClaw desktop client with structured task management",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump desktop version from 0.0.7 to 0.0.8

## Type of change

- [x] `[Build]` CI, packaging, or tooling change

## What changed?

release to 0.0.8

## Validation

- [x] Not run