### PR TITLE
[Fix] Block SSRF and unbounded memory in remote image auto-fetch

### DIFF
--- a/packages/desktop/src/main/artifact/auto-extract.ts
+++ b/packages/desktop/src/main/artifact/auto-extract.ts
@@ -16,11 +16,41 @@ interface AutoExtractParams {
   content: string;
 }
 
+const MAX_REMOTE_SIZE = 10 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 10_000;
+
+function isPrivateHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
 async function fetchToBuffer(url: string): Promise<Buffer> {
-  const res = await net.fetch(url);
-  if (!res.ok) throw new Error(`fetch ${url} failed: ${res.status}`);
-  const ab = await res.arrayBuffer();
-  return Buffer.from(ab);
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:') {
+    throw new Error('remote fetch disabled for non-https scheme');
+  }
+  if (isPrivateHost(parsed.hostname)) {
+    throw new Error('remote fetch disabled for private hosts');
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await net.fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`fetch ${url} failed: ${res.status}`);
+
+    const contentLength = Number(res.headers.get('content-length') ?? '0');
+    if (contentLength > MAX_REMOTE_SIZE) {
+      throw new Error('remote artifact too large');
+    }
+
+    const ab = await res.arrayBuffer();
+    if (ab.byteLength > MAX_REMOTE_SIZE) {
+      throw new Error('remote artifact too large');
+    }
+    return Buffer.from(ab);
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function autoExtractArtifacts(params: AutoExtractParams): Promise<void> {


### PR DESCRIPTION
## Summary

Harden `fetchToBuffer` in the artifact auto-extract path to prevent assistant-authored image URLs from becoming an SSRF primitive or crashing the main process via unbounded memory buffering.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The main process fetches any assistant-provided `http`/`https` image URL with no host restrictions, timeout, or size limit. A malicious or hallucinated URL pointing to localhost/private networks enables SSRF; a URL returning a multi-GB response causes OOM.

## What changed?

- Reject non-`https:` schemes (blocks `http:`, `file:`, etc.)
- Reject private hosts (`localhost`, `127.0.0.1`, `::1`)
- Add 10-second `AbortController` timeout
- Add 10 MB size limit (checked via `Content-Length` header and actual `arrayBuffer` size)

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched: none
- The local `clawwork-media://` path branch is untouched

## Validation

- [x] `pnpm typecheck`
- [ ] Manual smoke test

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described