### PR TITLE
feat(homebrew): support devel cask for dev releases

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -142,3 +142,16 @@ jobs:
           make_latest: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-homebrew-devel:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Homebrew tap update for devel
+        run: |
+          gh workflow run update-homebrew.yml \
+            --repo clawwork-ai/clawwork \
+            -f tag=dev \
+            -f cask_name=clawwork@devel
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -3,24 +3,43 @@ name: Update Homebrew Tap
 on:
   release:
     types: [published]
+  workflow_call:
+    secrets:
+      HOMEBREW_TAP_TOKEN:
+        required: false
+    inputs:
+      tag:
+        type: string
+        required: false
+        description: 'Git tag to publish to Homebrew tap (for example: v0.0.2)'
+      cask_name:
+        type: string
+        required: false
+        default: 'clawwork'
+        description: 'Cask name (e.g., clawwork or clawwork@devel)'
   workflow_dispatch:
     inputs:
       tag:
         description: 'Git tag to publish to Homebrew tap (for example: v0.0.2)'
         required: true
         type: string
+      cask_name:
+        description: 'Cask name (e.g., clawwork or clawwork@devel)'
+        required: false
+        type: string
+        default: 'clawwork'
 
 permissions:
   contents: read
 
 jobs:
   update-homebrew-tap:
-    if: ${{ github.event_name != 'release' || github.event.release.prerelease != true }}
     runs-on: ubuntu-latest
     env:
       CLAWWORK_REPO: clawwork-ai/clawwork
       TAP_DIR: homebrew-clawwork
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || (github.event_name == 'workflow_call' && inputs.tag) || github.event.release.tag_name }}
+      CASK_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.cask_name || (github.event_name == 'workflow_call' && inputs.cask_name) || 'clawwork' }}
 
     steps:
       - name: Checkout source repository
@@ -39,6 +58,7 @@ jobs:
           CLAWWORK_REPO: ${{ env.CLAWWORK_REPO }}
           TAP_DIR: ${{ env.TAP_DIR }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          CASK_NAME: ${{ env.CASK_NAME }}
         run: |
           bash scripts/update-homebrew-tap.sh
 
@@ -56,6 +76,6 @@ jobs:
             exit 0
           fi
 
-          git add Casks/clawwork.rb
-          git commit -m "chore: update clawwork cask for ${RELEASE_TAG}"
+          git add "Casks/${CASK_NAME}.rb"
+          git commit -m "chore: update ${CASK_NAME} cask for ${RELEASE_TAG}"
           git push origin HEAD:main

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -5,11 +5,15 @@ set -euo pipefail
 CLAWWORK_REPO="${CLAWWORK_REPO:-clawwork-ai/clawwork}"
 TAP_DIR="${TAP_DIR:-homebrew-clawwork}"
 RELEASE_TAG="${RELEASE_TAG:-${GITHUB_REF_NAME:-}}"
+CASK_NAME="${CASK_NAME:-clawwork}"
 
 if [[ -z "${RELEASE_TAG}" ]]; then
   echo "RELEASE_TAG is required" >&2
   exit 1
 fi
+
+# Handle @devel suffix for cask name (clawwork@devel -> clawwork@devel.rb)
+CASK_FILE="${CASK_NAME}.rb"
 
 asset_json="$(gh release view "${RELEASE_TAG}" -R "${CLAWWORK_REPO}" --json assets --jq '.assets[] | select(.name | endswith("-mac-universal.dmg"))' | head -n 1)"
 
@@ -34,7 +38,7 @@ fi
 
 mkdir -p "${TAP_DIR}/Casks"
 
-cat > "${TAP_DIR}/Casks/clawwork.rb" <<EOF
+cat > "${TAP_DIR}/Casks/${CASK_FILE}" <<EOF
 cask "clawwork" do
   version "${version}"
   sha256 "${sha256}"


### PR DESCRIPTION
## Summary

Add support for clawwork@devel Homebrew cask that tracks the dev release (main branch builds).

## Changes

- update-homebrew-tap.sh: Add CASK_NAME parameter support
- update-homebrew.yml: Add workflow_call trigger and cask_name input
- dev-release.yml: Trigger Homebrew tap update after dev builds

## Usage

After merge, users can install the dev version:
brew install clawwork-ai/clawwork/clawwork@devel

Closes #136