### PR TITLE
[Fix] Stabilize gateway sync, error propagation, and tool state persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,73 @@ See memory files for detailed phase history and technical pitfalls discovered du
 | `mediaLocalRoots` security check             | File sends may be rejected             | [#20258](https://github.com/openclaw/openclaw/issues/20258), [#36477](https://github.com/openclaw/openclaw/issues/36477) |
 | Session auto-reset at 4 AM                   | Long-running Task context gets cleared | Requires server-side config to disable auto-reset                                                                        |
 
+## Message Persistence Architecture (CRITICAL — do not modify without full review)
+
+### Root Principle: Single Writer per Message Role
+
+Each message role has exactly ONE code path that writes to the SQLite database. Violating this invariant **will** cause message duplication. This architecture was established after multiple duplication regressions caused by dual-write patterns.
+
+| Message Role | Sole DB Writer                            | Source of Truth            | File              |
+| ------------ | ----------------------------------------- | -------------------------- | ----------------- |
+| `user`       | `ChatInput` (after `chat.send` succeeds)  | Client (we are the author) | `ChatInput.tsx`   |
+| `assistant`  | `syncSessionMessages` / `syncFromGateway` | Gateway (`chat.history`)   | `session-sync.ts` |
+| `system`     | `addMessage` (client-generated)           | Client (local status)      | `messageStore.ts` |
+
+### Assistant Message State Machine
+
+```
+                                         sync succeeds
+  ┌────────┐  first delta  ┌───────────┐  state=final  ┌─────────┐  ──────────►  ┌───────────┐
+  │  idle  │ ────────────► │ streaming │ ────────────► │ pending │               │ canonical │
+  └────────┘               └───────────┘               └─────────┘  ◄──────────  └───────────┘
+                                                           │        sync fails       ▲
+                                                           └─► retry (backoff) ──────┘
+                                                           └─► reconnect ────────────┘
+                                                           └─► startup sync ─────────┘
+```
+
+| State     | Storage                          | In DB | In UI                          |
+| --------- | -------------------------------- | ----- | ------------------------------ |
+| streaming | `streamingByTask[taskId]`        | No    | Yes (live text)                |
+| pending   | `pendingAssistantByTask[taskId]` | No    | Yes (finalized, awaiting sync) |
+| canonical | `messagesByTask[taskId]`         | Yes   | Yes (persisted history)        |
+
+**Invariant**: These three storages never contain the same message simultaneously. Streaming becomes pending on `final`. Pending becomes canonical on sync success. Pending is cleared (not promoted) on `error`/`aborted`.
+
+### Key Functions and Their Roles
+
+| Function              | Role                                                                                                                                                      | MUST NOT                                                                            |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `finalizeStream`      | State transition: streaming → pending. Clears streaming buffers unconditionally.                                                                          | Write to DB. Write to `messagesByTask`.                                             |
+| `syncSessionMessages` | Runtime sync: pending → canonical. Fetches `chat.history`, persists to DB, calls `promotePending`. Serialized per task.                                   | Be called for `error`/`aborted` events.                                             |
+| `syncFromGateway`     | Startup sync: recover history from Gateway on connect. For existing tasks, only syncs assistant messages. For new tasks, syncs all.                       | Write user messages for existing tasks (ChatInput is the sole user message writer). |
+| `promotePending`      | Atomic Zustand update: append canonical to `messagesByTask` + merge pending's `thinkingContent`/`toolCalls`/`runId` + clear pending. Single `set()` call. | Execute as two separate updates (would cause UI flicker/duplication).               |
+| `retrySyncPending`    | On Gateway reconnect, retries sync for all tasks with pending messages.                                                                                   | —                                                                                   |
+
+### Sync Timing
+
+- **Runtime sync**: Triggered immediately after each `state === 'final'` event. Retries with backoff (2s, 4s, 8s) on failure.
+- **Startup sync**: Triggered once on first Gateway connect. Recovers messages that were pending when the app crashed.
+- **Reconnect sync**: `retrySyncPending()` retries all pending tasks when Gateway reconnects.
+
+### DB Unique Index
+
+`messages_dedup ON messages(task_id, role, timestamp)` — This is a **single-writer idempotency guard**, not a dedup strategy. Since the sync path is the sole writer for assistant messages, and all timestamps come from Gateway, the index prevents accidental re-insertion of the same message if sync runs twice.
+
+### PROHIBITED Patterns
+
+**DO NOT introduce any of the following. Each has caused regressions:**
+
+- `finalizeStream` calling `persistMessage` — Creates dual-write with sync path
+- Content-based dedup (`role:content` matching) — Fragile; streaming content differs from Gateway content (leading whitespace, encoding)
+- `content.trim()` as identity/dedup mechanism — Message content is user data, not an identity key
+- Timestamp-based dedup as the "fix" — Timestamps are a side effect of single-writer, not the mechanism that prevents duplication
+- Persisting assistant messages from any path other than `session-sync.ts`
+
+### Protocol Limitation
+
+OpenClaw Gateway `chat.history` does not return per-message IDs. The Gateway's `timestamp` (epoch ms) is the closest to a stable message identifier. The `runId` is present in streaming events but not in history responses. This is why single-writer architecture is necessary — without message IDs, any dual-write scheme requires fragile dedup.
+
 ## Coding Conventions
 
 - TypeScript strict mode; `any` is not allowed
@@ -174,9 +241,32 @@ sqlite3 clawwork.db "SELECT task_id, role, substr(content,1,50), COUNT(*) as cnt
 - `renderer.event.dropped.*` — event dropped (missing session, unknown task, etc.)
 - `renderer.toolcall.upserted` — tool call added/updated
 
-### Main Process Debug Events
+### Main Process Logs (Gateway WS Traffic)
 
-`window.clawwork.reportDebugEvent` forwards renderer events to the main process. These are captured in debug bundle exports (`fix(debug)` PR #125). Use the debug export feature to collect a full event trace.
+Gateway WS runs in Electron main process via Node.js `ws` library — **not visible in DevTools Network tab** (that only shows Vite HMR on :5173).
+
+**Terminal output:** `pnpm dev` terminal prints all `DebugLogger` output in real time:
+
+```
+[info] [gateway] gateway.connect.start {...}
+[debug] [gateway] gateway.req.sent {...}
+[debug] [gateway] gateway.event.received {...}
+```
+
+**Log file:** persisted as ndjson at `app.getPath('logs')` → `~/Library/Logs/@clawwork/desktop/debug-YYYY-MM-DD.ndjson`
+
+```bash
+# Real-time Gateway traffic
+tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | grep gateway
+
+# Filter specific event types
+tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | grep 'gateway.event.received'
+
+# Pretty-print with jq
+tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | jq 'select(.domain=="gateway")'
+```
+
+**Renderer forwarding:** `window.clawwork.reportDebugEvent` forwards renderer events to the main process. These are captured in debug bundle exports (`fix(debug)` PR #125).
 
 ### Zustand State Inspection
 
@@ -199,13 +289,16 @@ window.__ZUSTAND_STORES__?.messageStore?.getState()?.messagesByTask['<taskId>'];
 | Streaming stuck / no final     | DevTools `[debug]` filter → look for `final.received` without `finalized`     |
 | Messages from wrong task       | DevTools `[debug]` filter → check `sessionKey` → `taskId` mapping             |
 | State sync issues (reconnect)  | DevTools `[debug]` filter → look for `syncFromGateway` calls and their timing |
+| Gateway WS not connecting      | `pnpm dev` terminal → look for `gateway.connect.start` / `gateway.ws.error`   |
+| Gateway request timeout/error  | `tail -f` ndjson log → filter `gateway.req.timeout` or `gateway.res.error`    |
+| Gateway event not reaching UI  | ndjson log confirms `gateway.event.received` → DevTools check renderer side   |
 
 ### Past Bug Patterns
 
-| Pattern                               | Root Cause                                                                                                          | Fix Reference                                                                     |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Every message doubled after bot reply | `syncFromGateway` triggered 500ms after each `state==='final'`; client vs server timestamp mismatch broke dedup key | Removed post-final sync trigger; changed dedup to content-counting (no timestamp) |
-| Startup hydration duplicates          | Race between `hydrateFromLocal` and `syncFromGateway`                                                               | Serialized via `hydrationPromise` + DB unique index (#126)                        |
+| Pattern                                 | Root Cause                                                                                                                                                              | Fix                                                                                                                                                                                   |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Assistant message doubled after restart | `finalizeStream` AND `syncFromGateway` both wrote assistant messages to DB (dual-write). Content/timestamp differed between streaming accumulation and Gateway history. | Eliminated dual-write: `finalizeStream` only writes to Zustand pending state; sync path is the sole DB writer for assistant messages. See "Message Persistence Architecture" section. |
+| Startup hydration duplicates            | Race between `hydrateFromLocal` and `syncFromGateway`                                                                                                                   | Serialized via `hydrationPromise` + DB unique index (#126)                                                                                                                            |
 
 ## Design Documents
 

--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -35,7 +35,8 @@ CREATE TABLE IF NOT EXISTS messages (
   role TEXT NOT NULL,
   content TEXT NOT NULL,
   timestamp TEXT NOT NULL,
-  image_attachments TEXT
+  image_attachments TEXT,
+  tool_calls TEXT
 );
 
 CREATE TABLE IF NOT EXISTS artifacts (
@@ -82,19 +83,19 @@ function openDatabaseAt(workspacePath: string): void {
     sqlite.exec('ALTER TABLE messages ADD COLUMN image_attachments TEXT');
   } catch {}
 
-  sqlite.exec(`
-    DELETE FROM messages
-    WHERE rowid NOT IN (
-      SELECT MIN(rowid)
-      FROM messages
-      GROUP BY task_id, role, content, timestamp, COALESCE(image_attachments, '')
-    )
-  `);
+  try {
+    sqlite.exec('ALTER TABLE messages ADD COLUMN tool_calls TEXT');
+  } catch {}
+
+  sqlite.exec(`DROP INDEX IF EXISTS messages_logical_unique`);
+  sqlite.exec(`DROP INDEX IF EXISTS messages_dedup`);
 
   sqlite.exec(`
-    CREATE UNIQUE INDEX IF NOT EXISTS messages_logical_unique
-    ON messages(task_id, role, content, timestamp, COALESCE(image_attachments, ''))
+    CREATE UNIQUE INDEX IF NOT EXISTS messages_dedup
+    ON messages(task_id, role, timestamp)
   `);
+
+  sqlite.exec("DELETE FROM messages WHERE role = 'assistant' AND (content = '' OR TRIM(content) = 'NO_REPLY')");
 
   try {
     sqlite.exec("ALTER TABLE artifacts ADD COLUMN content_text TEXT NOT NULL DEFAULT ''");

--- a/packages/desktop/src/main/db/schema.ts
+++ b/packages/desktop/src/main/db/schema.ts
@@ -28,6 +28,7 @@ export const messages = sqliteTable('messages', {
   content: text('content').notNull(),
   timestamp: text('timestamp').notNull(),
   imageAttachments: text('image_attachments'),
+  toolCalls: text('tool_calls'),
 });
 
 export const artifacts = sqliteTable('artifacts', {

--- a/packages/desktop/src/main/ipc/data-handlers.ts
+++ b/packages/desktop/src/main/ipc/data-handlers.ts
@@ -113,6 +113,7 @@ export function registerDataHandlers(): void {
         content: string;
         timestamp: string;
         imageAttachments?: unknown[];
+        toolCalls?: unknown[];
       },
     ) => {
       if (!isDbReady()) return ipcError(new Error('database not ready'));
@@ -126,6 +127,15 @@ export function registerDataHandlers(): void {
             content: msg.content,
             timestamp: msg.timestamp,
             imageAttachments: msg.imageAttachments?.length ? JSON.stringify(msg.imageAttachments) : null,
+            toolCalls: msg.toolCalls?.length ? JSON.stringify(msg.toolCalls) : null,
+          })
+          .onConflictDoUpdate({
+            target: [messages.taskId, messages.role, messages.timestamp],
+            set: {
+              content: msg.content,
+              imageAttachments: msg.imageAttachments?.length ? JSON.stringify(msg.imageAttachments) : null,
+              toolCalls: msg.toolCalls?.length ? JSON.stringify(msg.toolCalls) : null,
+            },
           })
           .run();
         if (msg.role === 'assistant' && msg.content.length > 0) {
@@ -138,9 +148,6 @@ export function registerDataHandlers(): void {
         }
         return { ok: true };
       } catch (err) {
-        if (err instanceof Error && /UNIQUE constraint failed|messages_logical_unique/i.test(err.message)) {
-          return { ok: true };
-        }
         console.error('[data] create-message failed:', err);
         return ipcError(err);
       }
@@ -196,12 +203,18 @@ export function registerDataHandlers(): void {
         ok: true,
         rows: rows.map((r) => {
           let imageAttachments: unknown[] | undefined;
+          let toolCalls: unknown[] | undefined;
           if (r.imageAttachments) {
             try {
               imageAttachments = JSON.parse(r.imageAttachments as string);
             } catch {}
           }
-          return { ...r, imageAttachments };
+          if (r.toolCalls) {
+            try {
+              toolCalls = JSON.parse(r.toolCalls as string);
+            } catch {}
+          }
+          return { ...r, imageAttachments, toolCalls };
         }),
       };
     } catch (err) {

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -9,14 +9,26 @@ import type { GatewayClient } from '../ws/gateway-client.js';
 async function gatewayRpc(
   gatewayId: string,
   fn: (gw: GatewayClient) => Promise<Record<string, unknown> | void>,
-): Promise<{ ok: boolean; result?: Record<string, unknown>; error?: string }> {
+): Promise<{
+  ok: boolean;
+  result?: Record<string, unknown>;
+  error?: string;
+  errorCode?: string;
+  errorDetails?: Record<string, unknown>;
+}> {
   const gw = getGatewayClient(gatewayId);
-  if (!gw?.isConnected) return { ok: false, error: 'gateway not connected' };
+  if (!gw?.isConnected) return { ok: false, error: 'gateway not connected', errorCode: 'GATEWAY_NOT_CONNECTED' };
   try {
     const result = await fn(gw);
     return result ? { ok: true, result } : { ok: true };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };
+    const typed = err as Error & { code?: string; details?: Record<string, unknown> };
+    return {
+      ok: false,
+      error: typed.message ?? 'unknown error',
+      errorCode: typed.code,
+      errorDetails: typed.details,
+    };
   }
 }
 
@@ -61,6 +73,8 @@ interface ChatHistoryPayload {
   sessionId?: string;
 }
 
+const INTERNAL_ASSISTANT_MARKERS = new Set(['NO_REPLY']);
+
 /** Parsed tool call for transport to renderer */
 interface ParsedToolCall {
   id: string;
@@ -103,7 +117,7 @@ export function registerWsHandlers(): void {
           taskId,
           error: { message: 'gateway not connected' },
         });
-        return { ok: false, error: 'gateway not connected' };
+        return { ok: false, error: 'gateway not connected', errorCode: 'GATEWAY_NOT_CONNECTED' };
       }
       try {
         await gw.sendChatMessage(payload.sessionKey, payload.content, payload.attachments);
@@ -117,16 +131,17 @@ export function registerWsHandlers(): void {
         });
         return { ok: true };
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'unknown error';
+        const typed = err as Error & { code?: string; details?: Record<string, unknown> };
+        const msg = typed.message ?? 'unknown error';
         getDebugLogger().error({
           domain: 'ipc',
           event: 'ipc.ws.send-message.failed',
           gatewayId: payload.gatewayId,
           sessionKey: payload.sessionKey,
           taskId,
-          error: { message: msg },
+          error: { message: msg, code: typed.code },
         });
-        return { ok: false, error: msg };
+        return { ok: false, error: msg, errorCode: typed.code, errorDetails: typed.details };
       }
     },
   );
@@ -281,7 +296,11 @@ export function registerWsHandlers(): void {
                 toolCalls,
               };
             })
-            .filter((m) => m.content || m.toolCalls.length > 0);
+            .filter((m) => {
+              if (!m.content && m.toolCalls.length === 0) return false;
+              if (m.role === 'assistant' && INTERNAL_ASSISTANT_MARKERS.has(m.content.trim())) return false;
+              return true;
+            });
 
           const firstUserMsg = msgs.find((m) => m.role === 'user' && m.content);
           const titleFromMsg = firstUserMsg ? firstUserMsg.content.slice(0, 30) : '';

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -433,7 +433,8 @@ export class GatewayClient {
         error: { message: errMsg, code: frame.error?.code },
         data: { method: pending.method },
       });
-      const err = new Error(errMsg) as Error & { details?: Record<string, unknown> };
+      const err = new Error(errMsg) as Error & { code?: string; details?: Record<string, unknown> };
+      err.code = frame.error?.code;
       if (frame.error?.details) {
         err.details = frame.error.details;
       }
@@ -458,7 +459,9 @@ export class GatewayClient {
           data: { method },
           error: { message: 'not connected' },
         });
-        reject(new Error('not connected'));
+        const notConnErr = new Error('not connected') as Error & { code?: string };
+        notConnErr.code = 'GATEWAY_NOT_CONNECTED';
+        reject(notConnErr);
         return;
       }
 
@@ -481,7 +484,9 @@ export class GatewayClient {
           data: { method },
           error: { message: `request timeout: ${method}` },
         });
-        reject(new Error(`request timeout: ${method}`));
+        const timeoutErr = new Error(`request timeout: ${method}`) as Error & { code?: string };
+        timeoutErr.code = 'TIMEOUT';
+        reject(timeoutErr);
       }, REQ_TIMEOUT_MS);
 
       this.pendingRequests.set(id, {
@@ -698,7 +703,9 @@ export class GatewayClient {
         data: { method: pending.method },
         error: { message: 'connection closed' },
       });
-      pending.reject(new Error('connection closed'));
+      const closeErr = new Error('connection closed') as Error & { code?: string };
+      closeErr.code = 'GATEWAY_CONNECTION_CLOSED';
+      pending.reject(closeErr);
       this.pendingRequests.delete(id);
     }
     if (this.ws) {

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -2,6 +2,8 @@ interface IpcResult {
   ok: boolean;
   result?: Record<string, unknown>;
   error?: string;
+  errorCode?: string;
+  errorDetails?: Record<string, unknown>;
   pairingRequired?: boolean;
 }
 
@@ -137,6 +139,7 @@ interface PersistedMessage {
   content: string;
   timestamp: string;
   imageAttachments?: unknown[];
+  toolCalls?: unknown[];
 }
 
 interface DiscoveredSession {
@@ -317,6 +320,7 @@ export interface ClawWorkAPI {
     content: string;
     timestamp: string;
     imageAttachments?: unknown[];
+    toolCalls?: unknown[];
   }) => Promise<IpcResult>;
 
   deleteTask: (taskId: string) => Promise<IpcResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -157,6 +157,7 @@ function buildApi(): ClawWorkAPI {
       content: string;
       timestamp: string;
       imageAttachments?: unknown[];
+      toolCalls?: unknown[];
     }) => ipcRenderer.invoke('data:create-message', msg),
 
     deleteTask: (taskId: string) => ipcRenderer.invoke('data:delete-task', { id: taskId }),

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -182,6 +182,7 @@ export default function App() {
               role: pendingUserMessage.role,
               content: pendingUserMessage.content,
               timestamp: pendingUserMessage.timestamp,
+              toolCalls: pendingUserMessage.toolCalls,
             })
             .catch(() => {});
         })

--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -19,6 +19,8 @@ import {
 } from 'lucide-react';
 import type { MessageImageAttachment, ModelCatalogEntry, ToolEntry, FileIndexEntry } from '@clawwork/shared';
 import { toast } from 'sonner';
+import { markAbortedByUser } from '@/hooks/useGatewayDispatcher';
+import { buildAppError, formatErrorForUser, formatErrorForToast } from '@/lib/error-format';
 import { cn, modKey } from '@/lib/utils';
 import { motion as motionPresets } from '@/styles/design-tokens';
 import { Button } from '@/components/ui/button';
@@ -233,9 +235,11 @@ export default function ChatInput() {
   const activeTask = useTaskStore((s) => s.tasks.find((t) => t.id === s.activeTaskId));
 
   const isProcessing = useMessageStore((s) => (activeTask ? s.processingTasks.has(activeTask.id) : false));
-  const isStreaming = useMessageStore((s) =>
-    activeTask ? Boolean(s.streamingByTask[activeTask.id]) || Boolean(s.streamingThinkingByTask[activeTask.id]) : false,
-  );
+  const isStreaming = useMessageStore((s) => {
+    if (!activeTask) return false;
+    const turn = s.activeTurnByTask[activeTask.id];
+    return !!turn && !turn.finalized && (!!turn.streamingText || !!turn.streamingThinking);
+  });
   const isGenerating = isProcessing || isStreaming;
 
   const addMessage = useMessageStore((s) => s.addMessage);
@@ -555,9 +559,16 @@ export default function ChatInput() {
       );
       if (result && !result.ok) {
         setProcessing(task.id, false);
-        const msg = result.error || t('errors.sendFailed');
-        addMessage(task.id, 'system', `${t('errors.sendFailed')}: ${msg}`);
-        toast.error('Failed to send message', { description: msg });
+        const appError = buildAppError({
+          source: 'gateway',
+          stage: 'send',
+          rawMessage: result.error || t('errors.sendFailed'),
+          code: result.errorCode,
+          details: result.errorDetails,
+        });
+        addMessage(task.id, 'system', formatErrorForUser(appError, t));
+        const toastMsg = formatErrorForToast(appError, t);
+        toast.error(toastMsg.title, { description: toastMsg.description });
       } else {
         window.clawwork
           .persistMessage({
@@ -567,14 +578,20 @@ export default function ChatInput() {
             content: pendingUserMessage.content,
             timestamp: pendingUserMessage.timestamp,
             imageAttachments: pendingUserMessage.imageAttachments as unknown[] | undefined,
+            toolCalls: pendingUserMessage.toolCalls,
           })
           .catch(() => {});
       }
     } catch (err) {
       setProcessing(task.id, false);
-      const msg = err instanceof Error ? err.message : String(err);
-      addMessage(task.id, 'system', `${t('errors.sendFailed')}: ${msg}`);
-      toast.error('Failed to send message', { description: msg });
+      const appError = buildAppError({
+        source: 'local',
+        stage: 'send',
+        rawMessage: err instanceof Error ? err.message : String(err),
+      });
+      addMessage(task.id, 'system', formatErrorForUser(appError, t));
+      const toastMsg = formatErrorForToast(appError, t);
+      toast.error(toastMsg.title, { description: toastMsg.description });
     }
   }, [
     activeTask,
@@ -659,6 +676,7 @@ export default function ChatInput() {
   const handleAbort = useCallback(async () => {
     if (!activeTask || aborting) return;
     setAborting(true);
+    markAbortedByUser(activeTask.id);
     try {
       await window.clawwork.abortChat(activeTask.gatewayId, activeTask.sessionKey);
     } catch {

--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -76,6 +76,10 @@ const ChatMessage = memo(function ChatMessage({
     return () => clearTimeout(timer);
   }, [highlighted, onHighlightDone]);
 
+  if (!isUser && !isSystem && !message.content && message.toolCalls.length === 0 && !message.thinkingContent) {
+    return null;
+  }
+
   if (isSystem) {
     return (
       <div className="flex justify-center py-3">

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
@@ -15,7 +15,66 @@ import { useMessageStore } from '../stores/messageStore';
 import { useTaskStore } from '../stores/taskStore';
 import { useUiStore } from '../stores/uiStore';
 import { useApprovalStore } from '../stores/approvalStore';
-import { hydrateFromLocal, syncFromGateway } from '../lib/session-sync';
+import { hydrateFromLocal, syncFromGateway, syncSessionMessages, retrySyncPending } from '../lib/session-sync';
+import { buildAppError, formatErrorForUser, formatErrorForToast } from '../lib/error-format';
+
+interface ErrorCorrelation {
+  taskId: string;
+  runId?: string;
+  code?: string;
+  source: string;
+  rawMessage: string;
+  displayedAt: number;
+}
+
+const DEDUP_FALLBACK_WINDOW_MS = 2000;
+
+function isSameFailure(a: ErrorCorrelation, existing: ErrorCorrelation): boolean {
+  if (a.taskId !== existing.taskId) return false;
+  if (a.runId && existing.runId) return a.runId === existing.runId;
+  if (a.code && existing.code) return a.code === existing.code && a.source === existing.source;
+  return false;
+}
+
+const perTaskLastError = new Map<string, ErrorCorrelation>();
+const lifecycleErrorBuffer = new Map<string, { error: string; runId?: string; timer: ReturnType<typeof setTimeout> }>();
+const abortedByUser = new Set<string>();
+
+export function markAbortedByUser(taskId: string): void {
+  abortedByUser.add(taskId);
+}
+
+function shouldDisplayError(correlation: ErrorCorrelation): boolean {
+  const existing = perTaskLastError.get(correlation.taskId);
+  if (!existing) return true;
+  if (isSameFailure(correlation, existing)) return false;
+  if (Date.now() - existing.displayedAt < DEDUP_FALLBACK_WINDOW_MS) {
+    if (
+      !correlation.runId &&
+      !existing.runId &&
+      !correlation.code &&
+      !existing.code &&
+      correlation.source === existing.source &&
+      correlation.rawMessage === existing.rawMessage
+    )
+      return false;
+  }
+  return true;
+}
+
+function recordDisplayedError(correlation: ErrorCorrelation): void {
+  perTaskLastError.set(correlation.taskId, { ...correlation, displayedAt: Date.now() });
+}
+
+function clearTaskErrorState(taskId: string): void {
+  perTaskLastError.delete(taskId);
+  abortedByUser.delete(taskId);
+  const buffered = lifecycleErrorBuffer.get(taskId);
+  if (buffered) {
+    clearTimeout(buffered.timer);
+    lifecycleErrorBuffer.delete(taskId);
+  }
+}
 
 function debugEvent(
   event: string,
@@ -45,6 +104,7 @@ interface ChatContentBlock {
 interface ChatMessage {
   role?: string;
   content?: ChatContentBlock[];
+  timestamp?: number;
 }
 
 interface ChatEventPayload {
@@ -54,24 +114,52 @@ interface ChatEventPayload {
   message?: ChatMessage;
   content?: ChatContentBlock[];
   text?: string;
+  errorMessage?: string;
+  errorCode?: string;
+  error?: { code?: string; message?: string; details?: Record<string, unknown> };
 }
+
+type AgentEventStream = 'lifecycle' | 'tool' | 'assistant' | 'error' | 'compaction';
 
 interface AgentToolData {
-  phase?: string; // "update" = running, "result" = done, "error" = error
-  name?: string; // tool name, e.g. "exec"
-  toolCallId?: string; // e.g. "call_9GV1FoNq..."
-  meta?: string; // result description (present on "result" phase)
-  isError?: boolean; // true if tool errored
-  args?: string; // tool arguments (sometimes present)
+  phase?: string;
+  name?: string;
+  toolCallId?: string;
+  meta?: string;
+  isError?: boolean;
+  args?: string;
 }
 
-interface AgentToolEvent {
+interface AgentLifecycleData {
+  phase?: 'start' | 'end' | 'error' | 'fallback';
+  error?: string;
+  startedAt?: number;
+  endedAt?: number;
+  selectedProvider?: string;
+  selectedModel?: string;
+  activeProvider?: string;
+  activeModel?: string;
+}
+
+interface AgentErrorData {
+  reason?: string;
+  expected?: number;
+  received?: number;
+}
+
+interface AgentCompactionData {
+  phase?: 'start' | 'end';
+  willRetry?: boolean;
+  completed?: boolean;
+}
+
+interface AgentEvent {
   sessionKey: string;
   runId?: string;
-  stream?: string;
+  stream?: AgentEventStream | string;
   seq?: number;
   ts?: number;
-  data?: AgentToolData;
+  data?: AgentToolData | AgentLifecycleData | AgentErrorData | AgentCompactionData;
 }
 
 /**
@@ -97,7 +185,7 @@ export function useGatewayEventDispatcher(): void {
       if (data.event === 'chat') {
         handleChatEvent(data.payload as unknown as ChatEventPayload);
       } else if (data.event === 'agent') {
-        handleAgentEvent(data.payload as unknown as AgentToolEvent);
+        handleAgentEvent(data.payload as unknown as AgentEvent);
       } else if (data.event === 'exec.approval.requested') {
         useApprovalStore.getState().addApproval(data.gatewayId, data.payload as unknown as ExecApprovalRequest);
         toast.warning(i18n.t('approval.newRequest'));
@@ -134,6 +222,7 @@ export function useGatewayEventDispatcher(): void {
       const thinking = extractThinking(payload);
 
       if (state === 'delta') {
+        clearTaskErrorState(taskId);
         if (text) {
           store.setProcessing(taskId, false);
           store.appendStreamDelta(taskId, text);
@@ -159,24 +248,75 @@ export function useGatewayEventDispatcher(): void {
         for (const tc of toolCalls) {
           store.upsertToolCall(taskId, tc);
         }
-        store.finalizeStream(taskId);
+        store.finalizeStream(taskId, { runId: payload.runId });
         debugEvent('renderer.chat.finalized', { taskId, sessionKey });
         autoTitleIfNeeded(taskId);
-      } else if (state === 'error' || state === 'aborted') {
+        syncSessionMessages(taskId).catch((err) => {
+          debugEvent('renderer.sync.post-final.failed', {
+            taskId,
+            sessionKey,
+            error: err instanceof Error ? err.message : 'unknown',
+          });
+        });
+      } else if (state === 'error') {
         store.setProcessing(taskId, false);
-        store.finalizeStream(taskId);
-        debugEvent('renderer.chat.terminated', { taskId, sessionKey, state });
-        if (state === 'error') {
-          const errText = extractText(payload) || i18n.t('errors.requestFailed');
-          store.addMessage(taskId, 'system', errText);
+        store.clearActiveTurn(taskId);
+
+        const buffered = lifecycleErrorBuffer.get(taskId);
+        if (buffered) {
+          clearTimeout(buffered.timer);
+          lifecycleErrorBuffer.delete(taskId);
         }
+
+        const errorCode = payload.errorCode ?? payload.error?.code;
+        const errorDetails = payload.error?.details;
+        const rawMessage =
+          payload.errorMessage ?? payload.error?.message ?? (extractText(payload) || i18n.t('errors.requestFailed'));
+        const appError = buildAppError({
+          source: 'upstream',
+          stage: 'stream',
+          rawMessage,
+          code: errorCode,
+          details: errorDetails,
+        });
+        const correlation: ErrorCorrelation = {
+          taskId,
+          runId: payload.runId,
+          code: errorCode,
+          source: 'upstream',
+          rawMessage,
+          displayedAt: 0,
+        };
+
+        debugEvent('renderer.chat.error', { taskId, sessionKey, rawMessage, code: errorCode, runId: payload.runId });
+
+        if (shouldDisplayError(correlation)) {
+          const userText = formatErrorForUser(appError, i18n.t);
+          store.addMessage(taskId, 'system', userText);
+          const { title, description } = formatErrorForToast(appError, i18n.t);
+          toast.error(title, { description });
+          recordDisplayedError(correlation);
+        }
+      } else if (state === 'aborted') {
+        store.setProcessing(taskId, false);
+        store.clearActiveTurn(taskId);
+        debugEvent('renderer.chat.aborted', { taskId, sessionKey, userInitiated: abortedByUser.has(taskId) });
+
+        if (!abortedByUser.has(taskId)) {
+          store.addMessage(
+            taskId,
+            'system',
+            i18n.t('errors.serverAborted', { defaultValue: 'Task interrupted by server' }),
+          );
+        }
+        abortedByUser.delete(taskId);
       }
     }
 
-    function handleAgentEvent(payload: AgentToolEvent): void {
+    function handleAgentEvent(payload: AgentEvent): void {
       const { sessionKey, stream, data } = payload;
-      if (stream !== 'tool' || !data || !sessionKey) {
-        debugEvent('renderer.agent.dropped.invalid_payload', {
+      if (!sessionKey || !data) {
+        debugEvent('renderer.agent.dropped.missing_fields', {
           stream,
           hasData: Boolean(data),
           hasSessionKey: Boolean(sessionKey),
@@ -190,13 +330,48 @@ export function useGatewayEventDispatcher(): void {
         return;
       }
 
-      if (!data.name || !data.toolCallId) return;
-
       const localTasks = useTaskStore.getState().tasks;
       if (!localTasks.some((t) => t.id === taskId)) {
         debugEvent('renderer.agent.dropped.unknown_task', { taskId, sessionKey, stream });
         return;
       }
+
+      switch (stream) {
+        case 'tool':
+          handleAgentToolStream(taskId, sessionKey, data as AgentToolData);
+          break;
+        case 'lifecycle':
+          handleAgentLifecycleStream(taskId, sessionKey, data as AgentLifecycleData);
+          break;
+        case 'error':
+          handleAgentErrorStream(taskId, sessionKey, data as AgentErrorData);
+          break;
+        case 'assistant':
+          debugEvent('renderer.agent.assistant_stream', { taskId, sessionKey });
+          break;
+        case 'compaction':
+          debugEvent('renderer.agent.compaction', {
+            taskId,
+            sessionKey,
+            phase: (data as AgentCompactionData).phase,
+            completed: (data as AgentCompactionData).completed,
+          });
+          break;
+        default:
+          debugEvent('renderer.agent.unknown_stream', {
+            taskId,
+            sessionKey,
+            stream,
+            topLevelKeys: data ? Object.keys(data) : [],
+            phase: (data as Record<string, unknown>)?.phase,
+            reason: (data as Record<string, unknown>)?.reason,
+          });
+          break;
+      }
+    }
+
+    function handleAgentToolStream(taskId: string, sessionKey: string, data: AgentToolData): void {
+      if (!data.name || !data.toolCallId) return;
 
       if (taskId !== activeTaskIdRef.current) {
         useUiStore.getState().markUnread(taskId);
@@ -234,6 +409,80 @@ export function useGatewayEventDispatcher(): void {
         toolCallId: tc.id,
         status: tc.status,
         name: tc.name,
+      });
+    }
+
+    function handleAgentLifecycleStream(taskId: string, sessionKey: string, data: AgentLifecycleData): void {
+      const store = useMessageStore.getState();
+
+      switch (data.phase) {
+        case 'start':
+          store.setProcessing(taskId, true);
+          debugEvent('renderer.agent.lifecycle.start', { taskId, sessionKey });
+          break;
+        case 'end':
+          store.setProcessing(taskId, false);
+          debugEvent('renderer.agent.lifecycle.end', { taskId, sessionKey });
+          break;
+        case 'error': {
+          store.setProcessing(taskId, false);
+          debugEvent('renderer.agent.lifecycle.error', {
+            taskId,
+            sessionKey,
+            error: data.error,
+          });
+          if (!data.error) break;
+
+          const existing = lifecycleErrorBuffer.get(taskId);
+          if (existing) clearTimeout(existing.timer);
+
+          const timer = setTimeout(() => {
+            lifecycleErrorBuffer.delete(taskId);
+            const errorText = data.error!;
+            const appError = buildAppError({ source: 'agent', stage: 'lifecycle', rawMessage: errorText });
+            const correlation: ErrorCorrelation = {
+              taskId,
+              runId: undefined,
+              source: 'agent',
+              rawMessage: errorText,
+              displayedAt: 0,
+            };
+            if (shouldDisplayError(correlation)) {
+              store.addMessage(taskId, 'system', formatErrorForUser(appError, i18n.t));
+              const { title, description } = formatErrorForToast(appError, i18n.t);
+              toast.error(title, { description });
+              recordDisplayedError(correlation);
+            }
+          }, DEDUP_FALLBACK_WINDOW_MS);
+
+          lifecycleErrorBuffer.set(taskId, { error: data.error, timer });
+          break;
+        }
+        case 'fallback':
+          debugEvent('renderer.agent.lifecycle.fallback', {
+            taskId,
+            sessionKey,
+            from: `${data.selectedProvider}/${data.selectedModel}`,
+            to: `${data.activeProvider}/${data.activeModel}`,
+          });
+          if (data.activeModel) {
+            const msg = i18n.t('agent.modelFallback', {
+              model: data.activeModel,
+              defaultValue: `Switched to model: ${data.activeModel}`,
+            });
+            store.addMessage(taskId, 'system', msg, undefined, { persist: false });
+          }
+          break;
+      }
+    }
+
+    function handleAgentErrorStream(taskId: string, sessionKey: string, data: AgentErrorData): void {
+      debugEvent('renderer.agent.stream_error', {
+        taskId,
+        sessionKey,
+        reason: data.reason,
+        expected: data.expected,
+        received: data.received,
       });
     }
 
@@ -311,6 +560,7 @@ export function useGatewayEventDispatcher(): void {
           syncedRef.current = true;
           syncFromGateway();
         }
+        retrySyncPending();
         fetchCatalogs(s.gatewayId);
       } else if (!s.connected && wasConnected) {
         connectedGatewaysRef.current.delete(s.gatewayId);
@@ -376,9 +626,12 @@ function autoTitleIfNeeded(taskId: string): void {
   const { tasks, updateTaskTitle } = useTaskStore.getState();
   const task = tasks.find((t) => t.id === taskId);
   if (task && !task.title) {
-    const msgs = useMessageStore.getState().messagesByTask[taskId] ?? [];
-    const firstAssistant = msgs.find((m) => m.role === 'assistant');
-    if (firstAssistant) {
+    const store = useMessageStore.getState();
+    const msgs = store.messagesByTask[taskId] ?? [];
+    const turn = store.activeTurnByTask[taskId];
+    const firstAssistant =
+      msgs.find((m) => m.role === 'assistant') ?? (turn?.content ? { content: turn.content } : null);
+    if (firstAssistant && firstAssistant.content) {
       const title = firstAssistant.content.slice(0, 30).replace(/\n/g, ' ').trim();
       if (title) {
         updateTaskTitle(taskId, title + (firstAssistant.content.length > 30 ? '…' : ''));

--- a/packages/desktop/src/renderer/hooks/useTraySync.ts
+++ b/packages/desktop/src/renderer/hooks/useTraySync.ts
@@ -36,13 +36,13 @@ export function useTraySync(): void {
     if (prevRef.current.status === status && prevRef.current.taskIds === taskIdsKey) return;
     prevRef.current = { status, taskIds: taskIdsKey };
 
-    const streamingByTask = useMessageStore.getState().streamingByTask;
+    const activeTurnByTask = useMessageStore.getState().activeTurnByTask;
     const activeTasks = activeIds.map((id) => {
       const t = tasks.find((task) => task.id === id)!;
       return {
         taskId: id,
         title: t.title || 'Untitled',
-        snippet: (streamingByTask[id] ?? '').slice(0, 60),
+        snippet: (activeTurnByTask[id]?.streamingText ?? '').slice(0, 60),
         duration: formatDuration(t.updatedAt),
       };
     });

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -208,7 +208,21 @@
   },
   "errors": {
     "requestFailed": "Request failed",
-    "sendFailed": "Send failed"
+    "sendFailed": "Send failed",
+    "serverAborted": "Task interrupted by server",
+    "unknown": "Unknown error",
+    "failed": "failed",
+    "stage": {
+      "send": "Send",
+      "stream": "Stream",
+      "final": "Finalize",
+      "lifecycle": "Agent",
+      "sync": "Sync",
+      "persist": "Persist"
+    }
+  },
+  "agent": {
+    "modelFallback": "Switched to model: {{model}}"
   },
   "chatInput": {
     "describeTask": "Describe your task…",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -208,7 +208,21 @@
   },
   "errors": {
     "requestFailed": "请求出错",
-    "sendFailed": "发送失败"
+    "sendFailed": "发送失败",
+    "serverAborted": "任务被服务端中止",
+    "unknown": "未知错误",
+    "failed": "失败",
+    "stage": {
+      "send": "发送",
+      "stream": "推流",
+      "final": "完成",
+      "lifecycle": "Agent",
+      "sync": "同步",
+      "persist": "持久化"
+    }
+  },
+  "agent": {
+    "modelFallback": "已切换至模型: {{model}}"
   },
   "chatInput": {
     "describeTask": "描述你的任务…",

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -27,7 +27,10 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, multi
   const clearUnread = useUiStore((s) => s.clearUnread);
   const hasUnread = useUiStore((s) => s.unreadTaskIds.has(task.id));
   const setMainView = useUiStore((s) => s.setMainView);
-  const isStreaming = useMessageStore((s) => !!s.streamingByTask[task.id]);
+  const isStreaming = useMessageStore((s) => {
+    const turn = s.activeTurnByTask[task.id];
+    return !!turn && !turn.finalized && (!!turn.streamingText || !!turn.streamingThinking);
+  });
   const gwInfo = useUiStore((s) => s.gatewayInfoMap[task.gatewayId]);
   const agentInfo = useUiStore((s) =>
     task.agentId && task.agentId !== 'main'

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -19,9 +19,8 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import type { ToolCall } from '@clawwork/shared';
 import { useTaskStore } from '@/stores/taskStore';
-import { useMessageStore, EMPTY_MESSAGES } from '@/stores/messageStore';
+import { useMessageStore, EMPTY_MESSAGES, activeTurnToMessage } from '@/stores/messageStore';
 import { useUiStore } from '@/stores/uiStore';
 import { cn, formatRelativeTime, formatTokenCount, formatCost } from '@/lib/utils';
 import { motion as motionPresets } from '@/styles/design-tokens';
@@ -41,7 +40,6 @@ import { useUsageStore } from '@/stores/usageStore';
 import { fetchAgentsForGateway } from '@/hooks/useGatewayDispatcher';
 
 const STICK_TO_BOTTOM_THRESHOLD_PX = 60;
-const EMPTY_TOOL_CALLS: ToolCall[] = [];
 
 interface MainAreaProps {
   onTogglePanel: () => void;
@@ -499,25 +497,10 @@ function ChatContent() {
   const messages = useMessageStore((s) =>
     activeTaskId ? (s.messagesByTask[activeTaskId] ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
   );
-  const streamingContent = useMessageStore((s) => (activeTaskId ? (s.streamingByTask[activeTaskId] ?? '') : ''));
-  const streamingThinkingContent = useMessageStore((s) =>
-    activeTaskId ? (s.streamingThinkingByTask[activeTaskId] ?? '') : '',
-  );
+  const activeTurn = useMessageStore((s) => (activeTaskId ? (s.activeTurnByTask[activeTaskId] ?? null) : null));
   const highlightedId = useMessageStore((s) => s.highlightedMessageId);
   const setHighlightedMessage = useMessageStore((s) => s.setHighlightedMessage);
   const isProcessing = useMessageStore((s) => (activeTaskId ? s.processingTasks.has(activeTaskId) : false));
-  const streamingToolCalls = useMessageStore((s) => {
-    if (!activeTaskId) return EMPTY_TOOL_CALLS;
-    const msgs = s.messagesByTask[activeTaskId];
-    if (!msgs?.length) return EMPTY_TOOL_CALLS;
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      if (msgs[i].role === 'user') break;
-      if (msgs[i].role === 'assistant' && msgs[i].toolCalls.length > 0) {
-        return msgs[i].toolCalls.some((tc) => tc.status === 'running') ? msgs[i].toolCalls : EMPTY_TOOL_CALLS;
-      }
-    }
-    return EMPTY_TOOL_CALLS;
-  });
   const viewportRef = useRef<HTMLDivElement>(null);
   const stickToBottom = useRef(true);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
@@ -536,14 +519,14 @@ function ChatContent() {
     if (!stickToBottom.current) return;
     const el = viewportRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [messages.length, streamingContent, streamingThinkingContent, isProcessing, streamingToolCalls]);
+  }, [messages.length, activeTurn, isProcessing]);
 
   return (
     <>
       <ScrollArea viewportRef={viewportRef} className="flex-1 px-6 py-4" onScrollCapture={handleScroll}>
         <div className="max-w-3xl mx-auto space-y-1">
           {!activeTask && <WelcomeScreen />}
-          {activeTask && messages.length === 0 && !streamingContent && !streamingThinkingContent && <WelcomeScreen />}
+          {activeTask && messages.length === 0 && !activeTurn && <WelcomeScreen />}
           {messages.map((msg) => (
             <ChatMessage
               key={msg.id}
@@ -554,17 +537,32 @@ function ChatContent() {
               onFileClick={setPreviewFile}
             />
           ))}
-          {(streamingContent || streamingThinkingContent || streamingToolCalls.length > 0) && (
-            <StreamingMessage
-              content={streamingContent}
-              thinkingContent={streamingThinkingContent || undefined}
-              toolCalls={streamingToolCalls}
+          {activeTurn?.finalized && activeTurn.content && (
+            <ChatMessage
+              key={`turn-${activeTurn.id}`}
+              message={activeTurnToMessage(activeTurn, activeTaskId!)}
+              highlighted={false}
+              onHighlightDone={handleHighlightDone}
+              onImageClick={setLightboxSrc}
+              onFileClick={setPreviewFile}
             />
           )}
-          <AnimatePresence>
-            {isProcessing && !streamingContent && !streamingThinkingContent && streamingToolCalls.length === 0 && (
-              <ThinkingIndicator />
+          {activeTurn &&
+            !activeTurn.finalized &&
+            (activeTurn.streamingText || activeTurn.streamingThinking || activeTurn.toolCalls.length > 0) && (
+              <StreamingMessage
+                content={activeTurn.streamingText}
+                thinkingContent={activeTurn.streamingThinking || undefined}
+                toolCalls={activeTurn.toolCalls}
+              />
             )}
+          <AnimatePresence>
+            {isProcessing &&
+              (!activeTurn ||
+                (!activeTurn.streamingText &&
+                  !activeTurn.streamingThinking &&
+                  activeTurn.toolCalls.length === 0 &&
+                  !activeTurn.finalized)) && <ThinkingIndicator />}
           </AnimatePresence>
         </div>
       </ScrollArea>

--- a/packages/desktop/src/renderer/lib/error-format.ts
+++ b/packages/desktop/src/renderer/lib/error-format.ts
@@ -1,0 +1,42 @@
+import type { AppError, ErrorSource, ErrorStage, Retryable } from '@clawwork/shared';
+import { RETRYABLE_ERROR_CODES, NON_RETRYABLE_ERROR_CODES } from '@clawwork/shared';
+import type { TFunction } from 'i18next';
+
+export function classifyRetryable(code?: string): Retryable {
+  if (!code) return 'unknown';
+  if (RETRYABLE_ERROR_CODES.has(code)) return 'yes';
+  if (NON_RETRYABLE_ERROR_CODES.has(code)) return 'no';
+  return 'unknown';
+}
+
+export function buildAppError(opts: {
+  source: ErrorSource;
+  stage: ErrorStage;
+  rawMessage: string;
+  code?: string;
+  details?: Record<string, unknown>;
+}): AppError {
+  return {
+    source: opts.source,
+    stage: opts.stage,
+    code: opts.code,
+    rawMessage: opts.rawMessage,
+    details: opts.details,
+    retryable: classifyRetryable(opts.code),
+  };
+}
+
+export function formatErrorForUser(err: AppError, t: TFunction): string {
+  const stageLabel = t(`errors.stage.${err.stage}`, { defaultValue: err.stage });
+  if (err.rawMessage) return `${stageLabel}: ${err.rawMessage}`;
+  if (err.code) return `${stageLabel}: [${err.code}]`;
+  return `${stageLabel}: ${t('errors.unknown', { defaultValue: 'Unknown error' })}`;
+}
+
+export function formatErrorForToast(err: AppError, t: TFunction): { title: string; description: string } {
+  const stageKey = `errors.stage.${err.stage}`;
+  const stageLabel = t(stageKey, { defaultValue: err.stage });
+  const title = `${stageLabel} ${t('errors.failed', { defaultValue: 'failed' })}`;
+  const description = err.rawMessage || err.code || t('errors.unknown', { defaultValue: 'Unknown error' });
+  return { title, description };
+}

--- a/packages/desktop/src/renderer/lib/session-sync.ts
+++ b/packages/desktop/src/renderer/lib/session-sync.ts
@@ -1,18 +1,23 @@
 import type { Message, MessageRole, ToolCall } from '@clawwork/shared';
 import { useTaskStore } from '../stores/taskStore';
-import { useMessageStore } from '../stores/messageStore';
+import { mergeCanonicalMessageWithActiveTurn, useMessageStore } from '../stores/messageStore';
 
 const GATEWAY_INJECTED_MODEL = 'gateway-injected';
+const INTERNAL_ASSISTANT_MARKERS = new Set(['NO_REPLY']);
 let hydrationPromise: Promise<void> | null = null;
 
 function sanitizeModel(model?: string): string | undefined {
   return model === GATEWAY_INJECTED_MODEL ? undefined : model;
 }
 
-/**
- * Load tasks and their messages from local SQLite.
- * Called once on mount for instant offline render.
- */
+function isVisibleAssistantContent(content: string): boolean {
+  const trimmed = content.trim();
+  return trimmed.length > 0 && !INTERNAL_ASSISTANT_MARKERS.has(trimmed);
+}
+
+const syncChains = new Map<string, Promise<void>>();
+const RETRY_DELAYS = [2000, 4000, 8000];
+
 export async function hydrateFromLocal(): Promise<void> {
   if (!hydrationPromise) {
     hydrationPromise = (async () => {
@@ -30,7 +35,7 @@ export async function hydrateFromLocal(): Promise<void> {
               role: r.role as MessageRole,
               content: r.content,
               artifacts: [],
-              toolCalls: [],
+              toolCalls: Array.isArray(r.toolCalls) ? (r.toolCalls as ToolCall[]) : [],
               timestamp: r.timestamp,
               imageAttachments: r.imageAttachments as Message['imageAttachments'],
             }));
@@ -40,14 +45,291 @@ export async function hydrateFromLocal(): Promise<void> {
       }
     })();
   }
-
   await hydrationPromise;
 }
 
-/**
- * Discover sessions from all connected Gateways and adopt any that don't exist locally.
- * Called once on first Gateway connect.
- */
+interface RawContentBlock {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown> | string;
+  result?: unknown;
+}
+
+interface RawHistoryMessage {
+  role: string;
+  content?: RawContentBlock[];
+  timestamp?: number;
+}
+
+interface NormalizedAssistantTurn {
+  content: string;
+  toolCalls: ToolCall[];
+  timestamp: string;
+}
+
+interface DiscoveredMessageShape {
+  role: string;
+  content: string;
+  timestamp: string;
+  toolCalls?: ToolCall[];
+}
+
+function extractAssistantText(blocks: RawContentBlock[]): string {
+  return blocks
+    .filter((b) => b.type === 'text' && b.text)
+    .map((b) => b.text!)
+    .join('');
+}
+
+function toISOTimestamp(epoch: number | undefined): string {
+  return epoch ? new Date(epoch).toISOString() : new Date().toISOString();
+}
+
+function appendSegment(base: string, segment: string): string {
+  const trimmed = segment.trim();
+  if (!trimmed) return base;
+  if (!base) return trimmed;
+  return `${base}\n\n${trimmed}`;
+}
+
+function safeJsonParse(raw: string): Record<string, unknown> | undefined {
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): NormalizedAssistantTurn[] {
+  const toolResultMap = new Map<string, string>();
+  for (const msg of rawMsgs) {
+    if (msg.role !== 'toolResult') continue;
+    for (const block of msg.content ?? []) {
+      if (block.type === 'toolResult' && block.id && block.result !== undefined) {
+        toolResultMap.set(block.id, typeof block.result === 'string' ? block.result : JSON.stringify(block.result));
+      }
+    }
+  }
+
+  const turns: NormalizedAssistantTurn[] = [];
+  let current: NormalizedAssistantTurn | null = null;
+
+  function ensureCurrent(timestamp: string): NormalizedAssistantTurn {
+    if (!current) {
+      current = { content: '', toolCalls: [], timestamp };
+      turns.push(current);
+    }
+    return current;
+  }
+
+  for (const msg of rawMsgs) {
+    if (msg.role === 'user') {
+      current = null;
+      continue;
+    }
+    if (msg.role !== 'assistant') continue;
+
+    const timestamp = toISOTimestamp(msg.timestamp);
+    const text = extractAssistantText(msg.content ?? []);
+    const toolCalls = (msg.content ?? [])
+      .filter((block) => block.type === 'toolCall' && block.id && block.name)
+      .map(
+        (block): ToolCall => ({
+          id: block.id!,
+          name: block.name!,
+          status: toolResultMap.has(block.id!) ? 'done' : 'running',
+          args:
+            typeof block.arguments === 'object' && block.arguments !== null
+              ? (block.arguments as Record<string, unknown>)
+              : typeof block.arguments === 'string'
+                ? safeJsonParse(block.arguments)
+                : undefined,
+          result: toolResultMap.get(block.id!),
+          startedAt: timestamp,
+          completedAt: toolResultMap.has(block.id!) ? timestamp : undefined,
+        }),
+      );
+
+    if (!text.trim() && toolCalls.length === 0) continue;
+
+    const visibleText = isVisibleAssistantContent(text) ? text.trim() : '';
+
+    if (toolCalls.length > 0) {
+      const turn = ensureCurrent(timestamp);
+      const existingIds = new Set(turn.toolCalls.map((toolCall) => toolCall.id));
+      turn.toolCalls.push(...toolCalls.filter((toolCall) => !existingIds.has(toolCall.id)));
+      if (visibleText) {
+        turn.content = appendSegment(turn.content, visibleText);
+      }
+      turn.timestamp = timestamp;
+      continue;
+    }
+
+    if (!visibleText) continue;
+
+    const turn = ensureCurrent(timestamp);
+    turn.content = appendSegment(turn.content, visibleText);
+    turn.timestamp = timestamp;
+  }
+
+  return turns.filter((turn) => turn.content || turn.toolCalls.length > 0);
+}
+
+function collapseDiscoveredMessages(messages: DiscoveredMessageShape[], taskId: string): Message[] {
+  const collapsed: Message[] = [];
+  let currentAssistant: Message | null = null;
+
+  function flushAssistant(): void {
+    if (!currentAssistant) return;
+    if (currentAssistant.content || currentAssistant.toolCalls.length > 0) {
+      collapsed.push(currentAssistant);
+    }
+    currentAssistant = null;
+  }
+
+  for (const message of messages) {
+    if (message.role === 'user') {
+      flushAssistant();
+      collapsed.push({
+        id: crypto.randomUUID(),
+        taskId,
+        role: 'user',
+        content: message.content,
+        artifacts: [],
+        toolCalls: [],
+        timestamp: message.timestamp,
+      });
+      continue;
+    }
+
+    if (message.role !== 'assistant') continue;
+
+    const visibleText = isVisibleAssistantContent(message.content) ? message.content.trim() : '';
+    const toolCalls = message.toolCalls ?? [];
+    if (!visibleText && toolCalls.length === 0) continue;
+
+    if (!currentAssistant) {
+      currentAssistant = {
+        id: crypto.randomUUID(),
+        taskId,
+        role: 'assistant',
+        content: '',
+        artifacts: [],
+        toolCalls: [],
+        timestamp: message.timestamp,
+      };
+    }
+
+    if (visibleText) {
+      currentAssistant.content = appendSegment(currentAssistant.content, visibleText);
+    }
+    if (toolCalls.length > 0) {
+      const existingIds = new Set(currentAssistant.toolCalls.map((toolCall) => toolCall.id));
+      currentAssistant.toolCalls.push(...toolCalls.filter((toolCall) => !existingIds.has(toolCall.id)));
+    }
+    currentAssistant.timestamp = message.timestamp;
+  }
+
+  flushAssistant();
+  return collapsed;
+}
+
+async function doSyncSession(taskId: string): Promise<void> {
+  const task = useTaskStore.getState().tasks.find((t) => t.id === taskId);
+  if (!task?.gatewayId || !task?.sessionKey) return;
+
+  const res = await window.clawwork.chatHistory(task.gatewayId, task.sessionKey);
+  if (!res.ok || !res.result) return;
+
+  const raw = res.result as { messages?: RawHistoryMessage[] };
+  const rawMsgs = raw.messages ?? [];
+
+  const localMsgs = useMessageStore.getState().messagesByTask[taskId] ?? [];
+  const localAssistantTimestamps = new Set(localMsgs.filter((m) => m.role === 'assistant').map((m) => m.timestamp));
+
+  const gatewayAssistant = normalizeAssistantTurns(rawMsgs);
+
+  const newest = gatewayAssistant.filter((m) => !localAssistantTimestamps.has(m.timestamp));
+  if (newest.length === 0) {
+    useMessageStore.getState().clearActiveTurn(taskId);
+    return;
+  }
+
+  for (let i = 0; i < newest.length; i++) {
+    const gm = newest[i];
+    const canonical: Message = {
+      id: crypto.randomUUID(),
+      taskId,
+      role: 'assistant',
+      content: gm.content,
+      artifacts: [],
+      toolCalls: gm.toolCalls,
+      timestamp: gm.timestamp,
+    };
+    const mergedCanonical = mergeCanonicalMessageWithActiveTurn(
+      canonical,
+      useMessageStore.getState().activeTurnByTask[taskId],
+    );
+
+    if (i === newest.length - 1) {
+      useMessageStore.getState().promoteActiveTurn(taskId, canonical);
+    } else {
+      useMessageStore.setState((s) => ({
+        messagesByTask: {
+          ...s.messagesByTask,
+          [taskId]: [...(s.messagesByTask[taskId] ?? []), mergedCanonical],
+        },
+      }));
+    }
+
+    window.clawwork
+      .persistMessage({
+        id: mergedCanonical.id,
+        taskId,
+        role: 'assistant',
+        content: mergedCanonical.content,
+        timestamp: mergedCanonical.timestamp,
+        toolCalls: mergedCanonical.toolCalls,
+      })
+      .catch(() => {});
+  }
+}
+
+export function syncSessionMessages(taskId: string): Promise<void> {
+  const prev = syncChains.get(taskId) ?? Promise.resolve();
+  const job = prev.then(() => syncWithRetry(taskId));
+  syncChains.set(
+    taskId,
+    job.catch(() => {}),
+  );
+  return job;
+}
+
+async function syncWithRetry(taskId: string): Promise<void> {
+  for (let attempt = 0; attempt <= RETRY_DELAYS.length; attempt++) {
+    try {
+      await doSyncSession(taskId);
+      return;
+    } catch {
+      if (attempt < RETRY_DELAYS.length) {
+        await new Promise((r) => setTimeout(r, RETRY_DELAYS[attempt]));
+      }
+    }
+  }
+  console.warn('[sync] syncSessionMessages exhausted retries for task', taskId);
+}
+
+export function retrySyncPending(): void {
+  const turns = useMessageStore.getState().activeTurnByTask;
+  for (const [taskId, turn] of Object.entries(turns)) {
+    if (turn.finalized) {
+      syncSessionMessages(taskId).catch(() => {});
+    }
+  }
+}
+
 export async function syncFromGateway(): Promise<void> {
   try {
     await hydrateFromLocal();
@@ -59,7 +341,16 @@ export async function syncFromGateway(): Promise<void> {
     adoptTasks(discovered);
 
     for (const d of discovered) {
-      // Update metadata for existing tasks (adoptTasks only creates new ones)
+      const collapsedMessages = collapseDiscoveredMessages(
+        d.messages.map((message: { role: string; content: string; timestamp: string; toolCalls?: ToolCall[] }) => ({
+          role: message.role,
+          content: message.content,
+          timestamp: message.timestamp,
+          toolCalls: message.toolCalls,
+        })),
+        d.taskId,
+      );
+
       updateTaskMetadata(d.taskId, {
         model: d.model,
         modelProvider: d.modelProvider,
@@ -68,68 +359,54 @@ export async function syncFromGateway(): Promise<void> {
         outputTokens: d.outputTokens,
         contextTokens: d.contextTokens,
       });
-      if (d.messages.length === 0) continue;
+      if (collapsedMessages.length === 0) continue;
+
       const local = messagesByTask[d.taskId] ?? [];
-      const existingCounts = new Map<string, number>();
-      for (const msg of local) {
-        const key = `${msg.role}:${msg.content}`;
-        existingCounts.set(key, (existingCounts.get(key) ?? 0) + 1);
-      }
-      const remoteCounts = new Map<string, number>();
-      const newMsgs: Message[] = d.messages
-        .filter((msg: { role: string; content: string; timestamp: string }) => {
-          const key = `${msg.role}:${msg.content}`;
-          const seen = remoteCounts.get(key) ?? 0;
-          remoteCounts.set(key, seen + 1);
-          return seen + 1 > (existingCounts.get(key) ?? 0);
-        })
-        .map(
-          (m: {
-            role: string;
-            content: string;
-            timestamp: string;
-            toolCalls?: {
-              id: string;
-              name: string;
-              status: string;
-              args?: Record<string, unknown>;
-              result?: string;
-              startedAt: string;
-              completedAt?: string;
-            }[];
-          }) => ({
-            id: crypto.randomUUID(),
-            taskId: d.taskId,
-            role: m.role as MessageRole,
-            content: m.content,
-            artifacts: [],
-            toolCalls: (m.toolCalls ?? []).map(
-              (tc): ToolCall => ({
-                id: tc.id,
-                name: tc.name,
-                status: tc.status as ToolCall['status'],
-                args: tc.args,
-                result: tc.result,
-                startedAt: tc.startedAt,
-                completedAt: tc.completedAt,
-              }),
-            ),
-            timestamp: m.timestamp,
-          }),
+      const hasLocalData = local.length > 0;
+
+      if (hasLocalData) {
+        const localTimestamps = new Set(local.filter((m) => m.role === 'assistant').map((m) => m.timestamp));
+        const newAssistantMsgs = collapsedMessages.filter(
+          (message) => message.role === 'assistant' && !localTimestamps.has(message.timestamp),
         );
-      if (newMsgs.length === 0) continue;
-      const merged = [...local, ...newMsgs].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
-      bulkLoad(d.taskId, merged);
-      for (const msg of newMsgs) {
-        window.clawwork
-          .persistMessage({
-            id: msg.id,
-            taskId: msg.taskId,
-            role: msg.role,
-            content: msg.content,
-            timestamp: msg.timestamp,
-          })
-          .catch(() => {});
+        if (newAssistantMsgs.length === 0) continue;
+
+        const mapped: Message[] = newAssistantMsgs.map((message) => ({
+          ...message,
+          id: crypto.randomUUID(),
+        }));
+        const merged = [...local, ...mapped].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+        bulkLoad(d.taskId, merged);
+        for (const msg of mapped) {
+          window.clawwork
+            .persistMessage({
+              id: msg.id,
+              taskId: msg.taskId,
+              role: msg.role,
+              content: msg.content,
+              timestamp: msg.timestamp,
+              toolCalls: msg.toolCalls,
+            })
+            .catch(() => {});
+        }
+      } else {
+        const mapped: Message[] = collapsedMessages.map((message) => ({
+          ...message,
+          id: crypto.randomUUID(),
+        }));
+        bulkLoad(d.taskId, mapped);
+        for (const msg of mapped) {
+          window.clawwork
+            .persistMessage({
+              id: msg.id,
+              taskId: msg.taskId,
+              role: msg.role,
+              content: msg.content,
+              timestamp: msg.timestamp,
+              toolCalls: msg.toolCalls,
+            })
+            .catch(() => {});
+        }
       }
     }
   } catch {

--- a/packages/desktop/src/renderer/stores/messageStore.ts
+++ b/packages/desktop/src/renderer/stores/messageStore.ts
@@ -2,19 +2,24 @@ import { create } from 'zustand';
 import { mergeGatewayStreamText } from '@clawwork/shared';
 import type { Message, MessageRole, MessageImageAttachment, ToolCall } from '@clawwork/shared';
 
-/** Stable empty array — avoids creating new references on every selector call */
 const EMPTY_MESSAGES: Message[] = [];
 
+export interface ActiveTurn {
+  id: string;
+  streamingText: string;
+  streamingThinking: string;
+  toolCalls: ToolCall[];
+  finalized: boolean;
+  content: string;
+  thinkingContent?: string;
+  runId?: string;
+  timestamp: string;
+}
+
 interface MessageState {
-  /** taskId → messages */
   messagesByTask: Record<string, Message[]>;
-  /** taskId → currently streaming assistant content (delta accumulator) */
-  streamingByTask: Record<string, string>;
-  /** taskId → currently streaming thinking content */
-  streamingThinkingByTask: Record<string, string>;
-  /** Set of taskIds currently waiting for Agent response */
+  activeTurnByTask: Record<string, ActiveTurn>;
   processingTasks: Set<string>;
-  /** message ID to highlight (e.g. from file navigation) */
   highlightedMessageId: string | null;
 
   addMessage: (
@@ -24,14 +29,13 @@ interface MessageState {
     imageAttachments?: MessageImageAttachment[],
     options?: { persist?: boolean },
   ) => Message;
-  /** Insert or update a ToolCall on the latest assistant message for a task.
-   *  If no assistant message exists yet, one is created to host the tool call. */
   upsertToolCall: (taskId: string, tc: ToolCall) => void;
-  /** Bulk-load messages into store without persisting to DB */
   bulkLoad: (taskId: string, msgs: Message[]) => void;
   appendStreamDelta: (taskId: string, delta: string) => void;
   appendThinkingDelta: (taskId: string, delta: string) => void;
-  finalizeStream: (taskId: string) => void;
+  finalizeStream: (taskId: string, meta?: { runId?: string }) => void;
+  promoteActiveTurn: (taskId: string, canonical: Message) => void;
+  clearActiveTurn: (taskId: string) => void;
   clearMessages: (taskId: string) => void;
   setHighlightedMessage: (id: string | null) => void;
   setProcessing: (taskId: string, processing: boolean) => void;
@@ -43,10 +47,95 @@ function generateId(): string {
   return crypto.randomUUID();
 }
 
+function newActiveTurn(): ActiveTurn {
+  return {
+    id: generateId(),
+    streamingText: '',
+    streamingThinking: '',
+    toolCalls: [],
+    finalized: false,
+    content: '',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function toolStatusRank(status: ToolCall['status']): number {
+  switch (status) {
+    case 'error':
+      return 3;
+    case 'done':
+      return 2;
+    case 'running':
+      return 1;
+  }
+}
+
+function mergeToolCallState(existing: ToolCall | undefined, incoming: ToolCall): ToolCall {
+  if (!existing) return incoming;
+
+  const preferIncoming = toolStatusRank(incoming.status) >= toolStatusRank(existing.status);
+  return {
+    ...existing,
+    ...incoming,
+    status: preferIncoming ? incoming.status : existing.status,
+    args: incoming.args ?? existing.args,
+    result: incoming.result ?? existing.result,
+    startedAt: existing.startedAt || incoming.startedAt,
+    completedAt: incoming.completedAt ?? existing.completedAt,
+  };
+}
+
+function mergeToolCalls(canonical: ToolCall[], turn: ToolCall[]): ToolCall[] {
+  const merged = new Map<string, ToolCall>();
+  for (const toolCall of canonical) {
+    merged.set(toolCall.id, toolCall);
+  }
+  for (const toolCall of turn) {
+    merged.set(toolCall.id, mergeToolCallState(merged.get(toolCall.id), toolCall));
+  }
+  return Array.from(merged.values());
+}
+
+export function mergeCanonicalMessageWithActiveTurn(canonical: Message, turn?: ActiveTurn): Message {
+  return {
+    ...canonical,
+    thinkingContent: turn?.thinkingContent ?? canonical.thinkingContent,
+    toolCalls: mergeToolCalls(canonical.toolCalls, turn?.toolCalls ?? []),
+    runId: turn?.runId ?? canonical.runId,
+  };
+}
+
+export function activeTurnToMessage(turn: ActiveTurn, taskId: string): Message {
+  return {
+    id: turn.id,
+    taskId,
+    role: 'assistant',
+    content: turn.content,
+    thinkingContent: turn.thinkingContent,
+    artifacts: [],
+    toolCalls: turn.toolCalls,
+    runId: turn.runId,
+    timestamp: turn.timestamp,
+  };
+}
+
+function persistMessageUpdate(msg: Message): void {
+  window.clawwork
+    .persistMessage({
+      id: msg.id,
+      taskId: msg.taskId,
+      role: msg.role,
+      content: msg.content,
+      timestamp: msg.timestamp,
+      imageAttachments: msg.imageAttachments as unknown[] | undefined,
+      toolCalls: msg.toolCalls,
+    })
+    .catch(() => {});
+}
+
 export const useMessageStore = create<MessageState>((set, _get) => ({
   messagesByTask: {},
-  streamingByTask: {},
-  streamingThinkingByTask: {},
+  activeTurnByTask: {},
   processingTasks: new Set(),
   highlightedMessageId: null,
 
@@ -68,24 +157,30 @@ export const useMessageStore = create<MessageState>((set, _get) => ({
       },
     }));
     if (options?.persist !== false) {
-      window.clawwork
-        .persistMessage({
-          id: msg.id,
-          taskId: msg.taskId,
-          role: msg.role,
-          content: msg.content,
-          timestamp: msg.timestamp,
-          imageAttachments: msg.imageAttachments as unknown[] | undefined,
-        })
-        .catch(() => {});
+      persistMessageUpdate(msg);
     }
     return msg;
   },
 
-  upsertToolCall: (taskId, tc) =>
-    set((s) => {
-      const msgs = s.messagesByTask[taskId] ?? [];
+  upsertToolCall: (taskId, tc) => {
+    let persistedMessage: Message | null = null;
 
+    set((s) => {
+      const turn = s.activeTurnByTask[taskId];
+      if (turn) {
+        const idx = turn.toolCalls.findIndex((t) => t.id === tc.id);
+        const next = [...turn.toolCalls];
+        if (idx >= 0) next[idx] = mergeToolCallState(next[idx], tc);
+        else next.push(tc);
+        return {
+          activeTurnByTask: {
+            ...s.activeTurnByTask,
+            [taskId]: { ...turn, toolCalls: next },
+          },
+        };
+      }
+
+      const msgs = s.messagesByTask[taskId] ?? [];
       let lastAssistantIdx = -1;
       let lastUserIdx = -1;
       for (let i = msgs.length - 1; i >= 0; i--) {
@@ -95,33 +190,30 @@ export const useMessageStore = create<MessageState>((set, _get) => ({
       }
 
       const targetIdx = lastAssistantIdx >= 0 && lastAssistantIdx > lastUserIdx ? lastAssistantIdx : -1;
-
-      const updatedMsgs = [...msgs];
       if (targetIdx >= 0) {
+        const updatedMsgs = [...msgs];
         const target = updatedMsgs[targetIdx];
-        const existingIdx = target.toolCalls.findIndex((t) => t.id === tc.id);
-        const nextToolCalls = [...target.toolCalls];
-        if (existingIdx >= 0) {
-          nextToolCalls[existingIdx] = tc;
-        } else {
-          nextToolCalls.push(tc);
-        }
-        updatedMsgs[targetIdx] = { ...target, toolCalls: nextToolCalls };
-      } else {
-        updatedMsgs.push({
-          id: generateId(),
-          taskId,
-          role: 'assistant',
-          content: '',
-          artifacts: [],
-          toolCalls: [tc],
-          timestamp: new Date().toISOString(),
-        });
+        const idx = target.toolCalls.findIndex((t) => t.id === tc.id);
+        const next = [...target.toolCalls];
+        if (idx >= 0) next[idx] = mergeToolCallState(next[idx], tc);
+        else next.push(tc);
+        updatedMsgs[targetIdx] = { ...target, toolCalls: next };
+        persistedMessage = updatedMsgs[targetIdx];
+        return { messagesByTask: { ...s.messagesByTask, [taskId]: updatedMsgs } };
       }
+
       return {
-        messagesByTask: { ...s.messagesByTask, [taskId]: updatedMsgs },
+        activeTurnByTask: {
+          ...s.activeTurnByTask,
+          [taskId]: { ...newActiveTurn(), toolCalls: [tc] },
+        },
       };
-    }),
+    });
+
+    if (persistedMessage) {
+      persistMessageUpdate(persistedMessage);
+    }
+  },
 
   bulkLoad: (taskId, msgs) =>
     set((s) => ({
@@ -132,81 +224,103 @@ export const useMessageStore = create<MessageState>((set, _get) => ({
     })),
 
   appendStreamDelta: (taskId, delta) =>
-    set((s) => ({
-      streamingByTask: {
-        ...s.streamingByTask,
-        [taskId]: mergeGatewayStreamText(s.streamingByTask[taskId] ?? '', delta),
-      },
-    })),
+    set((s) => {
+      const turn = s.activeTurnByTask[taskId] ?? newActiveTurn();
+      return {
+        activeTurnByTask: {
+          ...s.activeTurnByTask,
+          [taskId]: {
+            ...turn,
+            streamingText: mergeGatewayStreamText(turn.streamingText, delta),
+          },
+        },
+      };
+    }),
 
   appendThinkingDelta: (taskId, delta) =>
-    set((s) => ({
-      streamingThinkingByTask: {
-        ...s.streamingThinkingByTask,
-        [taskId]: mergeGatewayStreamText(s.streamingThinkingByTask[taskId] ?? '', delta),
-      },
-    })),
-
-  finalizeStream: (taskId) => {
-    let captured: Message | null = null;
     set((s) => {
-      const content = s.streamingByTask[taskId];
-      if (!content) return s;
-      const thinkingContent = s.streamingThinkingByTask[taskId] || undefined;
-      const msg: Message = {
-        id: generateId(),
-        taskId,
-        role: 'assistant',
-        content,
-        thinkingContent,
-        artifacts: [],
-        toolCalls: [],
-        timestamp: new Date().toISOString(),
+      const turn = s.activeTurnByTask[taskId] ?? newActiveTurn();
+      return {
+        activeTurnByTask: {
+          ...s.activeTurnByTask,
+          [taskId]: {
+            ...turn,
+            streamingThinking: mergeGatewayStreamText(turn.streamingThinking, delta),
+          },
+        },
       };
-      captured = msg;
-      const nextStreaming = { ...s.streamingByTask };
-      delete nextStreaming[taskId];
-      const nextThinking = { ...s.streamingThinkingByTask };
-      delete nextThinking[taskId];
+    }),
+
+  finalizeStream: (taskId, meta?) => {
+    set((s) => {
+      const turn = s.activeTurnByTask[taskId];
+      if (!turn) return s;
+
+      const content = turn.streamingText;
+      const thinkingContent = turn.streamingThinking || undefined;
+
+      if (!content && !thinkingContent) {
+        return {
+          activeTurnByTask: {
+            ...s.activeTurnByTask,
+            [taskId]: { ...turn, streamingText: '', streamingThinking: '' },
+          },
+        };
+      }
+
+      return {
+        activeTurnByTask: {
+          ...s.activeTurnByTask,
+          [taskId]: {
+            ...turn,
+            finalized: true,
+            content,
+            thinkingContent,
+            streamingText: '',
+            streamingThinking: '',
+            runId: meta?.runId ?? turn.runId,
+          },
+        },
+      };
+    });
+  },
+
+  promoteActiveTurn: (taskId, canonical) =>
+    set((s) => {
+      const turn = s.activeTurnByTask[taskId];
+      const merged = mergeCanonicalMessageWithActiveTurn(canonical, turn);
+      const nextTurns = { ...s.activeTurnByTask };
+      delete nextTurns[taskId];
       return {
         messagesByTask: {
           ...s.messagesByTask,
-          [taskId]: [...(s.messagesByTask[taskId] ?? []), msg],
+          [taskId]: [...(s.messagesByTask[taskId] ?? []), merged],
         },
-        streamingByTask: nextStreaming,
-        streamingThinkingByTask: nextThinking,
+        activeTurnByTask: nextTurns,
       };
-    });
-    if (captured) {
-      const msg = captured as Message;
-      window.clawwork
-        .persistMessage({
-          id: msg.id,
-          taskId: msg.taskId,
-          role: msg.role,
-          content: msg.content,
-          timestamp: msg.timestamp,
-        })
-        .catch(() => {});
-    }
-  },
+    }),
+
+  clearActiveTurn: (taskId) =>
+    set((s) => {
+      if (!s.activeTurnByTask[taskId]) return s;
+      const next = { ...s.activeTurnByTask };
+      delete next[taskId];
+      return { activeTurnByTask: next };
+    }),
 
   clearMessages: (taskId) =>
     set((s) => {
       const nextMessages = { ...s.messagesByTask };
-      const nextStreaming = { ...s.streamingByTask };
-      const nextThinking = { ...s.streamingThinkingByTask };
+      const nextTurns = { ...s.activeTurnByTask };
       const nextProcessing = new Set(s.processingTasks);
 
       delete nextMessages[taskId];
-      delete nextStreaming[taskId];
-      delete nextThinking[taskId];
+      delete nextTurns[taskId];
       nextProcessing.delete(taskId);
 
       return {
         messagesByTask: nextMessages,
-        streamingByTask: nextStreaming,
-        streamingThinkingByTask: nextThinking,
+        activeTurnByTask: nextTurns,
         processingTasks: nextProcessing,
       };
     }),

--- a/packages/desktop/test/data-handlers.test.ts
+++ b/packages/desktop/test/data-handlers.test.ts
@@ -4,7 +4,9 @@ const handleMap = new Map<string, (...args: unknown[]) => unknown>();
 const getWorkspacePathMock = vi.fn(() => null);
 const autoExtractArtifactsMock = vi.fn();
 const runMock = vi.fn();
-const valuesMock = vi.fn(() => ({ run: runMock }));
+const conflictRunMock = vi.fn();
+const onConflictDoUpdateMock = vi.fn(() => ({ run: conflictRunMock }));
+const valuesMock = vi.fn(() => ({ onConflictDoUpdate: onConflictDoUpdateMock, run: runMock }));
 const insertMock = vi.fn(() => ({ values: valuesMock }));
 const getDbMock = vi.fn(() => ({ insert: insertMock }));
 
@@ -36,6 +38,8 @@ describe('registerDataHandlers', () => {
     getWorkspacePathMock.mockReturnValue(null);
     autoExtractArtifactsMock.mockReset();
     runMock.mockReset();
+    conflictRunMock.mockReset();
+    onConflictDoUpdateMock.mockClear();
     valuesMock.mockClear();
     insertMock.mockClear();
     getDbMock.mockClear();
@@ -49,13 +53,7 @@ describe('registerDataHandlers', () => {
     const createMessage = handleMap.get('data:create-message');
     expect(createMessage).toBeTypeOf('function');
 
-    runMock
-      .mockImplementationOnce(() => undefined)
-      .mockImplementationOnce(() => {
-        throw new Error(
-          'UNIQUE constraint failed: messages.task_id, messages.role, messages.content, messages.timestamp',
-        );
-      });
+    conflictRunMock.mockImplementation(() => undefined);
 
     const payload = {
       id: 'msg-1',
@@ -68,7 +66,47 @@ describe('registerDataHandlers', () => {
     expect(createMessage?.({}, payload)).toEqual({ ok: true });
     expect(createMessage?.({}, { ...payload, id: 'msg-2' })).toEqual({ ok: true });
 
-    expect(runMock).toHaveBeenCalledTimes(2);
+    expect(conflictRunMock).toHaveBeenCalledTimes(2);
     expect(autoExtractArtifactsMock).not.toHaveBeenCalled();
+  });
+
+  it('updates toolCalls when persisting the same logical message again', async () => {
+    const { registerDataHandlers } = await import('../src/main/ipc/data-handlers.js');
+
+    registerDataHandlers();
+
+    const createMessage = handleMap.get('data:create-message');
+    expect(createMessage).toBeTypeOf('function');
+
+    const payload = {
+      id: 'msg-tool-1',
+      taskId: 'task-1',
+      role: 'assistant',
+      content: 'CPU info',
+      timestamp: '2026-03-16T00:00:01.000Z',
+      toolCalls: [{ id: 'exec-1', name: 'exec', status: 'running' }],
+    };
+
+    expect(createMessage?.({}, payload)).toEqual({ ok: true });
+    expect(
+      createMessage?.(
+        {},
+        {
+          ...payload,
+          id: 'msg-tool-2',
+          toolCalls: [{ id: 'exec-1', name: 'exec', status: 'done', result: 'uname -a' }],
+        },
+      ),
+    ).toEqual({ ok: true });
+
+    expect(onConflictDoUpdateMock).toHaveBeenCalledTimes(2);
+    expect(onConflictDoUpdateMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        target: expect.anything(),
+        set: expect.objectContaining({
+          toolCalls: JSON.stringify([{ id: 'exec-1', name: 'exec', status: 'done', result: 'uname -a' }]),
+        }),
+      }),
+    );
   });
 });

--- a/packages/desktop/test/message-store.test.ts
+++ b/packages/desktop/test/message-store.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadStore() {
+  vi.resetModules();
+  const module = await import('../src/renderer/stores/messageStore');
+  return module;
+}
+
+describe('message store tool call persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as Window & {
+      clawwork: {
+        persistMessage: ReturnType<typeof vi.fn>;
+      };
+    };
+    windowWithClawwork.clawwork = {
+      persistMessage: vi.fn().mockResolvedValue({ ok: true }),
+    } as unknown as typeof windowWithClawwork.clawwork;
+  });
+
+  it('persists tool status updates for the latest assistant message after promotion', async () => {
+    const { useMessageStore } = await loadStore();
+
+    useMessageStore.setState({
+      messagesByTask: {
+        'task-1': [
+          {
+            id: 'assistant-1',
+            taskId: 'task-1',
+            role: 'assistant',
+            content: 'Done',
+            artifacts: [],
+            toolCalls: [
+              {
+                id: 'exec-1',
+                name: 'exec',
+                status: 'running',
+                startedAt: '2026-03-16T10:00:00.000Z',
+              },
+            ],
+            timestamp: '2026-03-16T10:00:01.000Z',
+          },
+        ],
+      },
+      activeTurnByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    useMessageStore.getState().upsertToolCall('task-1', {
+      id: 'exec-1',
+      name: 'exec',
+      status: 'done',
+      result: 'uname -a',
+      startedAt: '2026-03-16T10:00:00.000Z',
+      completedAt: '2026-03-16T10:00:02.000Z',
+    });
+
+    const saved = useMessageStore.getState().messagesByTask['task-1'][0];
+    expect(saved.toolCalls).toEqual([expect.objectContaining({ id: 'exec-1', status: 'done', result: 'uname -a' })]);
+    expect(window.clawwork.persistMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'assistant-1',
+        taskId: 'task-1',
+        role: 'assistant',
+        toolCalls: [expect.objectContaining({ id: 'exec-1', status: 'done', result: 'uname -a' })],
+      }),
+    );
+  });
+});

--- a/packages/desktop/test/session-sync.test.ts
+++ b/packages/desktop/test/session-sync.test.ts
@@ -27,6 +27,7 @@ describe('session sync startup flow', () => {
     const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as Window & {
       clawwork: {
         syncSessions: ReturnType<typeof vi.fn>;
+        chatHistory: ReturnType<typeof vi.fn>;
         persistTask: ReturnType<typeof vi.fn>;
         persistTaskUpdate: ReturnType<typeof vi.fn>;
         loadMessages: ReturnType<typeof vi.fn>;
@@ -37,6 +38,7 @@ describe('session sync startup flow', () => {
     };
     windowWithClawwork.clawwork = {
       syncSessions: vi.fn(),
+      chatHistory: vi.fn(),
       persistTask: vi.fn().mockResolvedValue({ ok: true }),
       persistTaskUpdate: vi.fn().mockResolvedValue({ ok: true }),
       loadMessages: vi.fn().mockResolvedValue({ ok: true, rows: [] }),
@@ -52,8 +54,7 @@ describe('session sync startup flow', () => {
     taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
     messageStore.useMessageStore.setState({
       messagesByTask: {},
-      streamingByTask: {},
-      streamingThinkingByTask: {},
+      activeTurnByTask: {},
       processingTasks: new Set(),
       highlightedMessageId: null,
     });
@@ -100,8 +101,7 @@ describe('session sync startup flow', () => {
     taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
     messageStore.useMessageStore.setState({
       messagesByTask: {},
-      streamingByTask: {},
-      streamingThinkingByTask: {},
+      activeTurnByTask: {},
       processingTasks: new Set(),
       highlightedMessageId: null,
     });
@@ -183,14 +183,13 @@ describe('session sync startup flow', () => {
     ]);
   });
 
-  it('deduplicates messages with different timestamps but same role+content', async () => {
+  it('deduplicates assistant messages by matching Gateway timestamp', async () => {
     const { sessionSync, taskStore, messageStore } = await loadModules();
 
     taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
     messageStore.useMessageStore.setState({
       messagesByTask: {},
-      streamingByTask: {},
-      streamingThinkingByTask: {},
+      activeTurnByTask: {},
       processingTasks: new Set(),
       highlightedMessageId: null,
     });
@@ -239,7 +238,7 @@ describe('session sync startup flow', () => {
           agentId: 'main',
           messages: [
             { role: 'user', content: 'Hello', timestamp: '2026-03-16T10:00:00.456Z' },
-            { role: 'assistant', content: 'Hi there!', timestamp: '2026-03-16T10:00:01.789Z' },
+            { role: 'assistant', content: 'Hi there!', timestamp: '2026-03-16T10:00:01.234Z' },
           ],
         },
       ],
@@ -254,14 +253,13 @@ describe('session sync startup flow', () => {
     expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
   });
 
-  it('allows genuine duplicate content messages (user sends same text twice)', async () => {
+  it('syncs only new assistant messages for existing tasks (single-writer)', async () => {
     const { sessionSync, taskStore, messageStore } = await loadModules();
 
     taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
     messageStore.useMessageStore.setState({
       messagesByTask: {},
-      streamingByTask: {},
-      streamingThinkingByTask: {},
+      activeTurnByTask: {},
       processingTasks: new Set(),
       highlightedMessageId: null,
     });
@@ -312,8 +310,385 @@ describe('session sync startup flow', () => {
     await sessionSync.syncFromGateway();
 
     const msgs = messageStore.useMessageStore.getState().messagesByTask['task-legit'];
-    expect(msgs).toHaveLength(4);
-    expect(msgs.map((m: { content: string }) => m.content)).toEqual(['Hello', 'Hi!', 'Hello', 'Hi again!']);
+    expect(msgs).toHaveLength(3);
+    expect(msgs.map((m: { content: string }) => m.content)).toEqual(['Hello', 'Hi!', 'Hi again!']);
+  });
+
+  it('collapses consecutive assistant history into one visible assistant turn during startup sync', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {},
+      activeTurnByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    const taskRow = {
+      id: 'task-collapse',
+      sessionKey: 'agent:main:clawwork:task:task-collapse',
+      sessionId: 'session-collapse',
+      title: 'Collapse test',
+      status: 'active',
+      model: null,
+      modelProvider: null,
+      thinkingLevel: null,
+      inputTokens: null,
+      outputTokens: null,
+      contextTokens: null,
+      createdAt: '2026-03-16T00:00:00.000Z',
+      updatedAt: '2026-03-16T00:00:00.000Z',
+      tags: [],
+      artifactDir: 'tasks/task-collapse',
+      gatewayId: 'gw-1',
+    };
+
+    window.clawwork.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
+    window.clawwork.loadMessages.mockResolvedValue({
+      ok: true,
+      rows: [
+        {
+          id: 'u1',
+          taskId: 'task-collapse',
+          role: 'user',
+          content: '再看看今天的记忆有什么',
+          timestamp: '2026-03-16T10:00:00.000Z',
+        },
+      ],
+    });
+    window.clawwork.syncSessions.mockResolvedValue({
+      ok: true,
+      discovered: [
+        {
+          gatewayId: 'gw-1',
+          taskId: 'task-collapse',
+          sessionKey: 'agent:main:clawwork:task:task-collapse',
+          title: 'Collapse test',
+          updatedAt: '2026-03-16T10:00:03.000Z',
+          agentId: 'main',
+          messages: [
+            { role: 'user', content: '再看看今天的记忆有什么', timestamp: '2026-03-16T10:00:00.000Z' },
+            {
+              role: 'assistant',
+              content: '今天还没记录。让我看看之前有啥：',
+              timestamp: '2026-03-16T10:00:01.000Z',
+              toolCalls: [],
+            },
+            {
+              role: 'assistant',
+              content: '',
+              timestamp: '2026-03-16T10:00:02.000Z',
+              toolCalls: [
+                {
+                  id: 'read-1',
+                  name: 'read',
+                  status: 'error',
+                  result: 'from memory/2026-03-23.md',
+                  startedAt: '2026-03-16T10:00:02.000Z',
+                  completedAt: '2026-03-16T10:00:02.100Z',
+                },
+              ],
+            },
+            {
+              role: 'assistant',
+              content: '记忆文件还没创建，今天是头一次聊。有啥需要我干的？',
+              timestamp: '2026-03-16T10:00:03.000Z',
+              toolCalls: [],
+            },
+            { role: 'assistant', content: 'NO_REPLY', timestamp: '2026-03-16T10:00:03.500Z', toolCalls: [] },
+          ],
+        },
+      ],
+    });
+
+    await sessionSync.syncFromGateway();
+
+    const msgs = messageStore.useMessageStore.getState().messagesByTask['task-collapse'];
+    expect(msgs).toHaveLength(2);
+    expect(msgs[1]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        content: '今天还没记录。让我看看之前有啥：\n\n记忆文件还没创建，今天是头一次聊。有啥需要我干的？',
+      }),
+    );
+    expect(msgs[1].toolCalls).toHaveLength(1);
+  });
+
+  it('promotes one collapsed assistant turn during runtime sync instead of appending multiple assistant bubbles', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({
+      tasks: [
+        {
+          id: 'task-runtime',
+          sessionKey: 'agent:main:clawwork:task:task-runtime',
+          sessionId: 'session-runtime',
+          title: 'Runtime test',
+          status: 'active',
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+          tags: [],
+          artifactDir: 'tasks/task-runtime',
+          gatewayId: 'gw-1',
+        },
+      ],
+      activeTaskId: 'task-runtime',
+      hydrated: true,
+    });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {
+        'task-runtime': [
+          {
+            id: 'u1',
+            taskId: 'task-runtime',
+            role: 'user',
+            content: '今天他的天气怎么样? 获取当前电脑的 IP',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+        ],
+      },
+      activeTurnByTask: {
+        'task-runtime': {
+          id: 'turn-1',
+          streamingText: '',
+          streamingThinking: '',
+          toolCalls: [
+            {
+              id: 'exec-1',
+              name: 'exec',
+              status: 'done',
+              result: 'fetch url',
+              startedAt: '2026-03-16T10:00:01.000Z',
+              completedAt: '2026-03-16T10:00:01.100Z',
+            },
+            {
+              id: 'read-1',
+              name: 'read',
+              status: 'error',
+              result: 'from memory/2026-03-23.md',
+              startedAt: '2026-03-16T10:00:01.200Z',
+              completedAt: '2026-03-16T10:00:01.300Z',
+            },
+          ],
+          finalized: true,
+          content: '天气（上海）： 15°C',
+          runId: 'run-1',
+          timestamp: '2026-03-16T10:00:03.000Z',
+        },
+      },
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    window.clawwork.chatHistory.mockResolvedValue({
+      ok: true,
+      result: {
+        messages: [
+          {
+            role: 'user',
+            timestamp: Date.parse('2026-03-16T10:00:00.000Z'),
+            content: [{ type: 'text', text: '今天他的天气怎么样? 获取当前电脑的 IP' }],
+          },
+          {
+            role: 'assistant',
+            timestamp: Date.parse('2026-03-16T10:00:01.000Z'),
+            content: [{ type: 'text', text: '今天他的天气怎么样? 我先看下天气和 IP。' }],
+          },
+          {
+            role: 'assistant',
+            timestamp: Date.parse('2026-03-16T10:00:02.000Z'),
+            content: [{ type: 'toolCall', id: 'exec-1', name: 'exec', arguments: '{}' }],
+          },
+          {
+            role: 'toolResult',
+            timestamp: Date.parse('2026-03-16T10:00:02.100Z'),
+            content: [{ type: 'toolResult', id: 'exec-1', result: 'fetch url' }],
+          },
+          {
+            role: 'assistant',
+            timestamp: Date.parse('2026-03-16T10:00:03.000Z'),
+            content: [{ type: 'text', text: '天气（上海）： 15°C' }],
+          },
+          {
+            role: 'assistant',
+            timestamp: Date.parse('2026-03-16T10:00:03.100Z'),
+            content: [{ type: 'text', text: 'NO_REPLY' }],
+          },
+        ],
+      },
+    });
+
+    await sessionSync.syncSessionMessages('task-runtime');
+
+    const state = messageStore.useMessageStore.getState();
+    const msgs = state.messagesByTask['task-runtime'];
+    expect(state.activeTurnByTask['task-runtime']).toBeUndefined();
+    expect(msgs).toHaveLength(2);
+    expect(msgs[1]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        content: '今天他的天气怎么样? 我先看下天气和 IP。\n\n天气（上海）： 15°C',
+      }),
+    );
+    expect(msgs[1].toolCalls).toHaveLength(2);
+    expect(msgs[1].toolCalls).toEqual([
+      expect.objectContaining({ id: 'exec-1', status: 'done', result: 'fetch url' }),
+      expect.objectContaining({ id: 'read-1', status: 'error', result: 'from memory/2026-03-23.md' }),
+    ]);
+    expect(window.clawwork.persistMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers terminal tool status from active turn over stale running canonical tool calls during promote', async () => {
+    const { messageStore } = await loadModules();
+
+    messageStore.useMessageStore.setState({
+      messagesByTask: { 'task-promote': [] },
+      activeTurnByTask: {
+        'task-promote': {
+          id: 'turn-promote',
+          streamingText: '',
+          streamingThinking: '',
+          toolCalls: [
+            {
+              id: 'exec-1',
+              name: 'exec',
+              status: 'done',
+              result: 'uname -a',
+              startedAt: '2026-03-16T10:00:00.000Z',
+              completedAt: '2026-03-16T10:00:01.000Z',
+            },
+          ],
+          finalized: true,
+          content: 'CPU info',
+          timestamp: '2026-03-16T10:00:01.500Z',
+        },
+      },
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    messageStore.useMessageStore.getState().promoteActiveTurn('task-promote', {
+      id: 'canonical-1',
+      taskId: 'task-promote',
+      role: 'assistant',
+      content: 'CPU info',
+      artifacts: [],
+      toolCalls: [
+        {
+          id: 'exec-1',
+          name: 'exec',
+          status: 'running',
+          startedAt: '2026-03-16T10:00:00.000Z',
+        },
+      ],
+      timestamp: '2026-03-16T10:00:01.500Z',
+    });
+
+    const saved = messageStore.useMessageStore.getState().messagesByTask['task-promote'];
+    expect(saved).toHaveLength(1);
+    expect(saved[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'exec-1',
+        status: 'done',
+        result: 'uname -a',
+        completedAt: '2026-03-16T10:00:01.000Z',
+      }),
+    ]);
+  });
+
+  it('persists merged terminal tool status during runtime sync instead of stale canonical running state', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({
+      tasks: [
+        {
+          id: 'task-sync-persist',
+          sessionKey: 'agent:main:clawwork:task:task-sync-persist',
+          sessionId: 'session-sync-persist',
+          title: 'Sync persist',
+          status: 'active',
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+          tags: [],
+          artifactDir: 'tasks/task-sync-persist',
+          gatewayId: 'gw-1',
+        },
+      ],
+      activeTaskId: 'task-sync-persist',
+      hydrated: true,
+    });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {
+        'task-sync-persist': [
+          {
+            id: 'u1',
+            taskId: 'task-sync-persist',
+            role: 'user',
+            content: '查 CPU',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+        ],
+      },
+      activeTurnByTask: {
+        'task-sync-persist': {
+          id: 'turn-sync-persist',
+          streamingText: '',
+          streamingThinking: '',
+          toolCalls: [
+            {
+              id: 'exec-1',
+              name: 'exec',
+              status: 'done',
+              result: 'uname -a',
+              startedAt: '2026-03-16T10:00:00.500Z',
+              completedAt: '2026-03-16T10:00:01.000Z',
+            },
+          ],
+          finalized: true,
+          content: 'CPU info',
+          runId: 'run-sync-persist',
+          timestamp: '2026-03-16T10:00:01.000Z',
+        },
+      },
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    window.clawwork.chatHistory.mockResolvedValue({
+      ok: true,
+      result: {
+        messages: [
+          {
+            role: 'user',
+            timestamp: Date.parse('2026-03-16T10:00:00.000Z'),
+            content: [{ type: 'text', text: '查 CPU' }],
+          },
+          {
+            role: 'assistant',
+            timestamp: Date.parse('2026-03-16T10:00:01.000Z'),
+            content: [
+              { type: 'text', text: 'CPU info' },
+              { type: 'toolCall', id: 'exec-1', name: 'exec', arguments: '{}' },
+            ],
+          },
+        ],
+      },
+    });
+
+    await sessionSync.syncSessionMessages('task-sync-persist');
+
+    expect(window.clawwork.persistMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task-sync-persist',
+        role: 'assistant',
+        toolCalls: [expect.objectContaining({ id: 'exec-1', status: 'done', result: 'uname -a' })],
+      }),
+    );
   });
 
   it('reuses resolved hydration state across later gateway sync calls', async () => {
@@ -322,8 +697,7 @@ describe('session sync startup flow', () => {
     taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
     messageStore.useMessageStore.setState({
       messagesByTask: {},
-      streamingByTask: {},
-      streamingThinkingByTask: {},
+      activeTurnByTask: {},
       processingTasks: new Set(),
       highlightedMessageId: null,
     });
@@ -360,5 +734,131 @@ describe('session sync startup flow', () => {
     expect(window.clawwork.loadTasks).toHaveBeenCalledTimes(1);
     expect(window.clawwork.loadMessages).toHaveBeenCalledTimes(1);
     expect(window.clawwork.syncSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it('hydrates persisted tool calls from local storage', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {},
+      activeTurnByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    window.clawwork.loadTasks.mockResolvedValue({
+      ok: true,
+      rows: [
+        {
+          id: 'task-tools',
+          sessionKey: 'agent:main:clawwork:task:task-tools',
+          sessionId: 'session-tools',
+          title: 'Task tools',
+          status: 'active',
+          model: null,
+          modelProvider: null,
+          thinkingLevel: null,
+          inputTokens: null,
+          outputTokens: null,
+          contextTokens: null,
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+          tags: [],
+          artifactDir: 'tasks/task-tools',
+          gatewayId: 'gw-1',
+        },
+      ],
+    });
+    window.clawwork.loadMessages.mockResolvedValue({
+      ok: true,
+      rows: [
+        {
+          id: 'a-tool',
+          taskId: 'task-tools',
+          role: 'assistant',
+          content: 'CPU info',
+          timestamp: '2026-03-16T10:00:01.000Z',
+          toolCalls: [
+            {
+              id: 'exec-1',
+              name: 'exec',
+              status: 'done',
+              result: 'uname -a',
+              startedAt: '2026-03-16T10:00:00.000Z',
+              completedAt: '2026-03-16T10:00:01.000Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    await sessionSync.hydrateFromLocal();
+
+    const msgs = messageStore.useMessageStore.getState().messagesByTask['task-tools'];
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].toolCalls).toEqual([
+      expect.objectContaining({ id: 'exec-1', name: 'exec', status: 'done', result: 'uname -a' }),
+    ]);
+  });
+
+  it('persists tool calls when syncing assistant messages', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {},
+      activeTurnByTask: {},
+      processingTasks: new Set(),
+      highlightedMessageId: null,
+    });
+
+    window.clawwork.syncSessions.mockResolvedValue({
+      ok: true,
+      discovered: [
+        {
+          gatewayId: 'gw-1',
+          taskId: 'task-persist-tools',
+          sessionKey: 'agent:main:clawwork:task:task-persist-tools',
+          title: 'Persist tools',
+          updatedAt: '2026-03-16T10:00:03.000Z',
+          agentId: 'main',
+          model: 'model-1',
+          modelProvider: 'openclaw',
+          thinkingLevel: 'medium',
+          inputTokens: 1,
+          outputTokens: 2,
+          contextTokens: 3,
+          messages: [
+            { role: 'user', content: '读 CPU', timestamp: '2026-03-16T10:00:00.000Z', toolCalls: [] },
+            {
+              role: 'assistant',
+              content: 'CPU info',
+              timestamp: '2026-03-16T10:00:01.000Z',
+              toolCalls: [
+                {
+                  id: 'exec-1',
+                  name: 'exec',
+                  status: 'done',
+                  result: 'uname -a',
+                  startedAt: '2026-03-16T10:00:00.500Z',
+                  completedAt: '2026-03-16T10:00:01.000Z',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await sessionSync.syncFromGateway();
+
+    expect(window.clawwork.persistMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task-persist-tools',
+        role: 'assistant',
+        toolCalls: [expect.objectContaining({ id: 'exec-1', name: 'exec', status: 'done' })],
+      }),
+    );
   });
 });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -68,3 +68,29 @@ export const CONFIG_FILE_NAME = 'clawwork-config.json';
 
 /** SQLite database file name within workspace */
 export const DB_FILE_NAME = '.clawwork.db';
+
+export const RETRYABLE_ERROR_CODES = new Set([
+  'RATE_LIMIT',
+  'RATE_LIMITED',
+  'TIMEOUT',
+  'PROVIDER_UNAVAILABLE',
+  'MODEL_UNAVAILABLE',
+  'SERVICE_UNAVAILABLE',
+  'GATEWAY_TIMEOUT',
+  'OVERLOADED',
+]);
+
+export const NON_RETRYABLE_ERROR_CODES = new Set([
+  'AUTH_INVALID',
+  'AUTH_FAILED',
+  'GATEWAY_AUTH_FAILED',
+  'QUOTA_EXHAUSTED',
+  'CONTENT_POLICY',
+  'CONTENT_FILTERED',
+  'CONTEXT_LENGTH_EXCEEDED',
+  'INVALID_REQUEST',
+  'SESSION_NOT_FOUND',
+  'AGENT_NOT_FOUND',
+  'PERMISSION_DENIED',
+  'METHOD_NOT_SUPPORTED',
+]);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -107,6 +107,28 @@ export interface ToolCall {
   completedAt?: string;
 }
 
+export type ErrorSource = 'local' | 'gateway' | 'upstream' | 'agent' | 'tool' | 'sync' | 'db';
+export type ErrorStage = 'send' | 'stream' | 'final' | 'lifecycle' | 'sync' | 'persist';
+export type Retryable = 'yes' | 'no' | 'unknown';
+
+export interface AppError {
+  source: ErrorSource;
+  stage: ErrorStage;
+  code?: string;
+  rawMessage: string;
+  details?: Record<string, unknown>;
+  retryable: Retryable;
+}
+
+export interface IpcResult<T = unknown> {
+  ok: boolean;
+  result?: T;
+  error?: string;
+  errorCode?: string;
+  errorDetails?: Record<string, unknown>;
+  pairingRequired?: boolean;
+}
+
 // ------------------------------------------------------------
 // Progress tracking (extracted from AI responses)
 // ------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR stabilizes desktop session synchronization so assistant messages stop duplicating, gateway failures surface with more useful error details, and tool call state persists correctly through sync and restart.

## Type of change

- [x] `[Fix]` bug fix
- [ ] `[Feat]` new feature
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The desktop client had a few related correctness problems in the session pipeline:
- assistant replies could be written twice by competing sync paths,
- gateway and upstream failures were often collapsed into generic request errors,
- tool calls could regress to stale running state or disappear after restart because persistence did not carry the final merged state.

These issues made the chat timeline unreliable and made real failures harder to understand.

## What changed?

- introduced shared error metadata and improved gateway error propagation across shared, main, preload, and renderer layers
- stabilized assistant-message reconciliation so sync writes the canonical merged state instead of stale intermediate data
- persisted `toolCalls` through DB schema, IPC, preload, renderer hydration, and later tool-state updates
- updated message-store and session-sync merge behavior to prefer terminal tool states and repersist canonical assistant messages when tool events arrive later
- added focused regression coverage for data handlers, session sync, and message-store persistence paths

## Architecture impact

- Owning layer: shared / main / preload / renderer
- Cross-layer impact: yes; the fix explicitly threads gateway error and tool-call persistence data across process boundaries instead of hiding it in renderer-only state
- Invariants touched from `docs/architecture-invariants.md`:
  - Gateway protocol and shared domain types live in `packages/shared/src/`
  - The Electron main process owns WebSocket, filesystem, database, Git, workspace config, and OS integration
  - The renderer owns UI state and presentation
  - The renderer must cross the process boundary only through `window.clawwork` from preload
  - Gateway broadcasts all session events; routing must stay explicit and keyed by `sessionKey`
- Why those invariants remain protected:
  - protocol and error metadata changes stay in shared types,
  - persistence and gateway handling stay in main,
  - renderer changes remain presentation/state reconciliation only,
  - cross-process data still flows only through typed preload APIs,
  - session reconciliation still routes by canonical session identity rather than hidden global state.

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
```

## Screenshots or recordings

No screenshots included. The renderer changes preserve the existing design-token and CSS-variable driven UI model while fixing state correctness in message rendering and session hydration.

## Release note

- [x] User-facing change. Release note is included below.
- [ ] No user-facing change. Release note is `NONE`.

```release-note
Desktop session sync is more reliable: assistant replies no longer duplicate, gateway errors surface more clearly, and tool execution state now survives synchronization and app restart.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate