### PR TITLE
chore(desktop): bump version to 0.0.10-rc.1

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawwork/desktop",
-  "version": "0.0.9",
+  "version": "0.0.10-rc.1",
   "private": true,
   "description": "OpenClaw desktop client with structured task management",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `@clawwork/desktop` version from `0.0.9` to `0.0.10-rc.1`

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm dev` launches correctly with new version