### PR TITLE
[Fix] prevent path traversal in extracted filenames

### DIFF
--- a/packages/desktop/src/main/artifact/extract.ts
+++ b/packages/desktop/src/main/artifact/extract.ts
@@ -37,6 +37,13 @@ export interface ExtractedCodeBlock {
   lineCount: number;
 }
 
+function sanitizeExtractedFileName(raw: string): string {
+  if (!raw || raw === '.' || raw === '..') throw new Error('invalid code block filename');
+  if (raw.includes('/') || raw.includes('\\')) throw new Error('invalid code block filename');
+  if (raw.includes('..')) throw new Error('invalid code block filename');
+  return raw;
+}
+
 export function extractImagesFromMarkdown(content: string): ExtractedImage[] {
   return [...content.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g)].map(([, alt, src]) => ({
     src,
@@ -52,7 +59,7 @@ export function extractCodeBlocksFromMarkdown(content: string): ExtractedCodeBlo
       const hasDot = lang.includes('.');
       if (lineCount <= 10 && !hasDot) return null;
       const fileName = hasDot
-        ? lang
+        ? sanitizeExtractedFileName(lang)
         : `snippet-${createHash('sha1').update(body).digest('hex').slice(0, 6)}.${LANG_EXT[lang.toLowerCase()] ?? 'txt'}`;
       return { language: lang, content: body, fileName, lineCount };
     })

--- a/packages/desktop/src/main/artifact/save.ts
+++ b/packages/desktop/src/main/artifact/save.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, statSync, writeFileSync } from 'fs';
-import { basename, extname, join } from 'path';
+import { basename, extname, resolve, sep } from 'path';
 import { randomUUID } from 'crypto';
 import type { Artifact } from '@clawwork/shared';
 import { getDb } from '../db/index.js';
@@ -30,9 +30,29 @@ function detectMimeType(fileName: string): string {
   return MIME_MAP[ext] ?? 'application/octet-stream';
 }
 
+function sanitizeArtifactName(name: string): string {
+  if (!name || name === '.' || name === '..') throw new Error('invalid artifact name');
+  if (name.includes('/') || name.includes('\\')) throw new Error('invalid artifact name');
+  if (name.includes('..')) throw new Error('invalid artifact name');
+  return basename(name);
+}
+
+function resolveArtifactDestination(taskDir: string, fileName: string): { destPath: string; finalName: string } {
+  const finalName = uniqueFileName(taskDir, fileName);
+  const resolvedTaskDir = resolve(taskDir);
+  const destPath = resolve(taskDir, finalName);
+
+  if (!destPath.startsWith(`${resolvedTaskDir}${sep}`)) {
+    throw new Error('artifact path escapes task dir');
+  }
+
+  return { destPath, finalName };
+}
+
 function uniqueFileName(_dir: string, name: string): string {
-  const ext = extname(name);
-  const base = name.slice(0, name.length - ext.length);
+  const safeName = sanitizeArtifactName(name);
+  const ext = extname(safeName);
+  const base = safeName.slice(0, safeName.length - ext.length);
   return `${base}-${randomUUID().slice(0, 8)}${ext}`;
 }
 
@@ -50,8 +70,7 @@ export async function saveArtifact(params: SaveArtifactParams): Promise<Artifact
 
   const taskDir = ensureTaskDir(workspacePath, taskId);
   const originalName = fileName ?? basename(sourcePath);
-  const finalName = uniqueFileName(taskDir, originalName);
-  const destPath = join(taskDir, finalName);
+  const { finalName, destPath } = resolveArtifactDestination(taskDir, originalName);
 
   copyFileSync(sourcePath, destPath);
 
@@ -109,8 +128,7 @@ export async function saveArtifactFromBuffer(params: SaveArtifactFromBufferParam
   const { workspacePath, taskId, messageId, fileName, buffer, artifactType, contentText } = params;
 
   const taskDir = ensureTaskDir(workspacePath, taskId);
-  const finalName = uniqueFileName(taskDir, fileName);
-  const destPath = join(taskDir, finalName);
+  const { finalName, destPath } = resolveArtifactDestination(taskDir, fileName);
 
   writeFileSync(destPath, buffer);
 


### PR DESCRIPTION
## Summary

Block assistant-controlled artifact filenames from escaping the task directory by validating extracted code block filenames and enforcing task-directory containment before writes.

## Type of change

- [x] `[Fix]` bug fix
- [ ] `[Feat]` new feature
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Assistant-provided code block info strings and artifact filenames could previously carry traversal payloads and reach disk-write code without containment checks. This breaks the local-first artifact isolation invariant for each task directory.

## What changed?

- validate extracted code block filenames before they are turned into artifact names
- sanitize artifact names before generating unique output names
- resolve artifact destinations and reject any path that escapes the task directory in both save paths

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`:
  - Artifact files are stored on disk and treated as the source of durable output
  - Preserve stable workspace paths and per-task artifact directories
  - Favor the smallest change that preserves layer boundaries
- Why those invariants remain protected:
  - the change stays inside `packages/desktop/src/main/artifact/`
  - artifact persistence remains local-first
  - each write is now explicitly constrained to the task directory

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
manual verification passed
- extractCodeBlocksFromMarkdown rejects ../../evil.txt with "invalid code block filename"
- saveArtifactFromBuffer accepts note.md and rejects ../note.md with "invalid artifact name"
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate