### PR TITLE
[Fix] Validate WebSocket frame shape before dispatching events

### DIFF
--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -190,6 +190,14 @@ export class GatewayClient {
     }
 
     if (frame.type === 'event') {
+      if (typeof frame.event !== 'string' || !frame.payload || typeof frame.payload !== 'object') {
+        getDebugLogger().error({
+          domain: 'gateway',
+          event: 'gateway.frame.invalid-shape',
+          gatewayId: this.gatewayId,
+        });
+        return;
+      }
       getDebugLogger().debug({
         domain: 'gateway',
         event: 'gateway.event.received',
@@ -200,7 +208,7 @@ export class GatewayClient {
           payload: summarizePayload(frame.payload),
         },
       });
-      this.handleEvent(frame);
+      this.handleEvent(frame as { event: string; payload: Record<string, unknown>; seq?: number });
       return;
     }
 


### PR DESCRIPTION
## Summary

When the Gateway sends a JSON-valid but structurally invalid WebSocket frame (missing `event` string or `payload` object), `handleRaw()` passes it directly to `handleEvent()`, which then throws on `frame.payload.sessionKey` access or `frame.event.replace()`. This crashes the Electron main process. This PR adds shape validation before dispatch to silently discard malformed frames.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

A single malformed WebSocket frame from the Gateway can crash the entire desktop application. The main process has no try/catch around the event dispatch path, so any uncaught TypeError propagates and kills Electron.

## What changed?

- Added type guards in `GatewayClient.handleRaw()` before calling `handleEvent()`: validates `frame.event` is a `string` and `frame.payload` is a non-null `object`
- Invalid frames are logged as `gateway.frame.invalid-shape` errors and discarded
- Added explicit type assertion on the `handleEvent()` call for type safety

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched: none
- Why those invariants remain protected: change is purely additive validation in the WS message handler

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passed, zero errors
pnpm test — 70/70 tests passed (shared: 6, desktop: 64)
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate