### PR TITLE
[Fix] Prevent symlink traversal in context file reader and directory scanner

### DIFF
--- a/packages/desktop/src/main/context/file-index.ts
+++ b/packages/desktop/src/main/context/file-index.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync } from 'fs';
+import { readdirSync, lstatSync } from 'fs';
 import { join, extname, relative } from 'path';
 import type { FileIndexEntry } from '@clawwork/shared';
 import { classifyTier, getMimeType } from './file-types.js';
@@ -45,10 +45,12 @@ function walkDir(dir: string, rootDir: string, results: FileIndexEntry[], depth:
     const fullPath = join(dir, name);
     let stat;
     try {
-      stat = statSync(fullPath);
+      stat = lstatSync(fullPath);
     } catch {
       continue;
     }
+
+    if (stat.isSymbolicLink()) continue;
 
     if (stat.isDirectory()) {
       if (SKIP_DIRS.has(name)) continue;

--- a/packages/desktop/src/main/context/file-reader.ts
+++ b/packages/desktop/src/main/context/file-reader.ts
@@ -1,15 +1,15 @@
-import { openSync, readSync, closeSync, readFileSync, statSync } from 'fs';
-import { extname, resolve } from 'path';
+import { openSync, readSync, closeSync, readFileSync, realpathSync, statSync } from 'fs';
+import { extname, sep } from 'path';
 import type { FileReadResult } from '@clawwork/shared';
 import { classifyTier, getMimeType } from './file-types.js';
 
 const MAX_TEXT_SIZE = 100 * 1024;
 
 export function validatePathSecurity(absolutePath: string, contextFolders: string[]): boolean {
-  const normalized = resolve(absolutePath);
+  const realPath = realpathSync(absolutePath);
   return contextFolders.some((folder) => {
-    const normalizedFolder = resolve(folder);
-    return normalized.startsWith(normalizedFolder + '/') || normalized === normalizedFolder;
+    const realFolder = realpathSync(folder);
+    return realPath.startsWith(realFolder + sep) || realPath === realFolder;
   });
 }
 


### PR DESCRIPTION
## Summary

Context file reader used `resolve()` for path boundary checks, which does not follow symlinks — allowing an attacker to place a symlink inside a context directory pointing to sensitive files outside it (private keys, credentials, configs). The directory scanner used `statSync()` which follows symlinks, indexing files outside the allowed boundary. This PR fixes both vectors.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

A symlink placed inside a context folder (e.g., `ln -s /etc/passwd ./evil`) bypasses the directory boundary check because `resolve()` normalizes the logical path without resolving symlinks. The prefix comparison passes, and the file is read. Similarly, `scanFolder()` using `statSync()` follows symlinks and indexes external files into the file browser.

## What changed?

- `file-reader.ts`: Replace `resolve()` with `realpathSync()` in `validatePathSecurity()` so the real filesystem path is compared against the real folder path. Replace hardcoded `/` with `sep` for cross-platform correctness.
- `file-index.ts`: Replace `statSync()` with `lstatSync()` in `walkDir()` and skip entries where `stat.isSymbolicLink()` is true, preventing symlink traversal during directory scanning.

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: path security boundary enforcement
- Why those invariants remain protected: `realpathSync` resolves the true filesystem path before prefix comparison; `lstatSync` prevents following symlinks during scan

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passed (0 errors)
pnpm test — 15 test files, 64 tests, all passed
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate