### PR TITLE
[Fix] Clear stale stream state on reset and defer user message persistence until send success

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -166,14 +166,24 @@ export default function App() {
       const task = createTask();
       const title = message.slice(0, 30).replace(/\n/g, ' ').trim();
       updateTaskTitle(task.id, title + (message.length > 30 ? '\u2026' : ''));
-      addMessage(task.id, 'user', message);
+      const pendingUserMessage = addMessage(task.id, 'user', message, undefined, { persist: false });
       setProcessing(task.id, true);
       window.clawwork
         .sendMessage(task.gatewayId, task.sessionKey, message)
         .then((result) => {
           if (result && !result.ok) {
             setProcessing(task.id, false);
+            return;
           }
+          window.clawwork
+            .persistMessage({
+              id: pendingUserMessage.id,
+              taskId: pendingUserMessage.taskId,
+              role: pendingUserMessage.role,
+              content: pendingUserMessage.content,
+              timestamp: pendingUserMessage.timestamp,
+            })
+            .catch(() => {});
         })
         .catch(() => {
           setProcessing(task.id, false);

--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -512,7 +512,7 @@ export default function ChatInput() {
         ? images.map((img) => ({ fileName: img.file.name, dataUrl: img.previewUrl }))
         : undefined;
 
-      addMessage(task.id, 'user', finalContent, msgImages);
+      const pendingUserMessage = addMessage(task.id, 'user', finalContent, msgImages, { persist: false });
       setProcessing(task.id, true);
 
       if (!task.title) {
@@ -558,6 +558,17 @@ export default function ChatInput() {
         const msg = result.error || t('errors.sendFailed');
         addMessage(task.id, 'system', `${t('errors.sendFailed')}: ${msg}`);
         toast.error('Failed to send message', { description: msg });
+      } else {
+        window.clawwork
+          .persistMessage({
+            id: pendingUserMessage.id,
+            taskId: pendingUserMessage.taskId,
+            role: pendingUserMessage.role,
+            content: pendingUserMessage.content,
+            timestamp: pendingUserMessage.timestamp,
+            imageAttachments: pendingUserMessage.imageAttachments as unknown[] | undefined,
+          })
+          .catch(() => {});
       }
     } catch (err) {
       setProcessing(task.id, false);

--- a/packages/desktop/src/renderer/stores/messageStore.ts
+++ b/packages/desktop/src/renderer/stores/messageStore.ts
@@ -22,6 +22,7 @@ interface MessageState {
     role: MessageRole,
     content: string,
     imageAttachments?: MessageImageAttachment[],
+    options?: { persist?: boolean },
   ) => Message;
   /** Insert or update a ToolCall on the latest assistant message for a task.
    *  If no assistant message exists yet, one is created to host the tool call. */
@@ -49,7 +50,7 @@ export const useMessageStore = create<MessageState>((set, _get) => ({
   processingTasks: new Set(),
   highlightedMessageId: null,
 
-  addMessage: (taskId, role, content, imageAttachments?) => {
+  addMessage: (taskId, role, content, imageAttachments?, options?) => {
     const msg: Message = {
       id: generateId(),
       taskId,
@@ -66,16 +67,18 @@ export const useMessageStore = create<MessageState>((set, _get) => ({
         [taskId]: [...(s.messagesByTask[taskId] ?? []), msg],
       },
     }));
-    window.clawwork
-      .persistMessage({
-        id: msg.id,
-        taskId: msg.taskId,
-        role: msg.role,
-        content: msg.content,
-        timestamp: msg.timestamp,
-        imageAttachments: msg.imageAttachments as unknown[] | undefined,
-      })
-      .catch(() => {});
+    if (options?.persist !== false) {
+      window.clawwork
+        .persistMessage({
+          id: msg.id,
+          taskId: msg.taskId,
+          role: msg.role,
+          content: msg.content,
+          timestamp: msg.timestamp,
+          imageAttachments: msg.imageAttachments as unknown[] | undefined,
+        })
+        .catch(() => {});
+    }
     return msg;
   },
 
@@ -190,9 +193,22 @@ export const useMessageStore = create<MessageState>((set, _get) => ({
 
   clearMessages: (taskId) =>
     set((s) => {
-      const next = { ...s.messagesByTask };
-      delete next[taskId];
-      return { messagesByTask: next };
+      const nextMessages = { ...s.messagesByTask };
+      const nextStreaming = { ...s.streamingByTask };
+      const nextThinking = { ...s.streamingThinkingByTask };
+      const nextProcessing = new Set(s.processingTasks);
+
+      delete nextMessages[taskId];
+      delete nextStreaming[taskId];
+      delete nextThinking[taskId];
+      nextProcessing.delete(taskId);
+
+      return {
+        messagesByTask: nextMessages,
+        streamingByTask: nextStreaming,
+        streamingThinkingByTask: nextThinking,
+        processingTasks: nextProcessing,
+      };
     }),
 
   setHighlightedMessage: (id) => set({ highlightedMessageId: id }),


### PR DESCRIPTION
### What's changed?

- `clearMessages()` now clears `streamingByTask`, `streamingThinkingByTask`, and `processingTasks` in addition to `messagesByTask`, preventing stale stream frames from leaking into a reset conversation
- `addMessage()` accepts an optional `{ persist: false }` flag to skip immediate DB writes
- `ChatInput.handleSend` and `App.onQuickLaunchSubmit` now add user messages optimistically but only persist after `sendMessage` succeeds

### Why

- A session reset mid-stream left behind streaming text and thinking text, which reappeared after the reset banner
- A failed `sendMessage` still wrote the user message to SQLite, causing ghost messages to survive renderer reload