### PR TITLE
[Fix] Serialize git operations and eliminate TOCTOU race in artifact file naming

### DIFF
--- a/packages/desktop/src/main/artifact/auto-extract.ts
+++ b/packages/desktop/src/main/artifact/auto-extract.ts
@@ -49,7 +49,9 @@ export async function autoExtractArtifacts(params: AutoExtractParams): Promise<v
       saved.push(
         await saveArtifactFromBuffer({ workspacePath, taskId, messageId, fileName, buffer, artifactType: 'image' }),
       );
-    } catch {}
+    } catch (err) {
+      console.error('[auto-extract] image save failed:', err);
+    }
   }
 
   for (const block of codeBlocks) {
@@ -65,7 +67,9 @@ export async function autoExtractArtifacts(params: AutoExtractParams): Promise<v
           contentText: block.content,
         }),
       );
-    } catch {}
+    } catch (err) {
+      console.error('[auto-extract] code block save failed:', err);
+    }
   }
 
   if (saved.length === 0) return;

--- a/packages/desktop/src/main/artifact/git.ts
+++ b/packages/desktop/src/main/artifact/git.ts
@@ -1,30 +1,45 @@
 import simpleGit from 'simple-git';
 import { basename } from 'path';
 
+let gitQueue = Promise.resolve<unknown>(undefined);
+
+function enqueueGitOp<T>(fn: () => Promise<T>): Promise<T> {
+  const op = gitQueue.then(fn, fn);
+  gitQueue = op.then(
+    () => {},
+    () => {},
+  );
+  return op;
+}
+
 export async function commitArtifact(workspacePath: string, localPath: string, message?: string): Promise<string> {
-  const git = simpleGit(workspacePath);
+  return enqueueGitOp(async () => {
+    const git = simpleGit(workspacePath);
 
-  await git.add(localPath);
+    await git.add(localPath);
 
-  const status = await git.status();
-  if (status.staged.length === 0) {
-    return '';
-  }
+    const status = await git.status();
+    if (status.staged.length === 0) {
+      return '';
+    }
 
-  const fileName = basename(localPath);
-  const commitMessage = message ?? `artifact: ${fileName}`;
-  const result = await git.commit(commitMessage);
+    const fileName = basename(localPath);
+    const commitMessage = message ?? `artifact: ${fileName}`;
+    const result = await git.commit(commitMessage);
 
-  return result.commit || '';
+    return result.commit || '';
+  });
 }
 
 export async function commitArtifactBatch(workspacePath: string, localPaths: string[]): Promise<string> {
-  const git = simpleGit(workspacePath);
-  for (const p of localPaths) {
-    await git.add(p);
-  }
-  const status = await git.status();
-  if (status.staged.length === 0) return '';
-  const result = await git.commit(`auto: extract ${localPaths.length} files from message`);
-  return result.commit || '';
+  return enqueueGitOp(async () => {
+    const git = simpleGit(workspacePath);
+    for (const p of localPaths) {
+      await git.add(p);
+    }
+    const status = await git.status();
+    if (status.staged.length === 0) return '';
+    const result = await git.commit(`auto: extract ${localPaths.length} files from message`);
+    return result.commit || '';
+  });
 }

--- a/packages/desktop/src/main/artifact/save.ts
+++ b/packages/desktop/src/main/artifact/save.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, statSync, writeFileSync } from 'fs';
+import { copyFileSync, statSync, writeFileSync } from 'fs';
 import { basename, extname, join } from 'path';
 import { randomUUID } from 'crypto';
 import type { Artifact } from '@clawwork/shared';
@@ -30,18 +30,10 @@ function detectMimeType(fileName: string): string {
   return MIME_MAP[ext] ?? 'application/octet-stream';
 }
 
-function uniqueFileName(dir: string, name: string): string {
-  if (!existsSync(join(dir, name))) return name;
-
+function uniqueFileName(_dir: string, name: string): string {
   const ext = extname(name);
   const base = name.slice(0, name.length - ext.length);
-  let counter = 1;
-  let candidate = `${base}-${counter}${ext}`;
-  while (existsSync(join(dir, candidate))) {
-    counter++;
-    candidate = `${base}-${counter}${ext}`;
-  }
-  return candidate;
+  return `${base}-${randomUUID().slice(0, 8)}${ext}`;
 }
 
 interface SaveArtifactParams {


### PR DESCRIPTION
## Summary

Concurrent git operations (from parallel task artifact saves and auto-extraction) race on the shared git index, causing `index.lock` failures and wrong files committed to wrong tasks. The `uniqueFileName` function has a TOCTOU race where `existsSync` check and file write are non-atomic, allowing concurrent saves to silently overwrite each other.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Multiple code paths trigger `git add` + `git commit` without serialization. `autoExtractArtifacts` is fire-and-forget on every assistant message. Parallel tasks cause concurrent git operations that race on the shared git index, leading to `index.lock` failures (silently swallowed by empty `catch {}`) and wrong files committed to wrong tasks. The `uniqueFileName` TOCTOU race causes two DB records to point to the same `localPath` where only the second file survives.

## What changed?

- **`git.ts`**: Added module-level promise queue (`enqueueGitOp`) that serializes all `commitArtifact` and `commitArtifactBatch` calls, preventing concurrent git index access
- **`save.ts`**: Replaced `existsSync`-based `uniqueFileName` with UUID-8 suffix naming (`{base}-{uuid8}{ext}`), eliminating the TOCTOU race entirely. Removed unused `existsSync` import
- **`auto-extract.ts`**: Replaced empty `catch {}` blocks with `console.error` logging so failures are no longer silently swallowed

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: changes are internal to the artifact persistence layer; no API surface changes

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passed (shared + desktop + website)
Pre-commit hooks (eslint, prettier, architecture check) — all passed
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate