### PR TITLE
[Fix] Add try/catch to ws:abort-chat IPC handler

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -375,8 +375,13 @@ export function registerWsHandlers(): void {
   ipcMain.handle('ws:abort-chat', async (_event, payload: { gatewayId: string; sessionKey: string }) => {
     const gw = getGatewayClient(payload.gatewayId);
     if (!gw?.isConnected) return { ok: false, error: 'gateway not connected' };
-    await gw.abortChat(payload.sessionKey);
-    return { ok: true };
+    try {
+      await gw.abortChat(payload.sessionKey);
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      return { ok: false, error: msg };
+    }
   });
 
   ipcMain.handle(


### PR DESCRIPTION
## Summary

The `ws:abort-chat` IPC handler was the only async handler in `ws-handlers.ts` without a try/catch block. When `gw.abortChat()` throws on network error or timeout, the unhandled promise rejection crashes the Electron main process, killing all windows and losing unsaved state.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

An unhandled rejection in an `ipcMain.handle` callback crashes the entire Electron app. Every other async handler in this file already wraps gateway calls in try/catch — this one was simply missed.

## What changed?

- Wrapped `gw.abortChat()` call in try/catch, returning `{ ok: false, error }` on failure instead of crashing
- Matches the exact error-handling pattern used by all other async IPC handlers in the same file

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched: none
- Why those invariants remain protected: N/A — pure error handling addition

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Audited all other async IPC handlers in ws-handlers.ts — all have try/catch

Commands, screenshots, or notes:

```text
pnpm typecheck — passed with zero errors
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate