### PR TITLE
[Feat] Scope sessions by device ID and sync titles to server

### DIFF
--- a/packages/desktop/src/main/ipc/workspace-handlers.ts
+++ b/packages/desktop/src/main/ipc/workspace-handlers.ts
@@ -5,6 +5,7 @@ import {
   updateConfig,
   isWorkspaceConfigured,
   getDefaultWorkspacePath,
+  ensureDeviceId,
 } from '../workspace/config.js';
 import { initWorkspace, migrateWorkspace } from '../workspace/init.js';
 import { reinitDatabase, closeDatabase } from '../db/index.js';
@@ -38,6 +39,7 @@ export function registerWorkspaceHandlers(): void {
       await initWorkspace(workspacePath);
       reinitDatabase(workspacePath);
       writeConfig({ workspacePath, gateways: [] });
+      ensureDeviceId();
       return { ok: true };
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'setup failed';
@@ -58,5 +60,9 @@ export function registerWorkspaceHandlers(): void {
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : 'migration failed' };
     }
+  });
+
+  ipcMain.handle('workspace:get-device-id', () => {
+    return ensureDeviceId();
   });
 }

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import { getGatewayClient, getAllGatewayClients, reconnectGateway } from '../ws/index.js';
-import { readConfig } from '../workspace/config.js';
+import { readConfig, ensureDeviceId } from '../workspace/config.js';
 import { isClawWorkSession, parseTaskIdFromSessionKey, parseAgentIdFromSessionKey } from '@clawwork/shared';
 import type { ChatAttachment } from '@clawwork/shared';
 import { getDebugLogger } from '../debug/index.js';
@@ -217,9 +217,10 @@ export function registerWsHandlers(): void {
     for (const [gatewayId, gw] of clients) {
       if (!gw.isConnected) continue;
       try {
+        const deviceId = ensureDeviceId();
         const raw = (await gw.listSessions()) as unknown as SessionsListPayload;
         const allSessions = raw.sessions ?? [];
-        const ours = allSessions.filter((s) => isClawWorkSession(s.key));
+        const ours = allSessions.filter((s) => isClawWorkSession(s.key, deviceId));
 
         for (const s of ours) {
           const taskId = parseTaskIdFromSessionKey(s.key);
@@ -282,11 +283,14 @@ export function registerWsHandlers(): void {
             })
             .filter((m) => m.content || m.toolCalls.length > 0);
 
+          const firstUserMsg = msgs.find((m) => m.role === 'user' && m.content);
+          const titleFromMsg = firstUserMsg ? firstUserMsg.content.slice(0, 30) : '';
+
           discovered.push({
             gatewayId,
             taskId,
             sessionKey: s.key,
-            title: s.derivedTitle ?? s.label ?? s.displayName ?? '',
+            title: s.derivedTitle ?? s.label ?? titleFromMsg,
             updatedAt: s.updatedAt ? new Date(s.updatedAt).toISOString() : new Date().toISOString(),
             agentId: parseAgentIdFromSessionKey(s.key),
             model: s.model,

--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -43,6 +43,7 @@ export interface AppConfig {
   trayEnabled?: boolean;
   leftNavShortcut?: 'Comma' | 'BracketLeft';
   rightPanelShortcut?: 'Period' | 'BracketRight';
+  deviceId?: string;
 }
 
 function configFilePath(): string {
@@ -131,6 +132,17 @@ export function buildGatewayAuth(gw: GatewayServerConfig): GatewayAuth {
   const envToken = process.env.OPENCLAW_GATEWAY_TOKEN;
   if (envToken) return { token: envToken };
   return { token: '' };
+}
+
+export function ensureDeviceId(): string {
+  const config = readConfig();
+  if (config?.deviceId) return config.deviceId;
+  const deviceId = randomUUID();
+  if (config) {
+    config.deviceId = deviceId;
+    writeConfig(config);
+  }
+  return deviceId;
 }
 
 export function clearGatewayPairingCode(gatewayId: string): void {

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -345,6 +345,8 @@ export interface ClawWorkAPI {
 
   setWindowButtonVisibility: (visible: boolean) => void;
 
+  getDeviceId: () => Promise<string>;
+
   selectContextFolder: () => Promise<IpcResult>;
   listContextFiles: (folders: string[], query?: string) => Promise<IpcResult>;
   readContextFile: (absolutePath: string, folders: string[]) => Promise<IpcResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -216,6 +216,8 @@ function buildApi(): ClawWorkAPI {
 
     setWindowButtonVisibility: (visible: boolean) => ipcRenderer.send('ui:set-window-button-visibility', visible),
 
+    getDeviceId: () => ipcRenderer.invoke('workspace:get-device-id') as Promise<string>,
+
     selectContextFolder: () => ipcRenderer.invoke('context:select-folder'),
     listContextFiles: (folders: string[], query?: string) =>
       ipcRenderer.invoke('context:list-files', { folders, query }),

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -114,6 +114,7 @@
     "systemDesc": "System behavior, shortcuts, and workspace",
     "gatewaysDesc": "Manage OpenClaw Gateway connections",
     "aboutDesc": "Version, updates, and links",
+    "deviceIdDesc": "Unique to this installation. Sessions are scoped by Device ID. To sync sessions across devices, copy this ID to the config file on the other device.",
     "confirmDeleteTitle": "Remove Gateway",
     "confirmDeleteDesc": "Remove \"{{name}}\"? Active connections to this gateway will be terminated."
   },

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -114,6 +114,7 @@
     "systemDesc": "系统行为、快捷键和工作空间",
     "gatewaysDesc": "管理 OpenClaw Gateway 连接",
     "aboutDesc": "版本、更新和链接",
+    "deviceIdDesc": "此安装的唯一标识，会话按 Device ID 隔离。如需跨设备同步会话，请将此 ID 复制到另一台设备的配置文件中。",
     "confirmDeleteTitle": "移除网关",
     "confirmDeleteDesc": "移除「{{name}}」？与该网关的活跃连接将被终止。"
   },

--- a/packages/desktop/src/renderer/layouts/Settings/sections/AboutSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AboutSection.tsx
@@ -23,11 +23,16 @@ export default function AboutSection() {
   const { t } = useTranslation();
   const [updateInfo, setUpdateInfo] = useState<UpdateCheckResult | null>(null);
   const [checkingUpdate, setCheckingUpdate] = useState(false);
+  const [deviceId, setDeviceId] = useState<string | null>(null);
 
   useEffect(() => {
     window.clawwork
       .checkForUpdates()
       .then(setUpdateInfo)
+      .catch(() => {});
+    window.clawwork
+      .getDeviceId()
+      .then(setDeviceId)
       .catch(() => {});
   }, []);
 
@@ -51,12 +56,20 @@ export default function AboutSection() {
       <h3 className="text-base font-semibold text-[var(--text-primary)]">{t('settings.about')}</h3>
       <p className="text-sm text-[var(--text-muted)] mt-1 mb-4">{t('settings.aboutDesc')}</p>
       <div className="rounded-xl bg-[var(--bg-elevated)] shadow-[var(--shadow-card)] border border-[var(--border-subtle)] divide-y divide-[var(--border-subtle)]">
-        <div className="px-5 py-4">
+        <div className="px-5 py-4 space-y-3">
           <SettingRow label={t('settings.version')}>
             <span className="text-sm text-[var(--text-primary)] font-mono">
               v{updateInfo?.currentVersion ?? '0.0.3'}
             </span>
           </SettingRow>
+          {deviceId && (
+            <div>
+              <SettingRow label="Device ID">
+                <span className="text-xs text-[var(--text-secondary)] font-mono select-all">{deviceId}</span>
+              </SettingRow>
+              <p className="text-xs text-[var(--text-muted)] mt-1">{t('settings.deviceIdDesc')}</p>
+            </div>
+          )}
         </div>
 
         {updateInfo?.hasUpdate && (

--- a/packages/desktop/src/renderer/stores/taskStore.ts
+++ b/packages/desktop/src/renderer/stores/taskStore.ts
@@ -10,6 +10,8 @@ interface PendingNewTask {
   thinkingLevel?: string;
 }
 
+let cachedDeviceId: string | null = null;
+
 interface TaskState {
   tasks: Task[];
   activeTaskId: string | null;
@@ -90,7 +92,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     const now = new Date().toISOString();
     const task: Task = {
       id,
-      sessionKey: buildSessionKey(id, agentId),
+      sessionKey: buildSessionKey(id, agentId, cachedDeviceId ?? undefined),
       sessionId: '',
       title: '',
       status: 'active',
@@ -110,10 +112,14 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
   updateTaskTitle: (id, title) => {
     const now = new Date().toISOString();
+    const task = get().tasks.find((t) => t.id === id);
     set((s) => ({
       tasks: s.tasks.map((t) => (t.id === id ? { ...t, title, updatedAt: now } : t)),
     }));
     window.clawwork.persistTaskUpdate({ id, title, updatedAt: now }).catch(() => {});
+    if (task?.gatewayId && task?.sessionKey) {
+      window.clawwork.patchSession(task.gatewayId, task.sessionKey, { label: title }).catch(() => {});
+    }
   },
 
   updateTaskStatus: (id, status) => {
@@ -157,6 +163,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   hydrate: async () => {
     if (get().hydrated) return;
     try {
+      cachedDeviceId = await window.clawwork.getDeviceId();
       const res = await window.clawwork.loadTasks();
       if (res.ok && res.rows) {
         set({

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -8,35 +8,33 @@ export const GATEWAY_WS_PORT = 18789;
 /** ClawWork session key prefix (default agent=main, kept for backward compat) */
 export const SESSION_KEY_PREFIX = 'agent:main:clawwork:task:';
 
-/** Regex matching any ClawWork session key: agent:<agentId>:clawwork:task:<taskId> */
+const CLAWWORK_DEVICE_SESSION_RE = /^agent:([^:]+):clawwork:([^:]+):task:(.+)$/;
 const CLAWWORK_SESSION_RE = /^agent:([^:]+):clawwork:task:(.+)$/;
 const LEGACY_SESSION_KEY_RE = /^agent:[^:]+:task-(.+)$/;
 
-/** Build a session key from taskId and optional agentId */
-export function buildSessionKey(taskId: string, agentId: string = 'main'): string {
+export function buildSessionKey(taskId: string, agentId: string = 'main', deviceId?: string): string {
+  if (deviceId) return `agent:${agentId}:clawwork:${deviceId}:task:${taskId}`;
   return `agent:${agentId}:clawwork:task:${taskId}`;
 }
 
-/** Extract taskId from a ClawWork session key */
 export function parseTaskIdFromSessionKey(sessionKey: string): string | null {
+  const dm = sessionKey.match(CLAWWORK_DEVICE_SESSION_RE);
+  if (dm) return dm[3] || null;
+
   const m = sessionKey.match(CLAWWORK_SESSION_RE);
   if (m) return m[2] || null;
 
-  // Keep old task sessions renderable after the gateway-only key migration.
   const legacyMatch = sessionKey.match(LEGACY_SESSION_KEY_RE);
   return legacyMatch ? legacyMatch[1] : null;
 }
 
-/** Extract agentId from a ClawWork session key (defaults to 'main') */
 export function parseAgentIdFromSessionKey(sessionKey: string): string {
+  const dm = sessionKey.match(CLAWWORK_DEVICE_SESSION_RE);
+  if (dm) return dm[1];
   const m = sessionKey.match(CLAWWORK_SESSION_RE);
   return m ? m[1] : 'main';
 }
 
-/**
- * Merge streaming chat text from Gateway.
- * Handles cumulative snapshots, duplicate frames, and true incremental chunks.
- */
 export function mergeGatewayStreamText(previous: string, incoming: string): string {
   if (!incoming) return previous;
   if (incoming === previous) return previous;
@@ -45,9 +43,12 @@ export function mergeGatewayStreamText(previous: string, incoming: string): stri
   return previous + incoming;
 }
 
-/** Check if a session key belongs to ClawWork */
-export function isClawWorkSession(sessionKey: string): boolean {
-  return CLAWWORK_SESSION_RE.test(sessionKey);
+export function isClawWorkSession(sessionKey: string, deviceId?: string): boolean {
+  if (deviceId) {
+    const dm = sessionKey.match(CLAWWORK_DEVICE_SESSION_RE);
+    return dm !== null && dm[2] === deviceId;
+  }
+  return CLAWWORK_DEVICE_SESSION_RE.test(sessionKey) || CLAWWORK_SESSION_RE.test(sessionKey);
 }
 
 /** Heartbeat interval in milliseconds */


### PR DESCRIPTION
## Summary

Embed a per-installation UUID (deviceId) in session keys so sync only picks up sessions created by this device, preventing cross-device session clutter. Additionally, persist task titles to the server via `sessions.patch` so renamed tasks survive sync.

## Type of change

- [x] `[Feat]` New device-scoped session keys and title sync

## Why is this needed?

When connecting to a gateway, ClawWork syncs ALL ClawWork sessions from the server, including sessions from other devices. This clutters the task list with irrelevant sessions. Synced session titles all show "ClawWork Desktop" because the locally-generated title is never persisted to the server.

## What changed?

- New session key format: `agent:<agentId>:clawwork:<deviceId>:task:<taskId>`
- `deviceId` (UUID v4) generated on first install, stored in `clawwork-config.json`
- `isClawWorkSession()` accepts optional `deviceId` param to filter by device
- `buildSessionKey()` accepts optional `deviceId` param
- Sync handler filters sessions by local deviceId
- `updateTaskTitle()` now also calls `sessions.patch` to sync title to server (fire-and-forget)
- Title fallback chain fixed: removed `displayName` (client identifier), added first-message extraction
- Device ID displayed in Settings > About with `select-all` for easy copying
- i18n strings added (en/zh) explaining Device ID purpose and cross-device sync

## Linked issues

N/A

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — clean
pnpm test — 70/70 tests pass (6 shared + 64 desktop)
```

## Screenshots or recordings

N/A

## Release note

- [x] User-facing change.

```release-note
Sessions are now scoped by device ID — syncing only picks up sessions created on this device. Task titles are persisted to the server so they survive cross-device sync.
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] The release note block is accurate