### PR TITLE
[Docs] Fix formatting in README.md for task descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ ClawWork talks to OpenClaw through the Gateway WebSocket API. Each task gets its
 ┌──────────────────────┐        WebSocket         ┌──────────────────────┐
 │  ClawWork Desktop    │ ◄──────────────────────► │  OpenClaw Gateway    │
 │                      │                          │                      │
-│  Task A              │   chat.send             │  Agent runtime        │
-│  Task B              │   chat stream           │  Session manager      │
-│  Task C              │   tool events           │  Parallel sessions    │
-│                      │   approval requests     │                      │
+│  Task A              │   chat.send              │  Agent runtime       │
+│  Task B              │   chat stream            │  Session manager     │
+│  Task C              │   tool events            │  Parallel sessions   │
+│                      │   approval requests      │                      │
 │  React UI            │                          │                      │
-│  SQLite index        │   route by sessionKey   │                      │
+│  SQLite index        │   route by sessionKey    │                      │
 │  Local workspace     │                          │                      │
 └──────────────────────┘                          └──────────────────────┘
 ```


### PR DESCRIPTION
## Summary

Fixed formatting in `README.md` for "How it works" task descriptions.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [x] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## What changed?

- Fixed formatting in `README.md` for "How it works" task descriptions