### PR TITLE
[Fix] Redact pairing and bootstrap credentials in debug bundle export

### DIFF
--- a/packages/shared/src/debug.ts
+++ b/packages/shared/src/debug.ts
@@ -1,6 +1,6 @@
 const REDACTED = '***redacted***';
 const TRUNCATE_AT = 500;
-const SECRET_KEY_RE = /(token|password|secret|authorization|cookie)/i;
+const SECRET_KEY_RE = /(token|password|secret|authorization|cookie|pairingcode|bootstraptoken)/i;
 
 export type DebugLevel = 'debug' | 'info' | 'warn' | 'error';
 export type DebugDomain =


### PR DESCRIPTION
## Summary

The debug bundle sanitizer (`SECRET_KEY_RE`) missed `pairingCode` and `bootstrapToken` fields, causing cleartext credentials to leak into `config.sanitized.json` when exporting support bundles.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Debug bundles are shared with support. Leaking pairing/bootstrap credentials in exported artifacts is a security risk.

## What changed?

- Extended `SECRET_KEY_RE` regex in `packages/shared/src/debug.ts` to match `pairingcode` and `bootstraptoken` (case-insensitive)

## Architecture impact

- Owning layer: shared
- Cross-layer impact: none — `sanitizeForLog` consumers (desktop `export.ts`) automatically benefit
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check (lint + architecture + format + typecheck + test) — all passed, 70 tests green
```

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate