### PR TITLE
chore(desktop): bump version to 0.0.9

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawwork/desktop",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "description": "OpenClaw desktop client with structured task management",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump desktop version from 0.0.8 to 0.0.9

## Type of change

- [x] `[Build]` CI, packaging, or tooling change

## What changed?

Release v0.0.9 — includes all PRs merged since v0.0.8:

### Fixes
- #110 Add try/catch to ws:abort-chat IPC handler
- #111 Prevent path traversal, migration state corruption, and config credential exposure
- #112 Serialize git operations and eliminate TOCTOU race in artifact file naming
- #113 Fix IPC listener leak in onArtifactSaved and remove unsafe removeAllListeners API
- #114 Validate file paths in url scheme handlers to prevent arbitrary file read
- #115 Prevent symlink traversal in context file reader and directory scanner
- #116 Reinit database on workspace setup to prevent stale connection
- #117 Validate WebSocket frame shape before dispatching events
- #120 Prevent path traversal in extracted filenames
- #121 Close database before migration copy to ensure consistent snapshot
- #122 Reconcile partial history instead of skipping synced tasks
- #123 Block SSRF and unbounded memory in remote image auto-fetch
- #124 Clear stale stream state on reset and defer user message persistence until send success
- #125 Redact pairing and bootstrap credentials in debug bundle export
- #126 Prevent message duplication on startup via hydration serialization and DB unique index
- #128 Eliminate message duplication caused by client-server timestamp mismatch in post-final sync
- #133 Stabilize gateway sync, error propagation, and tool state persistence
- #134 Replace hardcoded 'main' agent fallback with gateway catalog defaultId and add response timeout

### Features
- #119 Scope sessions by device ID and sync titles to server

### Refactoring
- #129 Rework typography scale to 16px base with zoom persistence

## Validation

- [ ] Not run