### PR TITLE
[Fix] Replace hardcoded 'main' agent fallback with gateway catalog defaultId and add response timeout

### DIFF
--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -241,6 +241,26 @@ export default function ChatInput() {
     return !!turn && !turn.finalized && (!!turn.streamingText || !!turn.streamingThinking);
   });
   const isGenerating = isProcessing || isStreaming;
+  const responseTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  useEffect(() => {
+    if (!activeTask) return;
+    if (isStreaming) {
+      const timer = responseTimers.current.get(activeTask.id);
+      if (timer) {
+        clearTimeout(timer);
+        responseTimers.current.delete(activeTask.id);
+      }
+    }
+  }, [isStreaming, activeTask]);
+
+  useEffect(() => {
+    const timers = responseTimers.current;
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
 
   const addMessage = useMessageStore((s) => s.addMessage);
   const setProcessing = useMessageStore((s) => s.setProcessing);
@@ -456,7 +476,12 @@ export default function ChatInput() {
 
     let task = activeTask;
     if (!task) {
-      task = commitPendingTask();
+      try {
+        task = commitPendingTask();
+      } catch {
+        toast.error(t('errors.agentNotResponding'));
+        return;
+      }
     }
 
     textarea.value = '';
@@ -570,6 +595,26 @@ export default function ChatInput() {
         const toastMsg = formatErrorForToast(appError, t);
         toast.error(toastMsg.title, { description: toastMsg.description });
       } else {
+        const sentTaskId = task.id;
+        const prev = responseTimers.current.get(sentTaskId);
+        if (prev) clearTimeout(prev);
+        responseTimers.current.set(
+          sentTaskId,
+          setTimeout(() => {
+            responseTimers.current.delete(sentTaskId);
+            const store = useMessageStore.getState();
+            const turn = store.activeTurnByTask[sentTaskId];
+            if (store.processingTasks.has(sentTaskId) && (!turn || (!turn.streamingText && !turn.streamingThinking))) {
+              store.setProcessing(sentTaskId, false);
+              const appError = buildAppError({
+                source: 'gateway',
+                stage: 'lifecycle',
+                rawMessage: t('errors.agentNotResponding'),
+              });
+              store.addMessage(sentTaskId, 'system', formatErrorForUser(appError, t));
+            }
+          }, 30_000),
+        );
         window.clawwork
           .persistMessage({
             id: pendingUserMessage.id,
@@ -677,6 +722,11 @@ export default function ChatInput() {
     if (!activeTask || aborting) return;
     setAborting(true);
     markAbortedByUser(activeTask.id);
+    const abortTimer = responseTimers.current.get(activeTask.id);
+    if (abortTimer) {
+      clearTimeout(abortTimer);
+      responseTimers.current.delete(activeTask.id);
+    }
     try {
       await window.clawwork.abortChat(activeTask.gatewayId, activeTask.sessionKey);
     } catch {

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -212,6 +212,7 @@
     "serverAborted": "Task interrupted by server",
     "unknown": "Unknown error",
     "failed": "failed",
+    "agentNotResponding": "Agent is not responding — it may be unavailable or misconfigured on the server. Try a different agent.",
     "stage": {
       "send": "Send",
       "stream": "Stream",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -212,6 +212,7 @@
     "serverAborted": "任务被服务端中止",
     "unknown": "未知错误",
     "failed": "失败",
+    "agentNotResponding": "Agent 未响应 — 可能不可用或服务端配置有误，请尝试其他 Agent",
     "stage": {
       "send": "发送",
       "stream": "推流",

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -32,11 +32,12 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, multi
     return !!turn && !turn.finalized && (!!turn.streamingText || !!turn.streamingThinking);
   });
   const gwInfo = useUiStore((s) => s.gatewayInfoMap[task.gatewayId]);
-  const agentInfo = useUiStore((s) =>
-    task.agentId && task.agentId !== 'main'
-      ? s.agentCatalogByGateway[task.gatewayId]?.agents.find((a) => a.id === task.agentId)
-      : undefined,
-  );
+  const agentInfo = useUiStore((s) => {
+    if (!task.agentId) return undefined;
+    const catalog = s.agentCatalogByGateway[task.gatewayId];
+    if (!catalog || task.agentId === catalog.defaultId) return undefined;
+    return catalog.agents.find((a) => a.id === task.agentId);
+  });
   const modelLabel = task.model === GATEWAY_INJECTED_MODEL ? 'Default' : task.model?.split('/').pop();
   const modelTooltip = task.model === GATEWAY_INJECTED_MODEL ? 'Default' : task.model;
 

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -57,13 +57,17 @@ function WelcomeScreen() {
   const [selectedGwId, setSelectedGwId] = useState(
     pendingNewTask?.gatewayId ?? defaultGatewayId ?? gateways[0]?.id ?? '',
   );
-  const [selectedAgentId, setSelectedAgentId] = useState(pendingNewTask?.agentId ?? 'main');
+  const initialAgentId =
+    pendingNewTask?.agentId ||
+    agentCatalogByGateway[pendingNewTask?.gatewayId ?? defaultGatewayId ?? '']?.defaultId ||
+    '';
+  const [selectedAgentId, setSelectedAgentId] = useState(initialAgentId);
   const [gwExpanded, setGwExpanded] = useState(false);
   const [agentExpanded, setAgentExpanded] = useState(false);
 
   const gwAgents = agentCatalogByGateway[selectedGwId];
   const agentCatalog = gwAgents?.agents ?? [];
-  const hasMultipleAgents = agentCatalog.length > 1;
+  const hasAgents = agentCatalog.length > 0;
   useEffect(() => {
     if (!selectedGwId) {
       const fallback = defaultGatewayId ?? gateways[0]?.id ?? '';
@@ -78,10 +82,8 @@ function WelcomeScreen() {
   }, [selectedGwId]);
 
   useEffect(() => {
-    if (gwAgents) {
+    if (gwAgents?.defaultId) {
       setSelectedAgentId(gwAgents.defaultId);
-    } else {
-      setSelectedAgentId('main');
     }
   }, [gwAgents]);
 
@@ -150,7 +152,7 @@ function WelcomeScreen() {
         </div>
       )}
 
-      {hasMultipleAgents && (
+      {hasAgents && (
         <div className={cn('flex flex-wrap items-center justify-center gap-2', hasMultipleGw ? 'mt-3' : 'mt-6')}>
           {visibleAgents.map((agent) => (
             <button
@@ -206,11 +208,12 @@ function ChatHeader({ onTogglePanel }: { onTogglePanel: () => void }) {
   const gatewayInfoMap = useUiStore((s) => s.gatewayInfoMap);
   const hasMultipleGateways = Object.keys(gatewayInfoMap).length > 1;
   const gwInfo = activeTask ? gatewayInfoMap[activeTask.gatewayId] : undefined;
-  const agentInfo = useUiStore((s) =>
-    activeTask?.agentId && activeTask.agentId !== 'main'
-      ? s.agentCatalogByGateway[activeTask.gatewayId]?.agents.find((a) => a.id === activeTask.agentId)
-      : undefined,
-  );
+  const agentInfo = useUiStore((s) => {
+    if (!activeTask?.agentId) return undefined;
+    const catalog = s.agentCatalogByGateway[activeTask.gatewayId];
+    if (!catalog || activeTask.agentId === catalog.defaultId) return undefined;
+    return catalog.agents.find((a) => a.id === activeTask.agentId);
+  });
   const sessionUsage = useUsageStore((s) => s.sessionUsage);
   const cost = useUsageStore((s) => s.cost);
   const usageStatus = useUsageStore((s) => s.status);

--- a/packages/desktop/src/renderer/stores/taskStore.ts
+++ b/packages/desktop/src/renderer/stores/taskStore.ts
@@ -66,19 +66,22 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   pendingNewTask: null,
 
   startNewTask: (gatewayId?, agentId?) => {
-    const resolvedGatewayId = gatewayId ?? useUiStore.getState().defaultGatewayId ?? '';
-    const resolvedAgentId = agentId ?? 'main';
+    const uiState = useUiStore.getState();
+    const resolvedGatewayId = gatewayId ?? uiState.defaultGatewayId ?? '';
+    const resolvedAgentId = agentId || uiState.agentCatalogByGateway[resolvedGatewayId]?.defaultId || '';
     set({
       activeTaskId: null,
       pendingNewTask: { gatewayId: resolvedGatewayId, agentId: resolvedAgentId },
     });
-    useUiStore.getState().setMainView('chat');
+    uiState.setMainView('chat');
   },
 
   commitPendingTask: () => {
     const pending = get().pendingNewTask;
-    const gwId = pending?.gatewayId ?? useUiStore.getState().defaultGatewayId ?? '';
-    const agId = pending?.agentId ?? 'main';
+    const uiState = useUiStore.getState();
+    const gwId = pending?.gatewayId ?? uiState.defaultGatewayId ?? '';
+    const agId = pending?.agentId || uiState.agentCatalogByGateway[gwId]?.defaultId;
+    if (!agId) throw new Error('no agent available — gateway catalog not loaded');
     const task = get().createTask(gwId, agId);
     set({ pendingNewTask: null });
     return task;
@@ -88,11 +91,13 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
   createTask: (gatewayId?, agentId?) => {
     const resolvedGatewayId = gatewayId ?? useUiStore.getState().defaultGatewayId ?? '';
+    const resolvedAgentId = agentId || useUiStore.getState().agentCatalogByGateway[resolvedGatewayId]?.defaultId;
+    if (!resolvedAgentId) throw new Error('no agent available — gateway catalog not loaded');
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
     const task: Task = {
       id,
-      sessionKey: buildSessionKey(id, agentId, cachedDeviceId ?? undefined),
+      sessionKey: buildSessionKey(id, resolvedAgentId, cachedDeviceId ?? undefined),
       sessionId: '',
       title: '',
       status: 'active',
@@ -101,7 +106,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       tags: [],
       artifactDir: '',
       gatewayId: resolvedGatewayId,
-      agentId: agentId ?? 'main',
+      agentId: resolvedAgentId,
     };
     set((s) => ({ tasks: [task, ...s.tasks], activeTaskId: id }));
     window.clawwork.persistTask(task).catch(() => {});

--- a/packages/desktop/src/renderer/stores/uiStore.ts
+++ b/packages/desktop/src/renderer/stores/uiStore.ts
@@ -116,7 +116,7 @@ interface UiState {
   setRightPanelShortcut: (s: PanelShortcutRight) => void;
 }
 
-const EMPTY_AGENT_CATALOG = { agents: [] as AgentInfo[], defaultId: 'main' };
+const EMPTY_AGENT_CATALOG = { agents: [] as AgentInfo[], defaultId: '' };
 
 export const useUiStore = create<UiState>((set, get) => ({
   rightPanelOpen: false,


### PR DESCRIPTION
### What's changed?

- Replace all hardcoded `'main'` agent fallback in UI/task creation layer with `defaultId` from Gateway `agents.list` response
- Add 30s per-task response timeout — if `chat.send` succeeds but agent never responds, clear processing and show error
- Show agent pill on WelcomeScreen even with a single agent (`> 0` instead of `> 1`)
- Use `catalog.defaultId` instead of `!== 'main'` for ChatHeader and LeftNav agent badge visibility
- Throw on task creation when no agent catalog is loaded (prevents sending to invalid agent)

### Why

- OpenClaw `main` is a virtual fallback that only exists in zero-config mode. When agents are explicitly configured, `main` is not a valid agent ID and Gateway rejects it with `INVALID_REQUEST`
- Users selecting `main` (or having it auto-selected before catalog loads) see silent failures — infinite spinner with no error feedback

Closes #102