### PR TITLE
[Fix] stabilize exec approval state handling

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron';
 import { getGatewayClient, getAllGatewayClients, reconnectGateway } from '../ws/index.js';
 import { readConfig, ensureDeviceId } from '../workspace/config.js';
 import { isClawWorkSession, parseTaskIdFromSessionKey, parseAgentIdFromSessionKey } from '@clawwork/shared';
-import type { ChatAttachment } from '@clawwork/shared';
+import type { ApprovalDecision, ChatAttachment, ExecApprovalResolveParams } from '@clawwork/shared';
 import { getDebugLogger } from '../debug/index.js';
 import type { GatewayClient } from '../ws/gateway-client.js';
 
@@ -450,16 +450,17 @@ export function registerWsHandlers(): void {
     'ws:exec-approval-resolve',
     async (
       _event,
-      payload: {
+      payload: ExecApprovalResolveParams & {
         gatewayId: string;
-        id: string;
-        decision: string;
       },
     ) => {
       const gw = getGatewayClient(payload.gatewayId);
       if (!gw?.isConnected) return { ok: false, error: 'gateway not connected' };
       try {
-        await gw.sendReq('exec.approval.resolve', { id: payload.id, decision: payload.decision });
+        await gw.sendReq('exec.approval.resolve', {
+          id: payload.id,
+          decision: payload.decision as ApprovalDecision,
+        });
         return { ok: true };
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'unknown error';

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -332,7 +332,7 @@ export interface ClawWorkAPI {
   ) => Promise<IpcResult>;
   getSessionUsage: (gatewayId: string, sessionKey: string) => Promise<IpcResult>;
 
-  resolveExecApproval: (gatewayId: string, id: string, decision: string) => Promise<IpcResult>;
+  resolveExecApproval: (gatewayId: string, id: string, decision: ApprovalDecision) => Promise<IpcResult>;
 
   resetSession: (gatewayId: string, sessionKey: string, reason?: 'new' | 'reset') => Promise<IpcResult>;
   deleteSession: (gatewayId: string, sessionKey: string) => Promise<IpcResult>;
@@ -367,3 +367,4 @@ declare global {
     clawwork: ClawWorkAPI;
   }
 }
+import type { ApprovalDecision } from '@clawwork/shared';

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { electronAPI } from '@electron-toolkit/preload';
+import type { ApprovalDecision } from '@clawwork/shared';
 import type { ClawWorkAPI, GatewayServerConfig } from './clawwork';
 
 function buildApi(): ClawWorkAPI {
@@ -168,7 +169,7 @@ function buildApi(): ClawWorkAPI {
     getSessionUsage: (gatewayId: string, sessionKey: string) =>
       ipcRenderer.invoke('ws:session-usage', { gatewayId, sessionKey }),
 
-    resolveExecApproval: (gatewayId: string, id: string, decision: string) =>
+    resolveExecApproval: (gatewayId: string, id: string, decision: ApprovalDecision) =>
       ipcRenderer.invoke('ws:exec-approval-resolve', { gatewayId, id, decision }),
 
     resetSession: (gatewayId: string, sessionKey: string, reason?: 'new' | 'reset') =>

--- a/packages/desktop/src/renderer/stores/approvalStore.ts
+++ b/packages/desktop/src/renderer/stores/approvalStore.ts
@@ -1,7 +1,21 @@
 import { create } from 'zustand';
+import { parseTaskIdFromSessionKey } from '@clawwork/shared';
 import type { ApprovalDecision, ExecApprovalRequest } from '@clawwork/shared';
+import { toast } from 'sonner';
+import i18n from '../i18n';
+import { useTaskStore } from './taskStore';
+import { useUiStore } from './uiStore';
+import { buildAppError, formatErrorForToast } from '../lib/error-format';
 
-type PendingApproval = ExecApprovalRequest & { gatewayId: string };
+type PendingApproval = ExecApprovalRequest & { gatewayId: string; taskId: string | null };
+
+function resolveTaskId(sessionKey?: string | null): string | null {
+  if (!sessionKey) return null;
+  const taskId = parseTaskIdFromSessionKey(sessionKey);
+  if (!taskId) return null;
+  const tasks = useTaskStore.getState().tasks;
+  return tasks.some((task) => task.id === taskId) ? taskId : null;
+}
 
 const expireTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -10,12 +24,17 @@ export const useApprovalStore = create<{
   addApproval: (gatewayId: string, req: ExecApprovalRequest) => void;
   removeApproval: (id: string) => void;
   resolveApproval: (id: string, decision: ApprovalDecision) => void;
+  clear: () => void;
 }>((set, get) => ({
   pendingApprovals: [],
 
   addApproval(gatewayId, req) {
     if (get().pendingApprovals.some((a) => a.id === req.id)) return;
-    set((s) => ({ pendingApprovals: [...s.pendingApprovals, { ...req, gatewayId }] }));
+    const taskId = resolveTaskId(req.request.sessionKey);
+    if (taskId && taskId !== useTaskStore.getState().activeTaskId) {
+      useUiStore.getState().markUnread(taskId);
+    }
+    set((s) => ({ pendingApprovals: [...s.pendingApprovals, { ...req, gatewayId, taskId }] }));
     const ttl = req.expiresAtMs - Date.now();
     if (ttl > 0) {
       expireTimers.set(
@@ -29,6 +48,10 @@ export const useApprovalStore = create<{
   },
 
   removeApproval(id) {
+    const approval = get().pendingApprovals.find((a) => a.id === id);
+    if (approval?.taskId && !get().pendingApprovals.some((a) => a.id !== id && a.taskId === approval.taskId)) {
+      useUiStore.getState().clearUnread(approval.taskId);
+    }
     clearTimeout(expireTimers.get(id));
     expireTimers.delete(id);
     set((s) => ({ pendingApprovals: s.pendingApprovals.filter((a) => a.id !== id) }));
@@ -37,7 +60,39 @@ export const useApprovalStore = create<{
   resolveApproval(id, decision) {
     const approval = get().pendingApprovals.find((a) => a.id === id);
     if (!approval) return;
-    window.clawwork.resolveExecApproval(approval.gatewayId, id, decision).catch(() => {});
-    get().removeApproval(id);
+    window.clawwork
+      .resolveExecApproval(approval.gatewayId, id, decision)
+      .then((result) => {
+        if (!result.ok) {
+          const appError = buildAppError({
+            source: 'gateway',
+            stage: 'send',
+            rawMessage: result.error ?? 'exec approval resolve failed',
+            code: result.errorCode,
+            details: result.errorDetails,
+          });
+          const { title, description } = formatErrorForToast(appError, i18n.t);
+          toast.error(title, { description });
+          return;
+        }
+        get().removeApproval(id);
+      })
+      .catch((err) => {
+        const appError = buildAppError({
+          source: 'gateway',
+          stage: 'send',
+          rawMessage: err instanceof Error ? err.message : 'exec approval resolve failed',
+        });
+        const { title, description } = formatErrorForToast(appError, i18n.t);
+        toast.error(title, { description });
+      });
+  },
+
+  clear() {
+    for (const timer of expireTimers.values()) {
+      clearTimeout(timer);
+    }
+    expireTimers.clear();
+    set({ pendingApprovals: [] });
   },
 }));

--- a/packages/desktop/test/approval-store.test.ts
+++ b/packages/desktop/test/approval-store.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Task } from '@clawwork/shared';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+async function loadStores() {
+  vi.resetModules();
+  const [approvalStore, taskStore, uiStore] = await Promise.all([
+    import('../src/renderer/stores/approvalStore'),
+    import('../src/renderer/stores/taskStore'),
+    import('../src/renderer/stores/uiStore'),
+  ]);
+  return { approvalStore, taskStore, uiStore };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('approval store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as Window & {
+      clawwork: {
+        resolveExecApproval: ReturnType<typeof vi.fn>;
+        updateSettings: ReturnType<typeof vi.fn>;
+      };
+    };
+    windowWithClawwork.clawwork = {
+      resolveExecApproval: vi.fn().mockResolvedValue({ ok: true }),
+      updateSettings: vi.fn().mockResolvedValue({ ok: true }),
+    } as unknown as typeof windowWithClawwork.clawwork;
+    const storage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    };
+    vi.stubGlobal('localStorage', storage);
+  });
+
+  it('associates approvals with the matching task and marks inactive tasks unread', async () => {
+    const { approvalStore, taskStore, uiStore } = await loadStores();
+
+    const task: Task = {
+      id: 'task-1',
+      sessionKey: 'agent:main:clawwork:task:task-1',
+      sessionId: '',
+      title: 'Task 1',
+      status: 'active',
+      createdAt: '2026-03-23T00:00:00.000Z',
+      updatedAt: '2026-03-23T00:00:00.000Z',
+      tags: [],
+      artifactDir: '',
+      gatewayId: 'gw-1',
+      agentId: 'main',
+    };
+
+    taskStore.useTaskStore.setState({
+      tasks: [task],
+      activeTaskId: 'another-task',
+      hydrated: true,
+      pendingNewTask: null,
+    });
+
+    approvalStore.useApprovalStore.getState().addApproval('gw-1', {
+      id: 'approval-1',
+      request: {
+        command: 'rm -rf tmp',
+        sessionKey: 'agent:main:clawwork:task:task-1',
+      },
+      createdAtMs: Date.now(),
+      expiresAtMs: Date.now() + 30_000,
+    });
+
+    const pending = approvalStore.useApprovalStore.getState().pendingApprovals;
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.taskId).toBe('task-1');
+    expect(uiStore.useUiStore.getState().unreadTaskIds.has('task-1')).toBe(true);
+  });
+
+  it('keeps pending approval visible when resolve fails', async () => {
+    const { approvalStore } = await loadStores();
+
+    window.clawwork.resolveExecApproval.mockResolvedValueOnce({ ok: false, error: 'denied upstream' });
+
+    approvalStore.useApprovalStore.setState({
+      pendingApprovals: [
+        {
+          id: 'approval-1',
+          gatewayId: 'gw-1',
+          taskId: null,
+          request: { command: 'uname -a' },
+          createdAtMs: Date.now(),
+          expiresAtMs: Date.now() + 30_000,
+        },
+      ],
+    });
+
+    approvalStore.useApprovalStore.getState().resolveApproval('approval-1', 'allow-once');
+    await flushMicrotasks();
+
+    expect(window.clawwork.resolveExecApproval).toHaveBeenCalledWith('gw-1', 'approval-1', 'allow-once');
+    expect(approvalStore.useApprovalStore.getState().pendingApprovals).toHaveLength(1);
+  });
+
+  it('removes pending approval after a successful resolve', async () => {
+    const { approvalStore } = await loadStores();
+
+    approvalStore.useApprovalStore.setState({
+      pendingApprovals: [
+        {
+          id: 'approval-1',
+          gatewayId: 'gw-1',
+          taskId: null,
+          request: { command: 'uname -a' },
+          createdAtMs: Date.now(),
+          expiresAtMs: Date.now() + 30_000,
+        },
+      ],
+    });
+
+    approvalStore.useApprovalStore.getState().resolveApproval('approval-1', 'allow-once');
+    await flushMicrotasks();
+
+    expect(approvalStore.useApprovalStore.getState().pendingApprovals).toHaveLength(0);
+  });
+});

--- a/packages/shared/src/gateway-protocol.ts
+++ b/packages/shared/src/gateway-protocol.ts
@@ -3,10 +3,12 @@
 // JSON-RPC inspired frames: req, res, event
 // ============================================================
 
+import type { ApprovalDecision, ExecApprovalRequest, ExecApprovalResolved } from './types.js';
+
 export interface GatewayReqFrame {
   type: 'req';
   id: string;
-  method: string;
+  method: GatewayReqMethod;
   params: Record<string, unknown>;
 }
 
@@ -18,14 +20,33 @@ export interface GatewayResFrame {
   error?: { code: string; message: string; details?: Record<string, unknown> };
 }
 
-export interface GatewayEventFrame {
+export interface GatewayEventFrame<TPayload = Record<string, unknown>> {
   type: 'event';
-  event: string;
+  event: GatewayEventName;
   seq?: number;
-  payload: Record<string, unknown>;
+  payload: TPayload;
 }
 
 export type GatewayFrame = GatewayReqFrame | GatewayResFrame | GatewayEventFrame;
+
+export type GatewayReqMethod = 'connect' | 'exec.approval.resolve' | (string & {});
+
+export type GatewayEventName = 'exec.approval.requested' | 'exec.approval.resolved' | (string & {});
+
+export interface ExecApprovalResolveParams {
+  id: string;
+  decision: ApprovalDecision;
+}
+
+export interface ExecApprovalRequestedEventFrame extends GatewayEventFrame<ExecApprovalRequest> {
+  event: 'exec.approval.requested';
+  payload: ExecApprovalRequest;
+}
+
+export interface ExecApprovalResolvedEventFrame extends GatewayEventFrame<ExecApprovalResolved> {
+  event: 'exec.approval.resolved';
+  payload: ExecApprovalResolved;
+}
 
 export type GatewayAuth =
   | { token: string; deviceToken?: string }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -261,26 +261,64 @@ export interface FileReadResult {
 
 export type ApprovalDecision = 'allow-once' | 'allow-always' | 'deny';
 
+export interface ExecApprovalMutableFileOperand {
+  argvIndex: number;
+  path: string;
+  sha256: string;
+}
+
+export interface ExecApprovalSystemRunBinding {
+  argv: string[];
+  cwd?: string | null;
+  agentId?: string | null;
+  sessionKey?: string | null;
+  envHash?: string | null;
+}
+
+export interface ExecApprovalSystemRunPlan {
+  argv: string[];
+  cwd?: string | null;
+  commandText: string;
+  commandPreview?: string | null;
+  agentId?: string | null;
+  sessionKey?: string | null;
+  mutableFileOperand?: ExecApprovalMutableFileOperand | null;
+}
+
+export interface ExecApprovalRequestDetails {
+  command: string;
+  commandPreview?: string | null;
+  commandArgv?: string[];
+  envKeys?: string[];
+  systemRunBinding?: ExecApprovalSystemRunBinding | null;
+  systemRunPlan?: ExecApprovalSystemRunPlan | null;
+  cwd?: string | null;
+  nodeId?: string | null;
+  host?: string | null;
+  security?: string | null;
+  ask?: string | null;
+  agentId?: string | null;
+  resolvedPath?: string | null;
+  sessionKey?: string | null;
+  turnSourceChannel?: string | null;
+  turnSourceTo?: string | null;
+  turnSourceAccountId?: string | null;
+  turnSourceThreadId?: string | number | null;
+}
+
 export interface ExecApprovalRequest {
   id: string;
-  request: {
-    command: string;
-    cwd?: string | null;
-    host?: string | null;
-    security?: string | null;
-    ask?: string | null;
-    agentId?: string | null;
-    sessionKey?: string | null;
-  };
+  request: ExecApprovalRequestDetails;
   createdAtMs: number;
   expiresAtMs: number;
 }
 
 export interface ExecApprovalResolved {
   id: string;
-  decision?: string | null;
+  decision?: ApprovalDecision | null;
   resolvedBy?: string | null;
   ts?: number | null;
+  request?: ExecApprovalRequestDetails | null;
 }
 
 // ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stabilize the desktop exec approval flow so pending approvals stay tied to the right task and do not disappear when resolve requests fail.

## Type of change

- [x] `[Fix]` bug fix
- [ ] `[Feat]` new feature
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Operators should not lose approval state because a resolve call failed, and approval requests should surface on the correct task.

## What changed?

- tightened exec approval typing in shared protocol and domain types
- updated the main/preload bridge to use the typed resolve params
- kept pending approvals task-aware in the renderer store and preserved them on resolve failure
- added store tests for task association and resolve success/failure behavior

## Architecture impact

- Owning layer: shared / main / preload / renderer
- Cross-layer impact: yes; the shared approval contract now flows through the existing main -> preload -> renderer boundary
- Invariants touched from `docs/architecture-invariants.md`: shared protocol ownership, preload-only renderer boundary, explicit task routing by `sessionKey`
- Why those invariants remain protected: protocol types stay in shared, renderer access still goes through `window.clawwork`, and task association is still derived from `sessionKey`

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
```

## Screenshots or recordings

No screenshots. This change updates approval state handling and test coverage.

## Release note

- [x] User-facing change. Release note is included below.
- [ ] No user-facing change. Release note is `NONE`.

```release-note
Improve desktop exec approval handling so pending approvals stay associated with the correct task and remain visible if approval resolution fails.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
