### PR TITLE
[Fix] Eliminate message duplication caused by client-server timestamp mismatch in post-final sync

### DIFF
--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
@@ -82,7 +82,6 @@ export function useGatewayEventDispatcher(): void {
   const activeTaskId = useTaskStore((s) => s.activeTaskId);
   const activeTaskIdRef = useRef(activeTaskId);
   activeTaskIdRef.current = activeTaskId;
-  const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const removeDebug = window.clawwork.onDebugEvent((event) => {
@@ -163,10 +162,6 @@ export function useGatewayEventDispatcher(): void {
         store.finalizeStream(taskId);
         debugEvent('renderer.chat.finalized', { taskId, sessionKey });
         autoTitleIfNeeded(taskId);
-        clearTimeout(syncTimerRef.current ?? undefined);
-        syncTimerRef.current = setTimeout(() => {
-          syncFromGateway().catch(() => {});
-        }, 500);
       } else if (state === 'error' || state === 'aborted') {
         store.setProcessing(taskId, false);
         store.finalizeStream(taskId);
@@ -246,7 +241,6 @@ export function useGatewayEventDispatcher(): void {
     return () => {
       removeGatewayEvent();
       removeDebug();
-      clearTimeout(syncTimerRef.current ?? undefined);
     };
   }, []);
 

--- a/packages/desktop/src/renderer/lib/session-sync.ts
+++ b/packages/desktop/src/renderer/lib/session-sync.ts
@@ -70,12 +70,19 @@ export async function syncFromGateway(): Promise<void> {
       });
       if (d.messages.length === 0) continue;
       const local = messagesByTask[d.taskId] ?? [];
-      const existingKeys = new Set(local.map((msg) => `${msg.role}:${msg.timestamp}:${msg.content}`));
+      const existingCounts = new Map<string, number>();
+      for (const msg of local) {
+        const key = `${msg.role}:${msg.content}`;
+        existingCounts.set(key, (existingCounts.get(key) ?? 0) + 1);
+      }
+      const remoteCounts = new Map<string, number>();
       const newMsgs: Message[] = d.messages
-        .filter(
-          (msg: { role: string; content: string; timestamp: string }) =>
-            !existingKeys.has(`${msg.role}:${msg.timestamp}:${msg.content}`),
-        )
+        .filter((msg: { role: string; content: string; timestamp: string }) => {
+          const key = `${msg.role}:${msg.content}`;
+          const seen = remoteCounts.get(key) ?? 0;
+          remoteCounts.set(key, seen + 1);
+          return seen + 1 > (existingCounts.get(key) ?? 0);
+        })
         .map(
           (m: {
             role: string;

--- a/packages/desktop/test/session-sync.test.ts
+++ b/packages/desktop/test/session-sync.test.ts
@@ -183,6 +183,139 @@ describe('session sync startup flow', () => {
     ]);
   });
 
+  it('deduplicates messages with different timestamps but same role+content', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {},
+      streamingByTask: {},
+      streamingThinkingByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    const taskRow = {
+      id: 'task-dup',
+      sessionKey: 'agent:main:clawwork:task:task-dup',
+      sessionId: 'session-dup',
+      title: 'Dup test',
+      status: 'active',
+      model: null,
+      modelProvider: null,
+      thinkingLevel: null,
+      inputTokens: null,
+      outputTokens: null,
+      contextTokens: null,
+      createdAt: '2026-03-16T00:00:00.000Z',
+      updatedAt: '2026-03-16T00:00:00.000Z',
+      tags: [],
+      artifactDir: 'tasks/task-dup',
+      gatewayId: 'gw-1',
+    };
+    window.clawwork.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
+    window.clawwork.loadMessages.mockResolvedValue({
+      ok: true,
+      rows: [
+        { id: 'u1', taskId: 'task-dup', role: 'user', content: 'Hello', timestamp: '2026-03-16T10:00:00.123Z' },
+        {
+          id: 'a1',
+          taskId: 'task-dup',
+          role: 'assistant',
+          content: 'Hi there!',
+          timestamp: '2026-03-16T10:00:01.234Z',
+        },
+      ],
+    });
+    window.clawwork.syncSessions.mockResolvedValue({
+      ok: true,
+      discovered: [
+        {
+          gatewayId: 'gw-1',
+          taskId: 'task-dup',
+          sessionKey: 'agent:main:clawwork:task:task-dup',
+          title: 'Dup test',
+          updatedAt: '2026-03-16T10:00:02.000Z',
+          agentId: 'main',
+          messages: [
+            { role: 'user', content: 'Hello', timestamp: '2026-03-16T10:00:00.456Z' },
+            { role: 'assistant', content: 'Hi there!', timestamp: '2026-03-16T10:00:01.789Z' },
+          ],
+        },
+      ],
+    });
+
+    await sessionSync.syncFromGateway();
+
+    const msgs = messageStore.useMessageStore.getState().messagesByTask['task-dup'];
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].content).toBe('Hello');
+    expect(msgs[1].content).toBe('Hi there!');
+    expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
+  });
+
+  it('allows genuine duplicate content messages (user sends same text twice)', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {},
+      streamingByTask: {},
+      streamingThinkingByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    const taskRow = {
+      id: 'task-legit',
+      sessionKey: 'agent:main:clawwork:task:task-legit',
+      sessionId: 'session-legit',
+      title: 'Legit dup',
+      status: 'active',
+      model: null,
+      modelProvider: null,
+      thinkingLevel: null,
+      inputTokens: null,
+      outputTokens: null,
+      contextTokens: null,
+      createdAt: '2026-03-16T00:00:00.000Z',
+      updatedAt: '2026-03-16T00:00:00.000Z',
+      tags: [],
+      artifactDir: 'tasks/task-legit',
+      gatewayId: 'gw-1',
+    };
+    window.clawwork.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
+    window.clawwork.loadMessages.mockResolvedValue({
+      ok: true,
+      rows: [{ id: 'u1', taskId: 'task-legit', role: 'user', content: 'Hello', timestamp: '2026-03-16T10:00:00.000Z' }],
+    });
+    window.clawwork.syncSessions.mockResolvedValue({
+      ok: true,
+      discovered: [
+        {
+          gatewayId: 'gw-1',
+          taskId: 'task-legit',
+          sessionKey: 'agent:main:clawwork:task:task-legit',
+          title: 'Legit dup',
+          updatedAt: '2026-03-16T10:00:03.000Z',
+          agentId: 'main',
+          messages: [
+            { role: 'user', content: 'Hello', timestamp: '2026-03-16T10:00:00.500Z' },
+            { role: 'assistant', content: 'Hi!', timestamp: '2026-03-16T10:00:01.000Z' },
+            { role: 'user', content: 'Hello', timestamp: '2026-03-16T10:00:02.000Z' },
+            { role: 'assistant', content: 'Hi again!', timestamp: '2026-03-16T10:00:03.000Z' },
+          ],
+        },
+      ],
+    });
+
+    await sessionSync.syncFromGateway();
+
+    const msgs = messageStore.useMessageStore.getState().messagesByTask['task-legit'];
+    expect(msgs).toHaveLength(4);
+    expect(msgs.map((m: { content: string }) => m.content)).toEqual(['Hello', 'Hi!', 'Hello', 'Hi again!']);
+  });
+
   it('reuses resolved hydration state across later gateway sync calls', async () => {
     const { sessionSync, taskStore, messageStore } = await loadModules();
 


### PR DESCRIPTION
### What's changed?

- Remove redundant `syncFromGateway()` call triggered 500ms after every `state==='final'` stream event
- Replace timestamp-based dedup key (`role:timestamp:content`) with content-counting dedup (`role:content`) in `session-sync.ts`
- Add 2 tests: timestamp-mismatch dedup + legitimate same-content preservation

### Why

- After each bot reply, a delayed sync fetched Gateway history where messages had **server timestamps**, while local messages used **client timestamps**. The dedup key included timestamp, so even a 1ms difference caused the same message to be re-added — doubling every user message and bot reply.
- The post-final sync was entirely redundant since the real-time stream already handled all messages. Removing it eliminates the primary duplication trigger.
- The new content-counting dedup correctly handles both false duplicates (same content, different timestamps) and legitimate duplicates (user intentionally sends the same text twice).