### PR TITLE
[Fix] Reinit database on workspace setup to prevent stale connection

### DIFF
--- a/packages/desktop/src/main/ipc/workspace-handlers.ts
+++ b/packages/desktop/src/main/ipc/workspace-handlers.ts
@@ -7,7 +7,7 @@ import {
   getDefaultWorkspacePath,
 } from '../workspace/config.js';
 import { initWorkspace, migrateWorkspace } from '../workspace/init.js';
-import { initDatabase, reinitDatabase, closeDatabase } from '../db/index.js';
+import { reinitDatabase, closeDatabase } from '../db/index.js';
 
 export function registerWorkspaceHandlers(): void {
   ipcMain.handle('workspace:open-folder', () => {
@@ -36,7 +36,7 @@ export function registerWorkspaceHandlers(): void {
   ipcMain.handle('workspace:setup', async (_event, workspacePath: string) => {
     try {
       await initWorkspace(workspacePath);
-      initDatabase(workspacePath);
+      reinitDatabase(workspacePath);
       writeConfig({ workspacePath, gateways: [] });
       return { ok: true };
     } catch (err) {


### PR DESCRIPTION
## Summary

The `workspace:setup` IPC handler called `initDatabase()` which short-circuits when a database connection already exists. After switching workspaces, the database remained pointed at the old workspace path, causing silent cross-workspace data corruption. This PR replaces `initDatabase()` with `reinitDatabase()` which properly closes the existing connection before opening a new one.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

When a user switches workspaces, file writes go to the new workspace directory but all metadata (tasks, messages, artifacts) keeps writing to the old SQLite database. This causes silent cross-workspace data corruption that is extremely difficult to diagnose.

## What changed?

- Replaced `initDatabase(workspacePath)` with `reinitDatabase(workspacePath)` in the `workspace:setup` handler
- Removed unused `initDatabase` import from workspace-handlers.ts

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched: none — `reinitDatabase` already existed and was correctly used by the `workspace:change` handler
- Why those invariants remain protected: no new logic introduced; reusing existing proven function

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passed
pnpm test — 70/70 tests passed (including workspace-handlers.test.ts)
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate