### PR TITLE
[Feat] Improve tool-call collapse UX with auto-expand and summary

### DIFF
--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -1,10 +1,11 @@
 import { memo, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { Message } from '@clawwork/shared';
-import { Bot, User, Brain, ChevronDown, FileCode } from 'lucide-react';
+import { Bot, User, Brain, ChevronDown, ChevronRight, FileCode, Wrench } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { motion as motionPresets } from '@/styles/design-tokens';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import ToolCallCard from './ToolCallCard';
 import MarkdownContent from './MarkdownContent';
 
@@ -52,6 +53,53 @@ function FileBlockChip({
       <span className="text-[var(--text-secondary)] font-medium truncate max-w-[200px]">{fileName}</span>
       <span className="text-[var(--text-muted)] flex-shrink-0">{file.lineCount}L</span>
     </button>
+  );
+}
+
+function ToolCallSummary({ toolCalls }: { toolCalls: Message['toolCalls'] }) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const errorCount = toolCalls.filter((tc) => tc.status === 'error').length;
+
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded}>
+      <CollapsibleTrigger asChild>
+        <button
+          className={cn(
+            'mt-2 inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm',
+            'text-[var(--text-secondary)] hover:text-[var(--text-primary)]',
+            'bg-[var(--bg-tertiary)] hover:bg-[var(--bg-hover)] transition-colors',
+          )}
+        >
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          <Wrench size={14} />
+          <span>
+            {errorCount > 0
+              ? t('chatMessage.toolCallSummaryWithErrors', { count: toolCalls.length, errorCount })
+              : t('chatMessage.toolCallSummary', { count: toolCalls.length })}
+          </span>
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent forceMount>
+        <AnimatePresence>
+          {expanded && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.15 }}
+              className="overflow-hidden"
+            >
+              <div className="mt-1 space-y-1">
+                {toolCalls.map((tc) => (
+                  <ToolCallCard key={tc.id} toolCall={tc} />
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -201,13 +249,7 @@ const ChatMessage = memo(function ChatMessage({
             ))}
           </div>
         ) : null}
-        {message.toolCalls.length > 0 && (
-          <div className="mt-2 space-y-1">
-            {message.toolCalls.map((tc) => (
-              <ToolCallCard key={tc.id} toolCall={tc} />
-            ))}
-          </div>
-        )}
+        {message.toolCalls.length > 0 && <ToolCallSummary toolCalls={message.toolCalls} />}
       </div>
     </motion.div>
   );

--- a/packages/desktop/src/renderer/components/StreamingMessage.tsx
+++ b/packages/desktop/src/renderer/components/StreamingMessage.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Bot, Brain, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -21,6 +21,14 @@ const StreamingMessage = memo(function StreamingMessage({
 }: StreamingMessageProps) {
   const { t } = useTranslation();
   const [thinkingOpen, setThinkingOpen] = useState(true);
+
+  const lastRunningId = useMemo(() => {
+    if (!toolCalls?.length) return null;
+    for (let i = toolCalls.length - 1; i >= 0; i--) {
+      if (toolCalls[i].status === 'running') return toolCalls[i].id;
+    }
+    return null;
+  }, [toolCalls]);
 
   return (
     <motion.div
@@ -75,9 +83,16 @@ const StreamingMessage = memo(function StreamingMessage({
         )}
         {toolCalls?.length ? (
           <div className="mb-2 space-y-1">
-            {toolCalls.map((tc) => (
-              <ToolCallCard key={tc.id} toolCall={tc} />
-            ))}
+            {toolCalls.map((tc) => {
+              const isLatestRunning = tc.id === lastRunningId;
+              return (
+                <ToolCallCard
+                  key={`${tc.id}-${isLatestRunning ? 'expanded' : 'collapsed'}`}
+                  toolCall={tc}
+                  defaultOpen={isLatestRunning}
+                />
+              );
+            })}
           </div>
         ) : null}
         {content && (

--- a/packages/desktop/src/renderer/components/ToolCallCard.tsx
+++ b/packages/desktop/src/renderer/components/ToolCallCard.tsx
@@ -8,6 +8,7 @@ import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/component
 
 interface ToolCallCardProps {
   toolCall: ToolCall;
+  defaultOpen?: boolean;
 }
 
 function StatusIcon({ status }: { status: ToolCall['status'] }) {
@@ -21,8 +22,8 @@ function StatusIcon({ status }: { status: ToolCall['status'] }) {
   }
 }
 
-const ToolCallCard = memo(function ToolCallCard({ toolCall }: ToolCallCardProps) {
-  const [open, setOpen] = useState(false);
+const ToolCallCard = memo(function ToolCallCard({ toolCall, defaultOpen }: ToolCallCardProps) {
+  const [open, setOpen] = useState(defaultOpen ?? false);
 
   const duration = useMemo(() => {
     if (!toolCall.completedAt) return null;

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -272,7 +272,9 @@
     "copyMessage": "Copy message",
     "copyCode": "Copy code",
     "copied": "Copied",
-    "thinkingProcess": "Thinking process"
+    "thinkingProcess": "Thinking process",
+    "toolCallSummary": "{{count}} tool calls executed",
+    "toolCallSummaryWithErrors": "{{count}} tool calls executed ({{errorCount}} failed)"
   },
   "dialog": {
     "selectWorkspaceDir": "Select Workspace Directory",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -272,7 +272,9 @@
     "copyMessage": "复制消息",
     "copyCode": "复制代码",
     "copied": "已复制",
-    "thinkingProcess": "思考过程"
+    "thinkingProcess": "思考过程",
+    "toolCallSummary": "执行了 {{count}} 个工具调用",
+    "toolCallSummaryWithErrors": "执行了 {{count}} 个工具调用（{{errorCount}} 个失败）"
   },
   "dialog": {
     "selectWorkspaceDir": "选择工作空间目录",


### PR DESCRIPTION
### What's changed?

- StreamingMessage: auto-expand the latest running tool-call, auto-collapse when next one starts (key-based remount strategy)
- ChatMessage: collapse completed tool-calls into a single summary line ("N tool calls executed"), expandable on click
- ToolCallCard: add `defaultOpen` prop for parent-controlled initial state
- i18n: add summary line translations for en/zh

### Why

- All tool-call cards were collapsed by default — users had to manually expand each one to see what's happening
- In history view, multiple tool-call cards consumed excessive vertical space with no quick overview