### PR TITLE
[Docs] Extract message-persistence and debugging guides into standalone docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ package-lock.json
 
 # Local AI tooling
 .opencode/
+.claude/settings.local.json
 
 # IDE
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,168 +137,42 @@ See memory files for detailed phase history and technical pitfalls discovered du
 | `mediaLocalRoots` security check             | File sends may be rejected             | [#20258](https://github.com/openclaw/openclaw/issues/20258), [#36477](https://github.com/openclaw/openclaw/issues/36477) |
 | Session auto-reset at 4 AM                   | Long-running Task context gets cleared | Requires server-side config to disable auto-reset                                                                        |
 
-## Message Persistence Architecture (CRITICAL — do not modify without full review)
+## Message Persistence (CRITICAL — do not modify without full review)
 
-### Root Principle: Single Writer per Message Role
+Single Writer per Message Role — violating this **will** cause duplication.
 
-Each message role has exactly ONE code path that writes to the SQLite database. Violating this invariant **will** cause message duplication. This architecture was established after multiple duplication regressions caused by dual-write patterns.
+| Message Role | Sole DB Writer                            | File              |
+| ------------ | ----------------------------------------- | ----------------- |
+| `user`       | `ChatInput` (after `chat.send` succeeds)  | `ChatInput.tsx`   |
+| `assistant`  | `syncSessionMessages` / `syncFromGateway` | `session-sync.ts` |
+| `system`     | `addMessage` (client-generated)           | `messageStore.ts` |
 
-| Message Role | Sole DB Writer                            | Source of Truth            | File              |
-| ------------ | ----------------------------------------- | -------------------------- | ----------------- |
-| `user`       | `ChatInput` (after `chat.send` succeeds)  | Client (we are the author) | `ChatInput.tsx`   |
-| `assistant`  | `syncSessionMessages` / `syncFromGateway` | Gateway (`chat.history`)   | `session-sync.ts` |
-| `system`     | `addMessage` (client-generated)           | Client (local status)      | `messageStore.ts` |
+**PROHIBITED** — each has caused regressions:
 
-### Assistant Message State Machine
-
-```
-                                         sync succeeds
-  ┌────────┐  first delta  ┌───────────┐  state=final  ┌─────────┐  ──────────►  ┌───────────┐
-  │  idle  │ ────────────► │ streaming │ ────────────► │ pending │               │ canonical │
-  └────────┘               └───────────┘               └─────────┘  ◄──────────  └───────────┘
-                                                           │        sync fails       ▲
-                                                           └─► retry (backoff) ──────┘
-                                                           └─► reconnect ────────────┘
-                                                           └─► startup sync ─────────┘
-```
-
-| State     | Storage                          | In DB | In UI                          |
-| --------- | -------------------------------- | ----- | ------------------------------ |
-| streaming | `streamingByTask[taskId]`        | No    | Yes (live text)                |
-| pending   | `pendingAssistantByTask[taskId]` | No    | Yes (finalized, awaiting sync) |
-| canonical | `messagesByTask[taskId]`         | Yes   | Yes (persisted history)        |
-
-**Invariant**: These three storages never contain the same message simultaneously. Streaming becomes pending on `final`. Pending becomes canonical on sync success. Pending is cleared (not promoted) on `error`/`aborted`.
-
-### Key Functions and Their Roles
-
-| Function              | Role                                                                                                                                                      | MUST NOT                                                                            |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `finalizeStream`      | State transition: streaming → pending. Clears streaming buffers unconditionally.                                                                          | Write to DB. Write to `messagesByTask`.                                             |
-| `syncSessionMessages` | Runtime sync: pending → canonical. Fetches `chat.history`, persists to DB, calls `promotePending`. Serialized per task.                                   | Be called for `error`/`aborted` events.                                             |
-| `syncFromGateway`     | Startup sync: recover history from Gateway on connect. For existing tasks, only syncs assistant messages. For new tasks, syncs all.                       | Write user messages for existing tasks (ChatInput is the sole user message writer). |
-| `promotePending`      | Atomic Zustand update: append canonical to `messagesByTask` + merge pending's `thinkingContent`/`toolCalls`/`runId` + clear pending. Single `set()` call. | Execute as two separate updates (would cause UI flicker/duplication).               |
-| `retrySyncPending`    | On Gateway reconnect, retries sync for all tasks with pending messages.                                                                                   | —                                                                                   |
-
-### Sync Timing
-
-- **Runtime sync**: Triggered immediately after each `state === 'final'` event. Retries with backoff (2s, 4s, 8s) on failure.
-- **Startup sync**: Triggered once on first Gateway connect. Recovers messages that were pending when the app crashed.
-- **Reconnect sync**: `retrySyncPending()` retries all pending tasks when Gateway reconnects.
-
-### DB Unique Index
-
-`messages_dedup ON messages(task_id, role, timestamp)` — This is a **single-writer idempotency guard**, not a dedup strategy. Since the sync path is the sole writer for assistant messages, and all timestamps come from Gateway, the index prevents accidental re-insertion of the same message if sync runs twice.
-
-### PROHIBITED Patterns
-
-**DO NOT introduce any of the following. Each has caused regressions:**
-
-- `finalizeStream` calling `persistMessage` — Creates dual-write with sync path
-- Content-based dedup (`role:content` matching) — Fragile; streaming content differs from Gateway content (leading whitespace, encoding)
-- `content.trim()` as identity/dedup mechanism — Message content is user data, not an identity key
-- Timestamp-based dedup as the "fix" — Timestamps are a side effect of single-writer, not the mechanism that prevents duplication
+- `finalizeStream` calling `persistMessage`
+- Content-based dedup (`role:content` matching)
+- `content.trim()` as identity/dedup mechanism
+- Timestamp-based dedup as the "fix"
 - Persisting assistant messages from any path other than `session-sync.ts`
 
-### Protocol Limitation
-
-OpenClaw Gateway `chat.history` does not return per-message IDs. The Gateway's `timestamp` (epoch ms) is the closest to a stable message identifier. The `runId` is present in streaming events but not in history responses. This is why single-writer architecture is necessary — without message IDs, any dual-write scheme requires fragile dedup.
+Full state machine, function roles, sync timing, past bug patterns: `docs/message-persistence.md`
 
 ## Coding Conventions
 
-- TypeScript strict mode; `any` is not allowed
-- All colors via CSS Variables — no hardcoded hex values
-- Component files go in `layouts/` (layout components) or `components/` (general components), organized by feature
-- State management uses Zustand, one store per domain (`taskStore`, `messageStore`, `uiStore`)
-- WebSocket message types are defined in `@clawwork/shared`; desktop imports from there
+See `.claude/rules/frontend.md` (always loaded).
+
+## Verification
+
+Before claiming done:
+
+- `pnpm typecheck` passes
+- `pnpm test` passes
+- Message-related changes: SQLite duplicate query returns empty
+- UI changes: verify in both dark/light themes
 
 ## Debugging
 
-When investigating message duplication, rendering glitches, or state sync issues, use these tools **before** asking the user for more info.
-
-### SQLite Database
-
-The workspace DB is at `<workspace>/clawwork.db`. Query it directly:
-
-```bash
-sqlite3 clawwork.db "SELECT id, task_id, role, substr(content,1,50), timestamp FROM messages WHERE task_id='<id>' ORDER BY timestamp"
-```
-
-Check for duplicate rows (same role+content, different timestamps — a known past bug pattern):
-
-```bash
-sqlite3 clawwork.db "SELECT task_id, role, substr(content,1,50), COUNT(*) as cnt FROM messages GROUP BY task_id, role, content HAVING cnt > 1"
-```
-
-### Renderer Debug Events
-
-`useGatewayDispatcher.ts` emits structured events via `debugEvent()`. Open DevTools Console and filter by `[debug]` to see the message lifecycle:
-
-- `renderer.gateway.event.received` — raw Gateway event arrived
-- `renderer.chat.delta.applied` — streaming delta appended
-- `renderer.chat.final.received` — final event received
-- `renderer.chat.finalized` — stream finalized into message
-- `renderer.event.dropped.*` — event dropped (missing session, unknown task, etc.)
-- `renderer.toolcall.upserted` — tool call added/updated
-
-### Main Process Logs (Gateway WS Traffic)
-
-Gateway WS runs in Electron main process via Node.js `ws` library — **not visible in DevTools Network tab** (that only shows Vite HMR on :5173).
-
-**Terminal output:** `pnpm dev` terminal prints all `DebugLogger` output in real time:
-
-```
-[info] [gateway] gateway.connect.start {...}
-[debug] [gateway] gateway.req.sent {...}
-[debug] [gateway] gateway.event.received {...}
-```
-
-**Log file:** persisted as ndjson at `app.getPath('logs')` → `~/Library/Logs/@clawwork/desktop/debug-YYYY-MM-DD.ndjson`
-
-```bash
-# Real-time Gateway traffic
-tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | grep gateway
-
-# Filter specific event types
-tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | grep 'gateway.event.received'
-
-# Pretty-print with jq
-tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | jq 'select(.domain=="gateway")'
-```
-
-**Renderer forwarding:** `window.clawwork.reportDebugEvent` forwards renderer events to the main process. These are captured in debug bundle exports (`fix(debug)` PR #125).
-
-### Zustand State Inspection
-
-In DevTools Console, directly inspect store state:
-
-```js
-// Current messages for a task
-window.__ZUSTAND_STORES__?.messageStore?.getState()?.messagesByTask['<taskId>'];
-
-// Or via the module (if source maps available)
-// Check streamingByTask for in-progress streams
-```
-
-### When to Use Each Tool
-
-| Symptom                        | First check                                                                   |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| Duplicate messages in UI       | SQLite duplicate query → check if DB has dupes or just Zustand store          |
-| Messages missing after restart | SQLite row count → check if persist failed                                    |
-| Streaming stuck / no final     | DevTools `[debug]` filter → look for `final.received` without `finalized`     |
-| Messages from wrong task       | DevTools `[debug]` filter → check `sessionKey` → `taskId` mapping             |
-| State sync issues (reconnect)  | DevTools `[debug]` filter → look for `syncFromGateway` calls and their timing |
-| Gateway WS not connecting      | `pnpm dev` terminal → look for `gateway.connect.start` / `gateway.ws.error`   |
-| Gateway request timeout/error  | `tail -f` ndjson log → filter `gateway.req.timeout` or `gateway.res.error`    |
-| Gateway event not reaching UI  | ndjson log confirms `gateway.event.received` → DevTools check renderer side   |
-
-### Past Bug Patterns
-
-| Pattern                                 | Root Cause                                                                                                                                                              | Fix                                                                                                                                                                                   |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Assistant message doubled after restart | `finalizeStream` AND `syncFromGateway` both wrote assistant messages to DB (dual-write). Content/timestamp differed between streaming accumulation and Gateway history. | Eliminated dual-write: `finalizeStream` only writes to Zustand pending state; sync path is the sole DB writer for assistant messages. See "Message Persistence Architecture" section. |
-| Startup hydration duplicates            | Race between `hydrateFromLocal` and `syncFromGateway`                                                                                                                   | Serialized via `hydrationPromise` + DB unique index (#126)                                                                                                                            |
+See `docs/debugging.md` for SQLite queries, renderer debug events, main process logs, and Zustand state inspection.
 
 ## Design Documents
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,71 @@
+# Debugging Guide
+
+When investigating message duplication, rendering glitches, or state sync issues, use these tools **before** asking the user for more info.
+
+## SQLite Database
+
+The workspace DB is at `<workspace>/clawwork.db`. Query it directly:
+
+```bash
+sqlite3 clawwork.db "SELECT id, task_id, role, substr(content,1,50), timestamp FROM messages WHERE task_id='<id>' ORDER BY timestamp"
+```
+
+Check for duplicate rows (same role+content, different timestamps — a known past bug pattern):
+
+```bash
+sqlite3 clawwork.db "SELECT task_id, role, substr(content,1,50), COUNT(*) as cnt FROM messages GROUP BY task_id, role, content HAVING cnt > 1"
+```
+
+## Renderer Debug Events
+
+`useGatewayDispatcher.ts` emits structured events via `debugEvent()`. Open DevTools Console and filter by `[debug]` to see the message lifecycle:
+
+- `renderer.gateway.event.received` — raw Gateway event arrived
+- `renderer.chat.delta.applied` — streaming delta appended
+- `renderer.chat.final.received` — final event received
+- `renderer.chat.finalized` — stream finalized into message
+- `renderer.event.dropped.*` — event dropped (missing session, unknown task, etc.)
+- `renderer.toolcall.upserted` — tool call added/updated
+
+## Main Process Logs (Gateway WS Traffic)
+
+Gateway WS runs in Electron main process via Node.js `ws` library — **not visible in DevTools Network tab** (that only shows Vite HMR on :5173).
+
+**Terminal output:** `pnpm dev` terminal prints all `DebugLogger` output in real time:
+
+```
+[info] [gateway] gateway.connect.start {...}
+[debug] [gateway] gateway.req.sent {...}
+[debug] [gateway] gateway.event.received {...}
+```
+
+**Log file:** persisted as ndjson at `app.getPath('logs')` → `~/Library/Logs/@clawwork/desktop/debug-YYYY-MM-DD.ndjson`
+
+```bash
+tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | grep gateway
+tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | grep 'gateway.event.received'
+tail -f ~/Library/Logs/@clawwork/desktop/debug-$(date +%Y-%m-%d).ndjson | jq 'select(.domain=="gateway")'
+```
+
+**Renderer forwarding:** `window.clawwork.reportDebugEvent` forwards renderer events to the main process. These are captured in debug bundle exports (`fix(debug)` PR #125).
+
+## Zustand State Inspection
+
+In DevTools Console, directly inspect store state:
+
+```js
+window.__ZUSTAND_STORES__?.messageStore?.getState()?.messagesByTask['<taskId>'];
+```
+
+## When to Use Each Tool
+
+| Symptom                        | First check                                                                   |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| Duplicate messages in UI       | SQLite duplicate query → check if DB has dupes or just Zustand store          |
+| Messages missing after restart | SQLite row count → check if persist failed                                    |
+| Streaming stuck / no final     | DevTools `[debug]` filter → look for `final.received` without `finalized`     |
+| Messages from wrong task       | DevTools `[debug]` filter → check `sessionKey` → `taskId` mapping             |
+| State sync issues (reconnect)  | DevTools `[debug]` filter → look for `syncFromGateway` calls and their timing |
+| Gateway WS not connecting      | `pnpm dev` terminal → look for `gateway.connect.start` / `gateway.ws.error`   |
+| Gateway request timeout/error  | `tail -f` ndjson log → filter `gateway.req.timeout` or `gateway.res.error`    |
+| Gateway event not reaching UI  | ndjson log confirms `gateway.event.received` → DevTools check renderer side   |

--- a/docs/message-persistence.md
+++ b/docs/message-persistence.md
@@ -1,0 +1,55 @@
+# Message Persistence Architecture — Full Reference
+
+> This file contains the detailed architecture. The CRITICAL invariant (single-writer table + prohibited patterns) is in `CLAUDE.md`.
+
+## Assistant Message State Machine
+
+```
+                                         sync succeeds
+  ┌────────┐  first delta  ┌───────────┐  state=final  ┌─────────┐  ──────────►  ┌───────────┐
+  │  idle  │ ────────────► │ streaming │ ────────────► │ pending │               │ canonical │
+  └────────┘               └───────────┘               └─────────┘  ◄──────────  └───────────┘
+                                                           │        sync fails       ▲
+                                                           └─► retry (backoff) ──────┘
+                                                           └─► reconnect ────────────┘
+                                                           └─► startup sync ─────────┘
+```
+
+| State     | Storage                          | In DB | In UI                          |
+| --------- | -------------------------------- | ----- | ------------------------------ |
+| streaming | `streamingByTask[taskId]`        | No    | Yes (live text)                |
+| pending   | `pendingAssistantByTask[taskId]` | No    | Yes (finalized, awaiting sync) |
+| canonical | `messagesByTask[taskId]`         | Yes   | Yes (persisted history)        |
+
+**Invariant**: These three storages never contain the same message simultaneously. Streaming becomes pending on `final`. Pending becomes canonical on sync success. Pending is cleared (not promoted) on `error`/`aborted`.
+
+## Key Functions and Their Roles
+
+| Function              | Role                                                                                                                                                      | MUST NOT                                                                            |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `finalizeStream`      | State transition: streaming → pending. Clears streaming buffers unconditionally.                                                                          | Write to DB. Write to `messagesByTask`.                                             |
+| `syncSessionMessages` | Runtime sync: pending → canonical. Fetches `chat.history`, persists to DB, calls `promotePending`. Serialized per task.                                   | Be called for `error`/`aborted` events.                                             |
+| `syncFromGateway`     | Startup sync: recover history from Gateway on connect. For existing tasks, only syncs assistant messages. For new tasks, syncs all.                       | Write user messages for existing tasks (ChatInput is the sole user message writer). |
+| `promotePending`      | Atomic Zustand update: append canonical to `messagesByTask` + merge pending's `thinkingContent`/`toolCalls`/`runId` + clear pending. Single `set()` call. | Execute as two separate updates (would cause UI flicker/duplication).               |
+| `retrySyncPending`    | On Gateway reconnect, retries sync for all tasks with pending messages.                                                                                   | —                                                                                   |
+
+## Sync Timing
+
+- **Runtime sync**: Triggered immediately after each `state === 'final'` event. Retries with backoff (2s, 4s, 8s) on failure.
+- **Startup sync**: Triggered once on first Gateway connect. Recovers messages that were pending when the app crashed.
+- **Reconnect sync**: `retrySyncPending()` retries all pending tasks when Gateway reconnects.
+
+## DB Unique Index
+
+`messages_dedup ON messages(task_id, role, timestamp)` — This is a **single-writer idempotency guard**, not a dedup strategy. Since the sync path is the sole writer for assistant messages, and all timestamps come from Gateway, the index prevents accidental re-insertion of the same message if sync runs twice.
+
+## Protocol Limitation
+
+OpenClaw Gateway `chat.history` does not return per-message IDs. The Gateway's `timestamp` (epoch ms) is the closest to a stable message identifier. The `runId` is present in streaming events but not in history responses. This is why single-writer architecture is necessary — without message IDs, any dual-write scheme requires fragile dedup.
+
+## Past Bug Patterns
+
+| Pattern                                 | Root Cause                                                                                                                                                              | Fix                                                                                                                                                                                   |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Assistant message doubled after restart | `finalizeStream` AND `syncFromGateway` both wrote assistant messages to DB (dual-write). Content/timestamp differed between streaming accumulation and Gateway history. | Eliminated dual-write: `finalizeStream` only writes to Zustand pending state; sync path is the sole DB writer for assistant messages. See "Message Persistence Architecture" section. |
+| Startup hydration duplicates            | Race between `hydrateFromLocal` and `syncFromGateway`                                                                                                                   | Serialized via `hydrationPromise` + DB unique index (#126)                                                                                                                            |


### PR DESCRIPTION
### What's changed?

- Extract detailed message-persistence architecture and debugging guides from CLAUDE.md into `docs/message-persistence.md` and `docs/debugging.md`
- Slim CLAUDE.md to summary tables with pointers to the new docs
- Add `.claude/settings.local.json` to .gitignore

### Why

- CLAUDE.md was getting unwieldy; dedicated docs are easier to reference and maintain