### PR TITLE
[Fix] Fix IPC listener leak in onArtifactSaved and remove unsafe removeAllListeners API

### DIFF
--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -213,7 +213,6 @@ export interface ClawWorkAPI {
     feature?: string;
     data?: Record<string, unknown>;
   }) => void;
-  removeAllListeners: (channel: string) => void;
 
   // Data persistence
   loadTasks: () => Promise<ListResult<PersistedTask>>;
@@ -230,7 +229,7 @@ export interface ClawWorkAPI {
   listArtifacts: (taskId?: string) => Promise<IpcResult>;
   getArtifact: (id: string) => Promise<IpcResult>;
   readArtifactFile: (localPath: string) => Promise<IpcResult>;
-  onArtifactSaved: (callback: (artifact: unknown) => void) => void;
+  onArtifactSaved: (callback: (artifact: unknown) => void) => () => void;
   saveCodeBlock: (params: {
     taskId: string;
     messageId: string;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -77,7 +77,13 @@ function buildApi(): ClawWorkAPI {
     getArtifact: (id: string) => ipcRenderer.invoke('artifact:get', { id }),
     readArtifactFile: (localPath: string) => ipcRenderer.invoke('artifact:read-file', { localPath }),
     onArtifactSaved: (callback: (artifact: unknown) => void) => {
-      ipcRenderer.on('artifact:saved', (_event, artifact) => callback(artifact));
+      const listener = (_event: Electron.IpcRendererEvent, artifact: unknown): void => {
+        callback(artifact);
+      };
+      ipcRenderer.on('artifact:saved', listener);
+      return () => {
+        ipcRenderer.removeListener('artifact:saved', listener);
+      };
     },
     saveCodeBlock: (params) => ipcRenderer.invoke('artifact:save-content', params),
     saveImageFromUrl: (params) => ipcRenderer.invoke('artifact:save-image-url', params),
@@ -170,10 +176,6 @@ function buildApi(): ClawWorkAPI {
       ipcRenderer.invoke('ws:session-delete', { gatewayId, sessionKey }),
     compactSession: (gatewayId: string, sessionKey: string, maxLines?: number) =>
       ipcRenderer.invoke('ws:session-compact', { gatewayId, sessionKey, maxLines }),
-
-    removeAllListeners: (channel: string) => {
-      ipcRenderer.removeAllListeners(channel);
-    },
 
     updateTrayStatus: (status, tasks) => ipcRenderer.send('tray:update-status', { status, tasks: tasks ?? [] }),
     getTrayEnabled: () => ipcRenderer.invoke('tray:get-enabled') as Promise<boolean>,

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -71,9 +71,10 @@ export default function App() {
   );
 
   useEffect(() => {
-    window.clawwork.onArtifactSaved((artifact) => {
+    const cleanup = window.clawwork.onArtifactSaved((artifact) => {
       useFileStore.getState().addArtifactIfNew(artifact as import('@clawwork/shared').Artifact);
     });
+    return cleanup;
   }, []);
 
   useEffect(() => {

--- a/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
+++ b/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
@@ -79,10 +79,8 @@ export default function RightPanel() {
         return [a, ...prev];
       });
     };
-    window.clawwork.onArtifactSaved(handleArtifactSaved);
-    return () => {
-      window.clawwork.removeAllListeners('artifact:saved');
-    };
+    const cleanup = window.clawwork.onArtifactSaved(handleArtifactSaved);
+    return cleanup;
   }, [activeTaskId]);
 
   return (


### PR DESCRIPTION
## Summary

`onArtifactSaved` did not return a cleanup function, forcing callers to use `removeAllListeners('artifact:saved')` which nuked all listeners on that channel — including the global one in `App.tsx`. After switching tasks once, the `addArtifactIfNew` listener was permanently destroyed and new artifacts stopped appearing. This PR makes `onArtifactSaved` return a per-listener cleanup function and removes the unsafe `removeAllListeners` API entirely.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Two bugs:

1. **Listener leak + global listener destruction**: `RightPanel` called `removeAllListeners('artifact:saved')` on task switch, destroying the global `App.tsx` listener that feeds new artifacts into the file store. After one task switch, artifacts silently stopped appearing.

2. **Unsafe API surface**: `removeAllListeners(channel)` accepted any channel name from the renderer process. Misuse or XSS could call `removeAllListeners('gateway-event')` and silently disconnect all Gateway events with no recovery path.

## What changed?

- `preload/index.ts`: `onArtifactSaved` now captures the listener reference and returns a `() => void` cleanup function (matching the pattern already used by `onGatewayEvent`, `onGatewayStatus`, `onDebugEvent`, etc.)
- `preload/clawwork.d.ts`: Updated `onArtifactSaved` return type from `void` to `() => void`; removed `removeAllListeners` from the `ClawWorkAPI` interface
- `renderer/App.tsx`: useEffect now captures and returns the cleanup function
- `renderer/layouts/RightPanel/index.tsx`: Replaced `removeAllListeners('artifact:saved')` with the returned per-listener cleanup function

## Architecture impact

- Owning layer: preload + renderer
- Cross-layer impact: yes — preload API contract changed (return type of `onArtifactSaved`, removal of `removeAllListeners`). Both changes are backward-incompatible but all callers are updated in this PR.
- Invariants touched: preload exposes only safe, scoped IPC APIs to renderer
- Why those invariants remain protected: removing `removeAllListeners` strictly improves the security boundary; per-listener cleanup is the established pattern for all other `on*` APIs in the preload

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm lint` (via pre-commit hook)
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm typecheck — zero errors
pre-commit: eslint --fix, prettier --write, architecture guardrails — all passed
```

## Screenshots or recordings

N/A — no UI changes

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate