### PR TITLE
[Fix] Reconcile partial history instead of skipping synced tasks

### DIFF
--- a/packages/desktop/src/renderer/lib/session-sync.ts
+++ b/packages/desktop/src/renderer/lib/session-sync.ts
@@ -63,43 +63,51 @@ export async function syncFromGateway(): Promise<void> {
         contextTokens: d.contextTokens,
       });
       if (d.messages.length === 0) continue;
-      if (messagesByTask[d.taskId]?.length) continue;
-      const msgs: Message[] = d.messages.map(
-        (m: {
-          role: string;
-          content: string;
-          timestamp: string;
-          toolCalls?: {
-            id: string;
-            name: string;
-            status: string;
-            args?: Record<string, unknown>;
-            result?: string;
-            startedAt: string;
-            completedAt?: string;
-          }[];
-        }) => ({
-          id: crypto.randomUUID(),
-          taskId: d.taskId,
-          role: m.role as MessageRole,
-          content: m.content,
-          artifacts: [],
-          toolCalls: (m.toolCalls ?? []).map(
-            (tc): ToolCall => ({
-              id: tc.id,
-              name: tc.name,
-              status: tc.status as ToolCall['status'],
-              args: tc.args,
-              result: tc.result,
-              startedAt: tc.startedAt,
-              completedAt: tc.completedAt,
-            }),
-          ),
-          timestamp: m.timestamp,
-        }),
-      );
-      bulkLoad(d.taskId, msgs);
-      for (const msg of msgs) {
+      const local = messagesByTask[d.taskId] ?? [];
+      const existingKeys = new Set(local.map((msg) => `${msg.role}:${msg.timestamp}:${msg.content}`));
+      const newMsgs: Message[] = d.messages
+        .filter(
+          (msg: { role: string; content: string; timestamp: string }) =>
+            !existingKeys.has(`${msg.role}:${msg.timestamp}:${msg.content}`),
+        )
+        .map(
+          (m: {
+            role: string;
+            content: string;
+            timestamp: string;
+            toolCalls?: {
+              id: string;
+              name: string;
+              status: string;
+              args?: Record<string, unknown>;
+              result?: string;
+              startedAt: string;
+              completedAt?: string;
+            }[];
+          }) => ({
+            id: crypto.randomUUID(),
+            taskId: d.taskId,
+            role: m.role as MessageRole,
+            content: m.content,
+            artifacts: [],
+            toolCalls: (m.toolCalls ?? []).map(
+              (tc): ToolCall => ({
+                id: tc.id,
+                name: tc.name,
+                status: tc.status as ToolCall['status'],
+                args: tc.args,
+                result: tc.result,
+                startedAt: tc.startedAt,
+                completedAt: tc.completedAt,
+              }),
+            ),
+            timestamp: m.timestamp,
+          }),
+        );
+      if (newMsgs.length === 0) continue;
+      const merged = [...local, ...newMsgs].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+      bulkLoad(d.taskId, merged);
+      for (const msg of newMsgs) {
         window.clawwork
           .persistMessage({
             id: msg.id,


### PR DESCRIPTION
## Summary

Fix `syncFromGateway` to merge missing Gateway messages into partial local history instead of permanently skipping tasks that already have cached messages.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

When a task already had any local messages, `syncFromGateway` would `continue` past it, permanently losing additional history the Gateway had. This caused incomplete conversation histories after reconnects or restarts.

## What changed?

- Replaced the early-return skip (`if (messagesByTask[d.taskId]?.length) continue`) with dedup-and-merge logic
- Remote messages are deduplicated against local using a `role:timestamp:content` composite key
- Only genuinely new messages are mapped, merged (sorted by timestamp), bulk-loaded into the store, and persisted to SQLite

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is scoped to sync merge logic within the renderer layer

## Validation

- [x] `pnpm typecheck`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm typecheck — passed, zero errors
```

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Fix: Gateway session sync now merges missing messages into partial local history instead of skipping tasks entirely
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate