### PR TITLE
[Fix] Trust Windows system root certificates for gateway connections

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -46,6 +46,7 @@
     "simple-git": "^3.33.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
+    "win-ca": "^3.5.1",
     "ws": "^8.18.0",
     "zustand": "^5.0.11"
   },

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -27,6 +27,7 @@ import {
   type DeviceIdentity,
 } from './device-identity.js';
 import { getDebugLogger } from '../debug/index.js';
+import { ensureGatewayWindowsSystemTrust } from './tls-trust.js';
 
 const WS_CLOSE_POLICY_VIOLATION = 1008;
 const WS_HANDSHAKE_TIMEOUT_MS = 10_000;
@@ -102,6 +103,7 @@ export class GatewayClient {
 
   connect(): void {
     if (this.destroyed) return;
+    ensureGatewayWindowsSystemTrust();
     this.cleanup();
     this.lastError = null;
 

--- a/packages/desktop/src/main/ws/tls-trust.ts
+++ b/packages/desktop/src/main/ws/tls-trust.ts
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module';
+import { getDebugLogger } from '../debug/index.js';
+
+type WinCaModule = {
+  inject?: (mode: '+' | boolean) => void;
+};
+
+let windowsSystemTrustAttempted = false;
+
+export function ensureGatewayWindowsSystemTrust(): void {
+  if (process.platform !== 'win32' || windowsSystemTrustAttempted) {
+    return;
+  }
+
+  windowsSystemTrustAttempted = true;
+
+  try {
+    const require = createRequire(import.meta.url);
+    const winCa = require('win-ca') as WinCaModule;
+
+    if (typeof winCa.inject !== 'function') {
+      throw new Error('win-ca inject is unavailable');
+    }
+
+    winCa.inject('+');
+
+    getDebugLogger().info({
+      domain: 'gateway',
+      event: 'gateway.tls.system-trust.enabled',
+    });
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+
+    getDebugLogger().warn({
+      domain: 'gateway',
+      event: 'gateway.tls.system-trust.failed',
+      error: { name: err.name, message: err.message, stack: err.stack },
+    });
+  }
+}

--- a/packages/desktop/test/gateway-tls.test.ts
+++ b/packages/desktop/test/gateway-tls.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const injectMock = vi.hoisted(() => vi.fn());
+const requireMock = vi.hoisted(() => vi.fn(() => ({ inject: injectMock })));
+
+vi.mock('node:module', () => ({
+  createRequire: vi.fn(() => requireMock),
+}));
+
+describe('ensureGatewayWindowsSystemTrust', () => {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  beforeEach(() => {
+    vi.resetModules();
+    requireMock.mockClear();
+    injectMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (platformDescriptor) {
+      Object.defineProperty(process, 'platform', platformDescriptor);
+    }
+  });
+
+  it('loads win-ca once on Windows and enables secure context injection', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
+
+    const { ensureGatewayWindowsSystemTrust } = await import('../src/main/ws/tls-trust.js');
+
+    ensureGatewayWindowsSystemTrust();
+    ensureGatewayWindowsSystemTrust();
+
+    expect(requireMock).toHaveBeenCalledTimes(1);
+    expect(requireMock).toHaveBeenCalledWith('win-ca');
+    expect(injectMock).toHaveBeenCalledTimes(1);
+    expect(injectMock).toHaveBeenCalledWith('+');
+  });
+
+  it('skips win-ca outside Windows', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' });
+
+    const { ensureGatewayWindowsSystemTrust } = await import('../src/main/ws/tls-trust.js');
+
+    ensureGatewayWindowsSystemTrust();
+
+    expect(requireMock).not.toHaveBeenCalled();
+    expect(injectMock).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      win-ca:
+        specifier: ^3.5.1
+        version: 3.5.1
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -2648,6 +2651,9 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2927,6 +2933,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  make-dir@1.3.0:
+    resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
+    engines: {node: '>=4'}
+
   make-fetch-happen@10.2.1:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -3199,6 +3209,10 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
+  node-forge@1.3.3:
+    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
+    engines: {node: '>= 6.13.0'}
+
   node-gyp@9.4.1:
     resolution: {integrity: sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==}
     engines: {node: ^12.13 || ^14.13 || >=16}
@@ -3313,6 +3327,10 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pify@3.0.0:
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
+    engines: {node: '>=4'}
 
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
@@ -3649,6 +3667,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  split@1.0.1:
+    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -3755,6 +3776,9 @@ packages:
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4050,6 +4074,9 @@ packages:
 
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
+  win-ca@3.5.1:
+    resolution: {integrity: sha512-RNy9gpBS6cxWHjfbqwBA7odaHyT+YQNhtdpJZwYCFoxB/Dq22oeOZ9YCXMwjhLytKpo7JJMnKdJ/ve7N12zzfQ==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -6629,6 +6656,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-electron@2.2.2: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -6879,6 +6908,10 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@1.3.0:
+    dependencies:
+      pify: 3.0.0
 
   make-fetch-happen@10.2.1:
     dependencies:
@@ -7359,6 +7392,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-forge@1.3.3: {}
+
   node-gyp@9.4.1:
     dependencies:
       env-paths: 2.2.1
@@ -7485,6 +7520,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  pify@3.0.0: {}
 
   playwright-core@1.58.2: {}
 
@@ -7876,6 +7913,10 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  split@1.0.1:
+    dependencies:
+      through: 2.3.8
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -7997,6 +8038,8 @@ snapshots:
     dependencies:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
+
+  through@2.3.8: {}
 
   tinybench@2.9.0: {}
 
@@ -8292,6 +8335,13 @@ snapshots:
   wide-align@1.1.5:
     dependencies:
       string-width: 4.2.3
+
+  win-ca@3.5.1:
+    dependencies:
+      is-electron: 2.2.2
+      make-dir: 1.3.0
+      node-forge: 1.3.3
+      split: 1.0.1
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary

Fix Windows `wss` gateway connections that fail when the server certificate chains to a root CA installed in the Windows trust store.

## Type of change

- [x] `[Fix]` bug fix
- [ ] `[Feat]` new feature
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

ClawWork's Electron main-process websocket client relied on Node/Electron's default CA bundle, which does not automatically honor the Windows system certificate store. That broke connections to gateways secured by locally trusted enterprise or self-managed roots.

## What changed?

- Added a Windows-only TLS trust bootstrap for gateway connections using `win-ca`
- Enabled the bootstrap before opening gateway websocket connections
- Added regression coverage for the Windows trust initialization path

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`:
  - `packages/desktop/src/main/` owns WebSocket and OS integration
  - Favor the smallest change that preserves layer boundaries
- Why those invariants remain protected:
  - The change stays entirely in the Electron main process and only affects TLS trust used by the gateway websocket client

## Linked issues

Closes #103

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
```

## Screenshots or recordings

N/A

## Release note

- [x] User-facing change. Release note is included below.
- [ ] No user-facing change. Release note is `NONE`.

```release-note
Fixed Windows gateway connections so ClawWork trusts certificates chained to roots installed in the Windows system certificate store.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate