### PR TITLE
[Fix] allow updater installs to quit cleanly

### DIFF
--- a/packages/desktop/src/main/auto-updater.ts
+++ b/packages/desktop/src/main/auto-updater.ts
@@ -23,6 +23,7 @@ const GITHUB_RELEASE_BASE = 'https://github.com/clawwork-ai/clawwork/releases/ta
 let initialized = false;
 let state: UpdaterState = 'idle';
 let inFlightCheck: Promise<UpdateCheckResult> | null = null;
+let installingUpdate = false;
 
 function broadcast(channel: string, data: unknown): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -53,6 +54,10 @@ function classifyError(err: unknown): UpdateErrorCode {
 
 export function isAutoUpdaterAvailable(): boolean {
   return !is.dev && app.isPackaged;
+}
+
+export function isInstallingUpdate(): boolean {
+  return installingUpdate;
 }
 
 export function initAutoUpdater(): void {
@@ -160,6 +165,21 @@ export function installUpdate(): { ok: boolean; error?: string } {
   if (state !== 'downloaded') {
     return { ok: false, error: 'no-downloaded-update' };
   }
-  autoUpdater.quitAndInstall(false, true);
+  installingUpdate = true;
+  getDebugLogger().info({
+    domain: 'updater',
+    event: 'updater.install.requested',
+    data: {
+      version: app.getVersion(),
+      exePath: app.getPath('exe'),
+      appPath: app.getAppPath(),
+      isPackaged: app.isPackaged,
+      isInApplications: process.platform !== 'darwin' || app.getPath('exe').startsWith('/Applications/'),
+    },
+  });
+  setImmediate(() => {
+    getDebugLogger().info({ domain: 'updater', event: 'updater.install.quit-and-install.called' });
+    autoUpdater.quitAndInstall(false, true);
+  });
   return { ok: true };
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -17,6 +17,7 @@ import { configureVoicePermissionHandlers, registerVoiceHandlers } from './ipc/v
 import { registerTrayHandlers } from './ipc/tray-handlers.js';
 import { registerQuickLaunchHandlers } from './ipc/quick-launch-handlers.js';
 import { registerContextHandlers } from './ipc/context-handlers.js';
+import { isInstallingUpdate } from './auto-updater.js';
 import { initTray, destroyTray, updateTrayWindow } from './tray.js';
 import { initQuickLaunch, destroyQuickLaunch, updateQuickLaunchMainWindow } from './quick-launch.js';
 import { getWorkspacePath, readConfig, updateConfig } from './workspace/config.js';
@@ -202,7 +203,7 @@ app.whenReady().then(() => {
   initQuickLaunch(mainWindow);
 
   mainWindow.on('close', (e) => {
-    if (!isQuitting) {
+    if (!isQuitting && !isInstallingUpdate()) {
       e.preventDefault();
       mainWindow.hide();
     }
@@ -229,7 +230,7 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   isQuitting = true;
-  getDebugLogger().info({ domain: 'app', event: 'app.before-quit' });
+  getDebugLogger().info({ domain: 'app', event: 'app.before-quit', data: { installingUpdate: isInstallingUpdate() } });
   globalShortcut.unregisterAll();
   destroyAllGateways();
   destroyTray();


### PR DESCRIPTION
## Summary

Allow update-triggered shutdown to bypass the normal close-to-hide window path and add install diagnostics around `quitAndInstall()`.

## Type of change

- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Feat]` new feature
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Desktop update downloads were succeeding, but clicking restart could relaunch back into the old version. The app's tray-style close behavior was still active during updater installs, and there was not enough install-phase logging to diagnose failures cleanly.

## What changed?

- allow update installs to mark the process as being in an updater-driven shutdown path
- let the main window close normally during updater installs instead of hiding to the tray-style lifecycle
- add updater install diagnostics for app path, executable path, packaging state, and `quitAndInstall()` invocation

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`:
- The Electron main process owns WebSocket, filesystem, database, Git, workspace config, and OS integration.
- The renderer owns UI state and presentation.
- The renderer must cross the process boundary only through `window.clawwork` from preload.
- Why those invariants remain protected:
- updater install handling remains in the Electron main process
- no preload or renderer contracts changed
- UI behavior continues to consume the existing bridge only

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm install
pnpm check
```

## Screenshots or recordings

Not included.

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Desktop app updater now lets restart-to-install complete without being intercepted by the app's normal close-to-hide behavior, and adds install diagnostics for updater troubleshooting.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate