### PR TITLE
[Fix] Prevent message duplication on startup via hydration serialization and DB unique index

### DIFF
--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS messages (
   task_id TEXT NOT NULL REFERENCES tasks(id),
   role TEXT NOT NULL,
   content TEXT NOT NULL,
-  timestamp TEXT NOT NULL
+  timestamp TEXT NOT NULL,
+  image_attachments TEXT
 );
 
 CREATE TABLE IF NOT EXISTS artifacts (
@@ -80,6 +81,20 @@ function openDatabaseAt(workspacePath: string): void {
   try {
     sqlite.exec('ALTER TABLE messages ADD COLUMN image_attachments TEXT');
   } catch {}
+
+  sqlite.exec(`
+    DELETE FROM messages
+    WHERE rowid NOT IN (
+      SELECT MIN(rowid)
+      FROM messages
+      GROUP BY task_id, role, content, timestamp, COALESCE(image_attachments, '')
+    )
+  `);
+
+  sqlite.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS messages_logical_unique
+    ON messages(task_id, role, content, timestamp, COALESCE(image_attachments, ''))
+  `);
 
   try {
     sqlite.exec("ALTER TABLE artifacts ADD COLUMN content_text TEXT NOT NULL DEFAULT ''");

--- a/packages/desktop/src/main/ipc/data-handlers.ts
+++ b/packages/desktop/src/main/ipc/data-handlers.ts
@@ -138,6 +138,9 @@ export function registerDataHandlers(): void {
         }
         return { ok: true };
       } catch (err) {
+        if (err instanceof Error && /UNIQUE constraint failed|messages_logical_unique/i.test(err.message)) {
+          return { ok: true };
+        }
         console.error('[data] create-message failed:', err);
         return ipcError(err);
       }

--- a/packages/desktop/src/renderer/lib/session-sync.ts
+++ b/packages/desktop/src/renderer/lib/session-sync.ts
@@ -3,6 +3,7 @@ import { useTaskStore } from '../stores/taskStore';
 import { useMessageStore } from '../stores/messageStore';
 
 const GATEWAY_INJECTED_MODEL = 'gateway-injected';
+let hydrationPromise: Promise<void> | null = null;
 
 function sanitizeModel(model?: string): string | undefined {
   return model === GATEWAY_INJECTED_MODEL ? undefined : model;
@@ -13,30 +14,34 @@ function sanitizeModel(model?: string): string | undefined {
  * Called once on mount for instant offline render.
  */
 export async function hydrateFromLocal(): Promise<void> {
-  const { hydrate } = useTaskStore.getState();
-  const { bulkLoad } = useMessageStore.getState();
-  await hydrate();
-  const tasks = useTaskStore.getState().tasks;
-  for (const t of tasks) {
-    try {
-      const res = await window.clawwork.loadMessages(t.id);
-      if (res.ok && res.rows && res.rows.length > 0) {
-        const msgs: Message[] = res.rows.map((r) => ({
-          id: r.id,
-          taskId: r.taskId,
-          role: r.role as MessageRole,
-          content: r.content,
-          artifacts: [],
-          toolCalls: [],
-          timestamp: r.timestamp,
-          imageAttachments: r.imageAttachments as Message['imageAttachments'],
-        }));
-        bulkLoad(t.id, msgs);
+  if (!hydrationPromise) {
+    hydrationPromise = (async () => {
+      const { hydrate } = useTaskStore.getState();
+      const { bulkLoad } = useMessageStore.getState();
+      await hydrate();
+      const tasks = useTaskStore.getState().tasks;
+      for (const t of tasks) {
+        try {
+          const res = await window.clawwork.loadMessages(t.id);
+          if (res.ok && res.rows && res.rows.length > 0) {
+            const msgs: Message[] = res.rows.map((r) => ({
+              id: r.id,
+              taskId: r.taskId,
+              role: r.role as MessageRole,
+              content: r.content,
+              artifacts: [],
+              toolCalls: [],
+              timestamp: r.timestamp,
+              imageAttachments: r.imageAttachments as Message['imageAttachments'],
+            }));
+            bulkLoad(t.id, msgs);
+          }
+        } catch {}
       }
-    } catch {
-      /* skip failed loads */
-    }
+    })();
   }
+
+  await hydrationPromise;
 }
 
 /**
@@ -45,6 +50,7 @@ export async function hydrateFromLocal(): Promise<void> {
  */
 export async function syncFromGateway(): Promise<void> {
   try {
+    await hydrateFromLocal();
     const res = await window.clawwork.syncSessions();
     if (!res.ok || !res.discovered) return;
     const { adoptTasks, updateTaskMetadata } = useTaskStore.getState();

--- a/packages/desktop/test/data-handlers.test.ts
+++ b/packages/desktop/test/data-handlers.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+const getWorkspacePathMock = vi.fn(() => null);
+const autoExtractArtifactsMock = vi.fn();
+const runMock = vi.fn();
+const valuesMock = vi.fn(() => ({ run: runMock }));
+const insertMock = vi.fn(() => ({ values: valuesMock }));
+const getDbMock = vi.fn(() => ({ insert: insertMock }));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handleMap.set(channel, handler);
+    }),
+  },
+}));
+
+vi.mock('../src/main/workspace/config.js', () => ({
+  getWorkspacePath: getWorkspacePathMock,
+}));
+
+vi.mock('../src/main/artifact/auto-extract.js', () => ({
+  autoExtractArtifacts: autoExtractArtifactsMock,
+}));
+
+vi.mock('../src/main/db/index.js', () => ({
+  getDb: getDbMock,
+  isDbReady: vi.fn(() => true),
+}));
+
+describe('registerDataHandlers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    handleMap.clear();
+    getWorkspacePathMock.mockReturnValue(null);
+    autoExtractArtifactsMock.mockReset();
+    runMock.mockReset();
+    valuesMock.mockClear();
+    insertMock.mockClear();
+    getDbMock.mockClear();
+  });
+
+  it('deduplicates repeated message inserts for the same logical message', async () => {
+    const { registerDataHandlers } = await import('../src/main/ipc/data-handlers.js');
+
+    registerDataHandlers();
+
+    const createMessage = handleMap.get('data:create-message');
+    expect(createMessage).toBeTypeOf('function');
+
+    runMock
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error(
+          'UNIQUE constraint failed: messages.task_id, messages.role, messages.content, messages.timestamp',
+        );
+      });
+
+    const payload = {
+      id: 'msg-1',
+      taskId: 'task-1',
+      role: 'assistant',
+      content: 'same reply',
+      timestamp: '2026-03-16T00:00:01.000Z',
+    };
+
+    expect(createMessage?.({}, payload)).toEqual({ ok: true });
+    expect(createMessage?.({}, { ...payload, id: 'msg-2' })).toEqual({ ok: true });
+
+    expect(runMock).toHaveBeenCalledTimes(2);
+    expect(autoExtractArtifactsMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/test/session-sync.test.ts
+++ b/packages/desktop/test/session-sync.test.ts
@@ -1,26 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { syncFromGateway } from '../src/renderer/lib/session-sync';
-import { useTaskStore } from '../src/renderer/stores/taskStore';
-import { useMessageStore } from '../src/renderer/stores/messageStore';
 
-describe('syncFromGateway', () => {
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function loadModules() {
+  vi.resetModules();
+  const [sessionSync, taskStore, messageStore] = await Promise.all([
+    import('../src/renderer/lib/session-sync'),
+    import('../src/renderer/stores/taskStore'),
+    import('../src/renderer/stores/messageStore'),
+  ]);
+  return { sessionSync, taskStore, messageStore };
+}
+
+describe('session sync startup flow', () => {
   beforeEach(() => {
-    useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
-    useMessageStore.setState({
-      messagesByTask: {},
-      streamingByTask: {},
-      streamingThinkingByTask: {},
-      processingTasks: new Set(),
-      highlightedMessageId: null,
-    });
-
+    vi.clearAllMocks();
     const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as Window & {
       clawwork: {
         syncSessions: ReturnType<typeof vi.fn>;
         persistTask: ReturnType<typeof vi.fn>;
         persistTaskUpdate: ReturnType<typeof vi.fn>;
         loadMessages: ReturnType<typeof vi.fn>;
+        loadTasks: ReturnType<typeof vi.fn>;
         persistMessage: ReturnType<typeof vi.fn>;
+        getDeviceId: ReturnType<typeof vi.fn>;
       };
     };
     windowWithClawwork.clawwork = {
@@ -28,11 +40,24 @@ describe('syncFromGateway', () => {
       persistTask: vi.fn().mockResolvedValue({ ok: true }),
       persistTaskUpdate: vi.fn().mockResolvedValue({ ok: true }),
       loadMessages: vi.fn().mockResolvedValue({ ok: true, rows: [] }),
+      loadTasks: vi.fn().mockResolvedValue({ ok: true, rows: [] }),
       persistMessage: vi.fn().mockResolvedValue({ ok: true }),
+      getDeviceId: vi.fn().mockResolvedValue('device-1'),
     };
   });
 
   it('filters gateway-injected model values from discovered session metadata', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {},
+      streamingByTask: {},
+      streamingThinkingByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
     window.clawwork.syncSessions.mockResolvedValue({
       ok: true,
       discovered: [
@@ -54,9 +79,9 @@ describe('syncFromGateway', () => {
       ],
     });
 
-    await syncFromGateway();
+    await sessionSync.syncFromGateway();
 
-    const task = useTaskStore.getState().tasks[0];
+    const task = taskStore.useTaskStore.getState().tasks[0];
     expect(task).toBeTruthy();
     expect(task.model).toBeUndefined();
     expect(task.modelProvider).toBe('openclaw');
@@ -67,5 +92,140 @@ describe('syncFromGateway', () => {
         modelProvider: 'openclaw',
       }),
     );
+  });
+
+  it('waits for local hydration before syncing gateway history for an existing task', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {},
+      streamingByTask: {},
+      streamingThinkingByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    const taskRow = {
+      id: 'task-1',
+      sessionKey: 'agent:main:clawwork:task:task-1',
+      sessionId: 'session-1',
+      title: 'Task 1',
+      status: 'active',
+      model: null,
+      modelProvider: null,
+      thinkingLevel: null,
+      inputTokens: null,
+      outputTokens: null,
+      contextTokens: null,
+      createdAt: '2026-03-16T00:00:00.000Z',
+      updatedAt: '2026-03-16T00:00:00.000Z',
+      tags: [],
+      artifactDir: 'tasks/task-1',
+      gatewayId: 'gw-1',
+    };
+    const existingRow = {
+      id: 'local-msg-1',
+      taskId: 'task-1',
+      role: 'assistant',
+      content: 'same reply',
+      timestamp: '2026-03-16T00:00:01.000Z',
+      imageAttachments: undefined,
+    };
+    const loadMessagesDeferred = createDeferred<{ ok: true; rows: (typeof existingRow)[] }>();
+
+    window.clawwork.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
+    window.clawwork.loadMessages.mockReturnValue(loadMessagesDeferred.promise);
+    window.clawwork.syncSessions.mockResolvedValue({
+      ok: true,
+      discovered: [
+        {
+          gatewayId: 'gw-1',
+          taskId: 'task-1',
+          sessionKey: 'agent:main:clawwork:task:task-1',
+          title: 'Task 1',
+          updatedAt: '2026-03-16T00:00:02.000Z',
+          agentId: 'main',
+          model: 'model-1',
+          modelProvider: 'openclaw',
+          thinkingLevel: 'medium',
+          inputTokens: 1,
+          outputTokens: 2,
+          contextTokens: 3,
+          messages: [
+            {
+              role: 'assistant',
+              content: 'same reply',
+              timestamp: '2026-03-16T00:00:01.000Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    const hydratePromise = sessionSync.hydrateFromLocal();
+    await Promise.resolve();
+
+    const syncPromise = sessionSync.syncFromGateway();
+    await Promise.resolve();
+
+    loadMessagesDeferred.resolve({ ok: true, rows: [existingRow] });
+
+    await Promise.all([hydratePromise, syncPromise]);
+
+    expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
+    expect(messageStore.useMessageStore.getState().messagesByTask['task-1']).toEqual([
+      expect.objectContaining({
+        id: 'local-msg-1',
+        content: 'same reply',
+        timestamp: '2026-03-16T00:00:01.000Z',
+      }),
+    ]);
+  });
+
+  it('reuses resolved hydration state across later gateway sync calls', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {},
+      streamingByTask: {},
+      streamingThinkingByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    window.clawwork.loadTasks.mockResolvedValue({
+      ok: true,
+      rows: [
+        {
+          id: 'task-1',
+          sessionKey: 'agent:main:clawwork:task:task-1',
+          sessionId: 'session-1',
+          title: 'Task 1',
+          status: 'active',
+          model: null,
+          modelProvider: null,
+          thinkingLevel: null,
+          inputTokens: null,
+          outputTokens: null,
+          contextTokens: null,
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+          tags: [],
+          artifactDir: 'tasks/task-1',
+          gatewayId: 'gw-1',
+        },
+      ],
+    });
+    window.clawwork.loadMessages.mockResolvedValue({ ok: true, rows: [] });
+    window.clawwork.syncSessions.mockResolvedValue({ ok: true, discovered: [] });
+
+    await sessionSync.syncFromGateway();
+    await sessionSync.syncFromGateway();
+
+    expect(window.clawwork.loadTasks).toHaveBeenCalledTimes(1);
+    expect(window.clawwork.loadMessages).toHaveBeenCalledTimes(1);
+    expect(window.clawwork.syncSessions).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
### What's changed?

- Serialize startup: `syncFromGateway` now awaits `hydrateFromLocal` via a singleton promise, ensuring local messages are loaded before gateway sync checks for duplicates
- Add `messages_logical_unique` DB index on `(task_id, role, content, timestamp, image_attachments)` as a storage-level dedup safety net
- Run a one-time migration to clean existing duplicate rows on DB open
- Silently handle UNIQUE constraint violations on message insert instead of propagating errors
- Add tests covering the hydration-sync race condition and duplicate insert resilience

### Why

- #122 added application-level content dedup in `syncFromGateway`, but the startup race between `hydrateFromLocal` and `syncFromGateway` could still defeat it — if hydration hasn't populated the store yet, the content comparison set is empty and all server messages get re-inserted with fresh UUIDs
- The DB unique index provides a last line of defense regardless of application-layer timing