### PR TITLE
[Fix] Validate file paths in url scheme handlers to prevent arbitrary file read

### DIFF
--- a/packages/desktop/src/main/artifact/auto-extract.ts
+++ b/packages/desktop/src/main/artifact/auto-extract.ts
@@ -1,5 +1,6 @@
 import { net, BrowserWindow } from 'electron';
 import { readFileSync } from 'fs';
+import { resolve, sep } from 'path';
 import { extractImagesFromMarkdown, extractCodeBlocksFromMarkdown } from './extract.js';
 import { saveArtifactFromBuffer } from './save.js';
 import { commitArtifactBatch } from './git.js';
@@ -40,7 +41,9 @@ export async function autoExtractArtifacts(params: AutoExtractParams): Promise<v
       if (img.isRemote) {
         buffer = await fetchToBuffer(img.src);
       } else if (img.src.startsWith('clawwork-media://')) {
-        buffer = readFileSync(img.src.replace('clawwork-media://', ''));
+        const filePath = resolve(img.src.replace('clawwork-media://', ''));
+        if (!filePath.startsWith(resolve(workspacePath) + sep)) continue;
+        buffer = readFileSync(filePath);
       } else {
         continue;
       }

--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -170,7 +170,11 @@ export function registerArtifactHandlers(): void {
           if (!res.ok) return { ok: false, error: `fetch failed: ${res.status}` };
           buffer = Buffer.from(await res.arrayBuffer());
         } else if (url.startsWith('file://')) {
-          buffer = readFileSync(url.replace('file://', ''));
+          const filePath = resolve(url.replace('file://', ''));
+          if (!filePath.startsWith(resolve(workspacePath) + sep)) {
+            return { ok: false, error: 'file path outside workspace' };
+          }
+          buffer = readFileSync(filePath);
         } else {
           return { ok: false, error: 'unsupported url scheme' };
         }


### PR DESCRIPTION
## Summary

The `file://` handler in `artifact:save-image-url` and the `clawwork-media://` handler in `autoExtractArtifacts` both read files from user-supplied URLs without validating that the resolved path falls within the workspace directory. This allows path traversal attacks (e.g., `file:///etc/passwd`) to read arbitrary files on the host filesystem.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Both custom URL scheme handlers pass user-controlled paths directly to `readFileSync` after only stripping the scheme prefix. An attacker (or a malicious agent response containing a crafted image URL) could read any file accessible to the Electron main process. This is a critical security vulnerability.

## What changed?

- `artifact-handlers.ts`: Added `resolve()` + workspace boundary check before `readFileSync` in the `file://` branch. Returns an error if the path escapes the workspace.
- `auto-extract.ts`: Added `resolve()` + workspace boundary check before `readFileSync` in the `clawwork-media://` branch. Silently skips images with paths outside the workspace.
- Added `import { resolve, sep } from 'path'` to `auto-extract.ts` (already present in `artifact-handlers.ts`).

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: file access security boundary
- Why those invariants remain protected: paths are now validated against the workspace root before any filesystem read

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Grep confirmed no other `readFileSync(*.replace(` patterns remain in codebase

Commands, screenshots, or notes:

```text
$ pnpm typecheck
> pnpm --filter @clawwork/shared exec tsc -b && pnpm --filter @clawwork/desktop exec tsc --noEmit && pnpm --filter @clawwork/website exec tsc --noEmit
(exit 0)
```

## Screenshots or recordings

N/A (no UI change)

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate