### PR TITLE
[Refactor] Rework typography scale to 16px base with zoom persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,68 @@ See memory files for detailed phase history and technical pitfalls discovered du
 - State management uses Zustand, one store per domain (`taskStore`, `messageStore`, `uiStore`)
 - WebSocket message types are defined in `@clawwork/shared`; desktop imports from there
 
+## Debugging
+
+When investigating message duplication, rendering glitches, or state sync issues, use these tools **before** asking the user for more info.
+
+### SQLite Database
+
+The workspace DB is at `<workspace>/clawwork.db`. Query it directly:
+
+```bash
+sqlite3 clawwork.db "SELECT id, task_id, role, substr(content,1,50), timestamp FROM messages WHERE task_id='<id>' ORDER BY timestamp"
+```
+
+Check for duplicate rows (same role+content, different timestamps — a known past bug pattern):
+
+```bash
+sqlite3 clawwork.db "SELECT task_id, role, substr(content,1,50), COUNT(*) as cnt FROM messages GROUP BY task_id, role, content HAVING cnt > 1"
+```
+
+### Renderer Debug Events
+
+`useGatewayDispatcher.ts` emits structured events via `debugEvent()`. Open DevTools Console and filter by `[debug]` to see the message lifecycle:
+
+- `renderer.gateway.event.received` — raw Gateway event arrived
+- `renderer.chat.delta.applied` — streaming delta appended
+- `renderer.chat.final.received` — final event received
+- `renderer.chat.finalized` — stream finalized into message
+- `renderer.event.dropped.*` — event dropped (missing session, unknown task, etc.)
+- `renderer.toolcall.upserted` — tool call added/updated
+
+### Main Process Debug Events
+
+`window.clawwork.reportDebugEvent` forwards renderer events to the main process. These are captured in debug bundle exports (`fix(debug)` PR #125). Use the debug export feature to collect a full event trace.
+
+### Zustand State Inspection
+
+In DevTools Console, directly inspect store state:
+
+```js
+// Current messages for a task
+window.__ZUSTAND_STORES__?.messageStore?.getState()?.messagesByTask['<taskId>'];
+
+// Or via the module (if source maps available)
+// Check streamingByTask for in-progress streams
+```
+
+### When to Use Each Tool
+
+| Symptom                        | First check                                                                   |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| Duplicate messages in UI       | SQLite duplicate query → check if DB has dupes or just Zustand store          |
+| Messages missing after restart | SQLite row count → check if persist failed                                    |
+| Streaming stuck / no final     | DevTools `[debug]` filter → look for `final.received` without `finalized`     |
+| Messages from wrong task       | DevTools `[debug]` filter → check `sessionKey` → `taskId` mapping             |
+| State sync issues (reconnect)  | DevTools `[debug]` filter → look for `syncFromGateway` calls and their timing |
+
+### Past Bug Patterns
+
+| Pattern                               | Root Cause                                                                                                          | Fix Reference                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Every message doubled after bot reply | `syncFromGateway` triggered 500ms after each `state==='final'`; client vs server timestamp mismatch broke dedup key | Removed post-final sync trigger; changed dedup to content-counting (no timestamp) |
+| Startup hydration duplicates          | Race between `hydrateFromLocal` and `syncFromGateway`                                                               | Serialized via `hydrationPromise` + DB unique index (#126)                        |
+
 ## Design Documents
 
 - Full design doc: `docs/openclaw-desktop-design.md` (v0.2)

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,6 +1,6 @@
 # ClawWork Design System
 
-> Version 1.1 — Phase 3.5 + Premium Depth Pass
+> Version 1.2 — Phase 3.5 + Premium Depth Pass + Typography Rework
 > Brand identity: `#0FFD0D` (accent green), dark-first developer tool aesthetic.
 
 ## Color System
@@ -44,13 +44,31 @@ Used for backgrounds, text, borders. Dark mode uses 800-950 for backgrounds, lig
 
 ## Typography
 
-| Property  | Value                                               |
-| --------- | --------------------------------------------------- |
-| Sans font | Inter Variable                                      |
-| Mono font | JetBrains Mono Variable                             |
-| Base size | 14px (bumped from 13px in Premium Depth Pass)       |
-| Scale     | xs:11 sm:12 base:13 md:14 lg:16 xl:18 2xl:20 3xl:24 |
-| Weight    | normal:400 medium:500 semibold:600 bold:700         |
+| Property       | Value                                                     |
+| -------------- | --------------------------------------------------------- |
+| Sans font      | Inter Variable                                            |
+| Mono font      | JetBrains Mono Variable                                   |
+| Base size      | 16px (browser standard)                                   |
+| Default weight | 420 (slightly heavier than normal for retina readability) |
+| Scale          | xs:13 sm:14 base:16 md:17 lg:18 xl:20 2xl:24 3xl:28       |
+| Weight         | normal:400 medium:500 semibold:600 bold:700               |
+
+### Typography Implementation
+
+Font sizes are defined as absolute px values via `@theme` in `theme.css`. The root font-size is 16px (browser standard). All `text-xs`, `text-sm`, `text-base` etc. Tailwind classes use the `@theme` px values, not rem.
+
+Users can adjust the overall zoom level via `Cmd+` / `Cmd-` (macOS) or `Ctrl+` / `Ctrl-` (Windows/Linux). Zoom level is persisted to config.
+
+### Icon Size Scale
+
+| Token | Size | Usage                                |
+| ----- | ---- | ------------------------------------ |
+| `xs`  | 12px | Inline badges, close buttons         |
+| `sm`  | 14px | Compact toolbar, secondary actions   |
+| `md`  | 16px | Standard UI elements                 |
+| `lg`  | 18px | Primary action buttons, input icons  |
+| `xl`  | 20px | Large UI elements, loading spinners  |
+| `2xl` | 24px | Hero elements, feature illustrations |
 
 ## Spacing
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -19,7 +19,7 @@ import { registerQuickLaunchHandlers } from './ipc/quick-launch-handlers.js';
 import { registerContextHandlers } from './ipc/context-handlers.js';
 import { initTray, destroyTray, updateTrayWindow } from './tray.js';
 import { initQuickLaunch, destroyQuickLaunch, updateQuickLaunchMainWindow } from './quick-launch.js';
-import { getWorkspacePath, readConfig } from './workspace/config.js';
+import { getWorkspacePath, readConfig, updateConfig } from './workspace/config.js';
 import { initDatabase, closeDatabase } from './db/index.js';
 
 let isQuitting = false;
@@ -58,11 +58,32 @@ function setupDevScreenshot(win: BrowserWindow): void {
   ipcMain.handle('dev:screenshot', () => captureScreenshot(win));
 }
 
+function buildAppMenu(): Menu {
+  const isMac = process.platform === 'darwin';
+  const template: Electron.MenuItemConstructorOptions[] = [
+    ...(isMac ? [{ role: 'appMenu' as const }] : []),
+    { role: 'editMenu' as const },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'reload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    ...(isMac ? [{ role: 'windowMenu' as const }] : []),
+  ];
+  return Menu.buildFromTemplate(template);
+}
+
 function createWindow(): BrowserWindow {
   getDebugLogger().info({ domain: 'app', event: 'app.window.create' });
-  if (process.platform !== 'darwin') {
-    Menu.setApplicationMenu(null);
-  }
+  Menu.setApplicationMenu(buildAppMenu());
   const mainWindow = new BrowserWindow({
     width: 1280,
     height: 800,
@@ -91,7 +112,29 @@ function createWindow(): BrowserWindow {
   });
 
   mainWindow.on('ready-to-show', () => {
+    const savedZoom = readConfig()?.zoomLevel;
+    if (savedZoom) {
+      mainWindow.webContents.setZoomLevel(savedZoom);
+    }
     mainWindow.show();
+  });
+
+  mainWindow.webContents.on('before-input-event', (_event, input) => {
+    if (!(input.meta || input.control) || input.type !== 'keyDown') return;
+    if (input.key === '-' || input.key === '_') {
+      const level = mainWindow.webContents.getZoomLevel() - 0.5;
+      mainWindow.webContents.setZoomLevel(level);
+      updateConfig({ zoomLevel: level });
+    }
+  });
+
+  mainWindow.on('blur', () => {
+    if (mainWindow.isDestroyed()) return;
+    const level = mainWindow.webContents.getZoomLevel();
+    const saved = readConfig()?.zoomLevel ?? 0;
+    if (level !== saved) {
+      updateConfig({ zoomLevel: level });
+    }
   });
 
   mainWindow.webContents.setWindowOpenHandler((details) => {

--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -44,6 +44,7 @@ export interface AppConfig {
   leftNavShortcut?: 'Comma' | 'BracketLeft';
   rightPanelShortcut?: 'Period' | 'BracketRight';
   deviceId?: string;
+  zoomLevel?: number;
 }
 
 function configFilePath(): string {

--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -894,9 +894,9 @@ export default function ChatInput() {
                       'text-[var(--text-muted)] hover:text-[var(--danger)]',
                     )}
                   >
-                    <X size={10} />
+                    <X size={12} />
                   </button>
-                  <span className="absolute bottom-0 left-0 right-0 text-[9px] text-center text-[var(--text-muted)] bg-black/50 rounded-b-lg truncate px-1">
+                  <span className="absolute bottom-0 left-0 right-0 text-[11px] text-center text-[var(--text-muted)] bg-black/50 rounded-b-lg truncate px-1">
                     {img.file.name}
                   </span>
                 </motion.div>
@@ -913,19 +913,19 @@ export default function ChatInput() {
               <DropdownMenuTrigger asChild>
                 <button
                   className={cn(
-                    'inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+                    'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm',
                     'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
                     'hover:bg-[var(--bg-hover)] transition-colors',
                   )}
                 >
-                  <Cpu size={12} className="flex-shrink-0" />
+                  <Cpu size={16} className="flex-shrink-0" />
                   <span className="max-w-[100px] truncate">{modelLabel}</span>
                   {currentModelEntry?.reasoning && (
-                    <span className="px-1 py-px rounded text-[9px] font-medium bg-[var(--accent)]/15 text-[var(--accent)]">
+                    <span className="px-1 py-px rounded text-[11px] font-medium bg-[var(--accent)]/15 text-[var(--accent)]">
                       R
                     </span>
                   )}
-                  <ChevronDown size={10} className="opacity-50" />
+                  <ChevronDown size={14} className="opacity-50" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">
@@ -943,7 +943,7 @@ export default function ChatInput() {
                         >
                           <span className="truncate">{m.name ?? m.id}</span>
                           {m.reasoning && (
-                            <span className="px-1 py-px rounded text-[9px] font-medium bg-[var(--accent)]/15 text-[var(--accent)]">
+                            <span className="px-1 py-px rounded text-[11px] font-medium bg-[var(--accent)]/15 text-[var(--accent)]">
                               R
                             </span>
                           )}
@@ -967,15 +967,15 @@ export default function ChatInput() {
               <DropdownMenuTrigger asChild>
                 <button
                   className={cn(
-                    'inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+                    'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm',
                     'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
                     'hover:bg-[var(--bg-hover)] transition-colors',
                     currentThinking !== 'off' && 'text-[var(--accent)]',
                   )}
                 >
-                  <Brain size={12} className="flex-shrink-0" />
+                  <Brain size={16} className="flex-shrink-0" />
                   <span>{t(THINKING_LABEL_KEYS[currentThinking])}</span>
-                  <ChevronDown size={10} className="opacity-50" />
+                  <ChevronDown size={14} className="opacity-50" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">
@@ -997,13 +997,13 @@ export default function ChatInput() {
               <TooltipTrigger asChild>
                 <button
                   className={cn(
-                    'inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+                    'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm',
                     'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
                     'hover:bg-[var(--bg-hover)] transition-colors',
                   )}
                   onClick={() => setDashboardOpen(true)}
                 >
-                  <TerminalSquare size={12} />
+                  <TerminalSquare size={16} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top">{t('slashDashboard.tooltip')}</TooltipContent>
@@ -1022,13 +1022,13 @@ export default function ChatInput() {
                   <TooltipTrigger asChild>
                     <button
                       className={cn(
-                        'inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+                        'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm',
                         'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
                         'hover:bg-[var(--bg-hover)] transition-colors',
                       )}
                       onClick={handleCompact}
                     >
-                      <Minimize2 size={12} />
+                      <Minimize2 size={16} />
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="top">{t('contextMenu.compactSession')}</TooltipContent>
@@ -1037,13 +1037,13 @@ export default function ChatInput() {
                   <TooltipTrigger asChild>
                     <button
                       className={cn(
-                        'inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+                        'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm',
                         'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
                         'hover:bg-[var(--bg-hover)] transition-colors',
                       )}
                       onClick={handleReset}
                     >
-                      <RotateCcw size={12} />
+                      <RotateCcw size={16} />
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="top">{t('contextMenu.resetSession')}</TooltipContent>
@@ -1124,7 +1124,7 @@ export default function ChatInput() {
                 disabled={disabled}
                 className="rounded-xl text-[var(--text-muted)] hover:text-[var(--text-primary)]"
               >
-                <Paperclip size={16} />
+                <Paperclip size={18} />
               </Button>
             </motion.div>
 
@@ -1139,13 +1139,13 @@ export default function ChatInput() {
                         'bg-[var(--bg-tertiary)] text-[var(--text-secondary)]',
                       )}
                     >
-                      <File size={12} className="flex-shrink-0" />
+                      <File size={14} className="flex-shrink-0" />
                       {f.fileName}
                       <button
                         onClick={() => removeSelectedFile(f.absolutePath)}
                         className="ml-0.5 opacity-50 hover:opacity-100"
                       >
-                        <X size={10} />
+                        <X size={12} />
                       </button>
                     </span>
                   ))}
@@ -1217,13 +1217,13 @@ export default function ChatInput() {
                         !isVoiceListening && 'text-[var(--text-muted)] hover:text-[var(--text-primary)]',
                       )}
                     >
-                      <Mic size={16} />
+                      <Mic size={18} />
                     </Button>
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>{voiceTooltip}</TooltipContent>
               </Tooltip>
-              <span className="rounded-full bg-[var(--accent-soft)] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--accent)]">
+              <span className="rounded-full bg-[var(--accent-soft)] px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--accent)]">
                 {t('voiceInput.beta')}
               </span>
             </div>
@@ -1245,7 +1245,7 @@ export default function ChatInput() {
                         disabled={aborting}
                         className="rounded-xl"
                       >
-                        <Square size={14} fill="currentColor" />
+                        <Square size={16} fill="currentColor" />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>{t('chatInput.stopGenerating')}</TooltipContent>
@@ -1262,7 +1262,7 @@ export default function ChatInput() {
                   whileTap={reduced ? undefined : motionPresets.scale.whileTap}
                 >
                   <Button variant="soft" size="icon" onClick={handleSend} disabled={disabled} className="rounded-xl">
-                    <Send size={16} />
+                    <Send size={18} />
                   </Button>
                 </motion.div>
               )}
@@ -1282,7 +1282,7 @@ export default function ChatInput() {
                   'hover:bg-[var(--bg-hover)] transition-colors',
                 )}
               >
-                <FolderPlus size={12} />
+                <FolderPlus size={16} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top">Add context folder for @ file references</TooltipContent>
@@ -1291,7 +1291,7 @@ export default function ChatInput() {
             <span
               key={folder}
               className={cn(
-                'inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded-md flex-shrink-0 max-w-[140px]',
+                'inline-flex items-center gap-1 text-sm px-2 py-1 rounded-md flex-shrink-0 max-w-[160px]',
                 'bg-[var(--bg-tertiary)] text-[var(--text-muted)]',
               )}
             >
@@ -1300,11 +1300,11 @@ export default function ChatInput() {
                 onClick={() => handleRemoveContextFolder(folder)}
                 className="opacity-50 hover:opacity-100 flex-shrink-0"
               >
-                <X size={9} />
+                <X size={12} />
               </button>
             </span>
           ))}
-          <p className="flex-1 text-xs text-[var(--text-muted)] text-right tracking-wide">
+          <p className="flex-1 text-sm text-[var(--text-muted)] text-right tracking-wide">
             {isOffline
               ? t('chatInput.offlineHint')
               : sendShortcut === 'cmdEnter'

--- a/packages/desktop/src/renderer/components/FileCard.tsx
+++ b/packages/desktop/src/renderer/components/FileCard.tsx
@@ -49,15 +49,15 @@ export default function FileCard({ artifact, taskTitle, selected, onClick }: Fil
             <p className="text-xs text-[var(--text-muted)] mt-0.5">{formatFileSize(artifact.size)}</p>
           </div>
           {ext && (
-            <span className="flex-shrink-0 text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] leading-none">
+            <span className="flex-shrink-0 text-[11px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] leading-none">
               {ext}
             </span>
           )}
         </div>
       </div>
       <div className="px-3 pb-2.5 flex items-center gap-1.5">
-        <span className="text-[10px] text-[var(--text-muted)] truncate flex-1">{taskTitle}</span>
-        <span className="text-[10px] text-[var(--text-muted)] flex-shrink-0">
+        <span className="text-[11px] text-[var(--text-muted)] truncate flex-1">{taskTitle}</span>
+        <span className="text-[11px] text-[var(--text-muted)] flex-shrink-0">
           {formatRelativeTime(new Date(artifact.createdAt))}
         </span>
       </div>

--- a/packages/desktop/src/renderer/components/FilePreview.tsx
+++ b/packages/desktop/src/renderer/components/FilePreview.tsx
@@ -115,14 +115,14 @@ export default function FilePreview({ artifact, onNavigateToTask }: FilePreviewP
       <header className="flex items-center justify-between gap-2 px-4 h-11 border-b border-[var(--border)] flex-shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           {ext && (
-            <span className="flex-shrink-0 text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] leading-none">
+            <span className="flex-shrink-0 text-[11px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] leading-none">
               {ext}
             </span>
           )}
           <h3 className="text-sm font-medium text-[var(--text-primary)] truncate min-w-0">{artifact.name}</h3>
         </div>
         <div className="flex items-center gap-1.5 flex-shrink-0">
-          <span className="text-[10px] text-[var(--text-muted)]">{formatFileSize(artifact.size)}</span>
+          <span className="text-[11px] text-[var(--text-muted)]">{formatFileSize(artifact.size)}</span>
           {isCode && content !== null && <CopyButton text={content} />}
         </div>
       </header>
@@ -146,7 +146,7 @@ export default function FilePreview({ artifact, onNavigateToTask }: FilePreviewP
           onClick={() => onNavigateToTask(artifact.taskId, artifact.messageId)}
           className="w-full gap-2"
         >
-          <ExternalLink size={13} />
+          <ExternalLink size={14} />
           <span className="text-xs">{t('filePreview.goToSource')}</span>
         </Button>
       </div>

--- a/packages/desktop/src/renderer/components/SlashArgPicker.tsx
+++ b/packages/desktop/src/renderer/components/SlashArgPicker.tsx
@@ -73,12 +73,12 @@ export default function SlashArgPicker({
                     onSelect(opt);
                   }}
                 >
-                  <span className="font-mono text-[13px] font-medium shrink-0">{opt.label}</span>
+                  <span className="font-mono text-sm font-medium shrink-0">{opt.label}</span>
                   {opt.detail && <span className="ml-auto text-xs text-[var(--fg-muted)] truncate">{opt.detail}</span>}
                 </li>
               ))}
             </ul>
-            <div className="px-4 py-1.5 border-t border-[var(--border-subtle)] flex gap-3 text-[10px] text-[var(--fg-muted)]">
+            <div className="px-4 py-1.5 border-t border-[var(--border-subtle)] flex gap-3 text-[11px] text-[var(--fg-muted)]">
               <span>
                 <kbd className="font-mono">↑↓</kbd> navigate
               </span>

--- a/packages/desktop/src/renderer/components/SlashCommandMenu.tsx
+++ b/packages/desktop/src/renderer/components/SlashCommandMenu.tsx
@@ -71,7 +71,7 @@ export default function SlashCommandMenu({
                   }}
                 >
                   {/* Command name */}
-                  <span className="font-mono text-[13px] font-medium text-[var(--accent)] shrink-0">/{cmd.name}</span>
+                  <span className="font-mono text-sm font-medium text-[var(--accent)] shrink-0">/{cmd.name}</span>
                   {/* Description */}
                   <span className="text-xs truncate">{cmd.description}</span>
                   {/* Arg hint */}
@@ -81,7 +81,7 @@ export default function SlashCommandMenu({
                 </li>
               ))}
             </ul>
-            <div className="px-4 py-1.5 border-t border-[var(--border-subtle)] flex gap-3 text-[10px] text-[var(--fg-muted)]">
+            <div className="px-4 py-1.5 border-t border-[var(--border-subtle)] flex gap-3 text-[11px] text-[var(--fg-muted)]">
               <span>
                 <kbd className="font-mono">↑↓</kbd> navigate
               </span>

--- a/packages/desktop/src/renderer/components/ToolsCatalog.tsx
+++ b/packages/desktop/src/renderer/components/ToolsCatalog.tsx
@@ -26,12 +26,12 @@ export default function ToolsCatalog({ groups, onToolSelect }: ToolsCatalogProps
       <DropdownMenuTrigger asChild>
         <button
           className={cn(
-            'inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+            'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm',
             'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
             'hover:bg-[var(--bg-hover)] transition-colors',
           )}
         >
-          <Wrench size={12} className="flex-shrink-0" />
+          <Wrench size={14} className="flex-shrink-0" />
           <span>{t('rightPanel.toolCount', { count: totalTools })}</span>
         </button>
       </DropdownMenuTrigger>
@@ -41,12 +41,12 @@ export default function ToolsCatalog({ groups, onToolSelect }: ToolsCatalogProps
             {gi > 0 && <DropdownMenuSeparator />}
             <div className="flex items-center gap-1.5 px-2 py-1.5">
               {group.source === 'plugin' ? (
-                <Plug size={12} className="text-[var(--text-muted)]" />
+                <Plug size={14} className="text-[var(--text-muted)]" />
               ) : (
-                <Wrench size={12} className="text-[var(--text-muted)]" />
+                <Wrench size={14} className="text-[var(--text-muted)]" />
               )}
               <span className="text-xs font-medium text-[var(--text-primary)]">{group.label}</span>
-              <span className="text-[10px] text-[var(--text-muted)] ml-auto">{group.tools.length}</span>
+              <span className="text-[11px] text-[var(--text-muted)] ml-auto">{group.tools.length}</span>
             </div>
             {group.tools.map((tool) => (
               <DropdownMenuItem
@@ -56,7 +56,7 @@ export default function ToolsCatalog({ groups, onToolSelect }: ToolsCatalogProps
               >
                 <span className="text-xs text-[var(--text-secondary)]">{tool.label}</span>
                 {tool.description && (
-                  <span className="text-[11px] text-[var(--text-muted)] line-clamp-1">{tool.description}</span>
+                  <span className="text-xs text-[var(--text-muted)] line-clamp-1">{tool.description}</span>
                 )}
               </DropdownMenuItem>
             ))}

--- a/packages/desktop/src/renderer/components/ui/button.tsx
+++ b/packages/desktop/src/renderer/components/ui/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
     'transition-all duration-150 ease-out',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-accent)]',
     'disabled:pointer-events-none disabled:opacity-50',
-    '[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    '[&_svg]:pointer-events-none [&_svg]:size-[18px] [&_svg]:shrink-0',
   ].join(' '),
   {
     variants: {

--- a/packages/desktop/src/renderer/components/ui/dropdown-menu.tsx
+++ b/packages/desktop/src/renderer/components/ui/dropdown-menu.tsx
@@ -13,7 +13,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'relative flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-xs outline-none transition-colors',
+      'relative flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none transition-colors',
       'focus:bg-[var(--bg-hover)] focus:text-[var(--text-primary)]',
       'data-[state=open]:bg-[var(--bg-hover)]',
       'text-[var(--text-secondary)]',
@@ -22,7 +22,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <ChevronRight size={12} className="ml-auto opacity-50" />
+    <ChevronRight size={14} className="ml-auto opacity-50" />
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
@@ -54,7 +54,7 @@ const DropdownMenuLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
-    className={cn('px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]', className)}
+    className={cn('px-2 py-1 text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]', className)}
     {...props}
   />
 ));
@@ -92,7 +92,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-xs outline-none transition-colors',
+      'relative flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none transition-colors',
       'focus:bg-[var(--bg-hover)] focus:text-[var(--text-primary)]',
       'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       danger && 'text-[var(--danger)] focus:bg-[var(--danger-bg)] focus:text-[var(--danger)]',

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -106,7 +106,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, multi
         </div>
         <div className="flex items-center gap-x-1.5 gap-y-1 mt-1 flex-wrap">
           {task.status === 'completed' && (
-            <span className="text-[11px] leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)]">
+            <span className="text-xs leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)]">
               {t('common.completed')}
             </span>
           )}
@@ -114,10 +114,10 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, multi
             <Tooltip>
               <TooltipTrigger asChild>
                 <span
-                  className="inline-flex items-center gap-1 text-[11px] leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate"
+                  className="inline-flex items-center gap-1 text-xs leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate"
                   style={gwInfo.color ? { borderLeft: `2px solid ${gwInfo.color}` } : undefined}
                 >
-                  <Server size={9} className="flex-shrink-0 opacity-60" />
+                  <Server size={10} className="flex-shrink-0 opacity-60" />
                   {gwInfo.name}
                 </span>
               </TooltipTrigger>
@@ -127,11 +127,11 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, multi
           {agentInfo && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="inline-flex items-center gap-1 text-[11px] leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate">
+                <span className="inline-flex items-center gap-1 text-xs leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate">
                   {agentInfo.identity?.emoji ? (
                     <span className="text-xs leading-none">{agentInfo.identity.emoji}</span>
                   ) : (
-                    <Bot size={9} className="flex-shrink-0 opacity-60" />
+                    <Bot size={10} className="flex-shrink-0 opacity-60" />
                   )}
                   {agentInfo.name ?? agentInfo.id}
                 </span>
@@ -142,15 +142,15 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, multi
           {modelLabel && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="inline-flex items-center gap-1 text-[11px] leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate">
-                  <Cpu size={9} className="flex-shrink-0 opacity-60" />
+                <span className="inline-flex items-center gap-1 text-xs leading-tight px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] max-w-[80px] truncate">
+                  <Cpu size={10} className="flex-shrink-0 opacity-60" />
                   {modelLabel}
                 </span>
               </TooltipTrigger>
               <TooltipContent>{modelTooltip}</TooltipContent>
             </Tooltip>
           )}
-          <span className="text-[11px] leading-tight text-[var(--text-muted)]">
+          <span className="text-xs leading-tight text-[var(--text-muted)]">
             {formatRelativeTime(new Date(task.updatedAt))}
           </span>
         </div>

--- a/packages/desktop/src/renderer/styles/design-tokens.ts
+++ b/packages/desktop/src/renderer/styles/design-tokens.ts
@@ -76,29 +76,6 @@ export const radius = {
   full: '9999px',
 } as const;
 
-export const typography = {
-  fontFamily: {
-    sans: "'Inter Variable', -apple-system, BlinkMacSystemFont, system-ui, sans-serif",
-    mono: "'JetBrains Mono Variable', 'SF Mono', 'Fira Code', monospace",
-  },
-  fontSize: {
-    xs: ['12px', { lineHeight: '16px' }],
-    sm: ['13px', { lineHeight: '18px' }],
-    base: ['14px', { lineHeight: '20px' }],
-    md: ['15px', { lineHeight: '22px' }],
-    lg: ['17px', { lineHeight: '24px' }],
-    xl: ['19px', { lineHeight: '28px' }],
-    '2xl': ['22px', { lineHeight: '30px' }],
-    '3xl': ['26px', { lineHeight: '34px' }],
-  },
-  fontWeight: {
-    normal: '400',
-    medium: '500',
-    semibold: '600',
-    bold: '700',
-  },
-} as const;
-
 export const shadows = {
   sm: '0 1px 2px rgba(0, 0, 0, 0.3)',
   md: '0 2px 8px rgba(0, 0, 0, 0.4)',

--- a/packages/desktop/src/renderer/styles/theme.css
+++ b/packages/desktop/src/renderer/styles/theme.css
@@ -7,6 +7,25 @@
    See docs/design-system.md for full specification.
    ============================================================ */
 
+@theme {
+  --font-size-xs: 13px;
+  --font-size-xs--line-height: 18px;
+  --font-size-sm: 14px;
+  --font-size-sm--line-height: 20px;
+  --font-size-base: 16px;
+  --font-size-base--line-height: 24px;
+  --font-size-lg: 18px;
+  --font-size-lg--line-height: 26px;
+  --font-size-xl: 20px;
+  --font-size-xl--line-height: 28px;
+  --font-size-2xl: 24px;
+  --font-size-2xl--line-height: 32px;
+  --font-size-3xl: 28px;
+  --font-size-3xl--line-height: 36px;
+  --font-size-4xl: 36px;
+  --font-size-4xl--line-height: 40px;
+}
+
 @layer base {
   :root,
   :root[data-theme='dark'] {
@@ -88,7 +107,8 @@
       BlinkMacSystemFont,
       system-ui,
       sans-serif;
-    font-size: 14px;
+    font-size: 16px;
+    font-weight: 420;
     line-height: 1.5;
     letter-spacing: -0.011em;
     background-color: var(--bg-primary);


### PR DESCRIPTION
### What's changed?

- Bump base font size from 14px to 16px (browser standard), add `@theme` CSS font-size tokens for Tailwind v4
- Bump icon sizes across all components to match the new typography scale
- Add application menu with standard View → Zoom In/Out/Reset actions
- Persist zoom level to workspace config across sessions
- Remove dead `typography` and `iconSize` exports from design-tokens.ts (never imported)
- Update design system docs and CLAUDE.md debugging section

### Why

- 14px base was too small on high-DPI displays; 16px matches browser default and improves retina readability
- Users had no way to adjust or persist zoom level
- Dead exports added maintenance burden with no consumers