### PR TITLE
[Feat] Support renaming task title via context menu and double-click

### DIFF
--- a/packages/desktop/src/renderer/components/ContextMenu.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu.tsx
@@ -24,6 +24,7 @@ const INITIAL_STATE: MenuState = {
 };
 
 export interface SessionActions {
+  rename: (taskId: string) => void;
   compact: (taskId: string) => void;
   reset: (taskId: string) => void;
   deleteTask: (taskId: string) => void;
@@ -47,6 +48,13 @@ export function useTaskContextMenu(
 
   const items: MenuItem[] = [];
   const connected = state.isOpen && sessionActions ? sessionActions.isConnected(state.taskId) : false;
+
+  if (sessionActions) {
+    items.push({
+      label: i18n.t('contextMenu.rename'),
+      action: () => sessionActions.rename(state.taskId),
+    });
+  }
 
   if (state.taskStatus === 'active') {
     items.push({

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -176,6 +176,7 @@
     "noResults": "No results found"
   },
   "contextMenu": {
+    "rename": "Rename",
     "markCompleted": "Mark Completed",
     "archive": "Archive",
     "reactivate": "Reactivate",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -176,6 +176,7 @@
     "noResults": "未找到结果"
   },
   "contextMenu": {
+    "rename": "重命名",
     "markCompleted": "标记完成",
     "archive": "归档",
     "reactivate": "重新激活",

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent } from 'react';
+import { type MouseEvent, useState, useRef, useEffect, useCallback } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { MessageSquare, Circle, Loader2, Server, Cpu, Bot } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -18,12 +18,48 @@ interface TaskItemProps {
   onContextMenu: (e: MouseEvent) => void;
   collapsed?: boolean;
   multiGateway?: boolean;
+  editing?: boolean;
+  onEditDone?: () => void;
 }
 
-export default function TaskItem({ task, active, onContextMenu, collapsed, multiGateway }: TaskItemProps) {
+export default function TaskItem({
+  task,
+  active,
+  onContextMenu,
+  collapsed,
+  multiGateway,
+  editing,
+  onEditDone,
+}: TaskItemProps) {
   const { t } = useTranslation();
   const reduced = useReducedMotion();
   const setActiveTask = useTaskStore((s) => s.setActiveTask);
+  const updateTaskTitle = useTaskStore((s) => s.updateTaskTitle);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useState(task.title);
+
+  useEffect(() => {
+    if (editing) {
+      setDraft(task.title);
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    }
+  }, [editing, task.title]);
+
+  const commitRename = useCallback(() => {
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== task.title) {
+      updateTaskTitle(task.id, trimmed);
+    }
+    onEditDone?.();
+  }, [draft, task.title, task.id, updateTaskTitle, onEditDone]);
+
+  const cancelRename = useCallback(() => {
+    onEditDone?.();
+  }, [onEditDone]);
   const clearUnread = useUiStore((s) => s.clearUnread);
   const hasUnread = useUiStore((s) => s.unreadTaskIds.has(task.id));
   const setMainView = useUiStore((s) => s.setMainView);
@@ -101,7 +137,29 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, multi
       <MessageSquare size={16} className="mt-0.5 flex-shrink-0 opacity-50" />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          <span className="font-medium truncate flex-1">{task.title || t('common.newTask')}</span>
+          {editing ? (
+            <input
+              ref={inputRef}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commitRename();
+                }
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelRename();
+                }
+                e.stopPropagation();
+              }}
+              onClick={(e) => e.stopPropagation()}
+              className="font-medium flex-1 min-w-0 bg-[var(--bg-primary)] border border-[var(--ring-accent)] rounded px-1 py-0 text-[var(--text-primary)] outline-none text-sm"
+            />
+          ) : (
+            <span className="font-medium truncate flex-1">{task.title || t('common.newTask')}</span>
+          )}
           {isStreaming ? (
             <Loader2 size={12} className="flex-shrink-0 animate-spin text-[var(--accent)]" />
           ) : hasUnread ? (

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -152,6 +152,7 @@ export default function LeftNav() {
 
   const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null);
   const [confirmTaskId, setConfirmTaskId] = useState('');
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
 
   const findTask = (taskId: string) => useTaskStore.getState().tasks.find((t) => t.id === taskId);
 
@@ -199,6 +200,7 @@ export default function LeftNav() {
 
   const sessionActions: SessionActions = useMemo(
     () => ({
+      rename: (taskId: string) => setEditingTaskId(taskId),
       compact: handleCompact,
       reset: (taskId: string) => {
         setConfirmTaskId(taskId);
@@ -502,6 +504,8 @@ export default function LeftNav() {
                       active={task.id === activeTaskId}
                       onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
                       multiGateway={hasMultipleGateways}
+                      editing={editingTaskId === task.id}
+                      onEditDone={() => setEditingTaskId(null)}
                     />
                   ))}
                 </>
@@ -518,6 +522,8 @@ export default function LeftNav() {
                       active={task.id === activeTaskId}
                       onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
                       multiGateway={hasMultipleGateways}
+                      editing={editingTaskId === task.id}
+                      onEditDone={() => setEditingTaskId(null)}
                     />
                   ))}
                 </>

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import ConnectionBanner from '@/components/ConnectionBanner';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -204,6 +204,46 @@ function WelcomeScreen() {
 function ChatHeader({ onTogglePanel }: { onTogglePanel: () => void }) {
   const { t } = useTranslation();
   const activeTask = useTaskStore((s) => s.tasks.find((task) => task.id === s.activeTaskId));
+  const updateTaskTitle = useTaskStore((s) => s.updateTaskTitle);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState('');
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const startTitleEdit = useCallback(() => {
+    if (!activeTask) return;
+    setTitleDraft(activeTask.title);
+    setEditingTitle(true);
+    requestAnimationFrame(() => {
+      titleInputRef.current?.focus();
+      titleInputRef.current?.select();
+    });
+  }, [activeTask]);
+
+  const commitTitleEdit = useCallback(() => {
+    const trimmed = titleDraft.trim();
+    if (activeTask && trimmed && trimmed !== activeTask.title) {
+      updateTaskTitle(activeTask.id, trimmed);
+    }
+    setEditingTitle(false);
+  }, [titleDraft, activeTask, updateTaskTitle]);
+
+  const cancelTitleEdit = useCallback(() => {
+    setEditingTitle(false);
+  }, []);
+
+  const handleTitleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        commitTitleEdit();
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        cancelTitleEdit();
+      }
+    },
+    [commitTitleEdit, cancelTitleEdit],
+  );
   const rightPanelOpen = useUiStore((s) => s.rightPanelOpen);
   const gatewayInfoMap = useUiStore((s) => s.gatewayInfoMap);
   const hasMultipleGateways = Object.keys(gatewayInfoMap).length > 1;
@@ -244,9 +284,28 @@ function ChatHeader({ onTogglePanel }: { onTogglePanel: () => void }) {
       <div className="titlebar-no-drag flex items-center gap-2.5">
         {activeTask ? (
           <>
-            <h2 className="font-medium text-[var(--text-primary)] truncate">
-              {activeTask.title || t('common.newTask')}
-            </h2>
+            {editingTitle ? (
+              <input
+                ref={titleInputRef}
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                onBlur={commitTitleEdit}
+                onKeyDown={handleTitleKeyDown}
+                className="font-medium text-[var(--text-primary)] bg-[var(--bg-primary)] border border-[var(--ring-accent)] rounded px-1.5 py-0.5 outline-none max-w-[240px]"
+              />
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <h2
+                    className="font-medium text-[var(--text-primary)] truncate cursor-pointer"
+                    onDoubleClick={startTitleEdit}
+                  >
+                    {activeTask.title || t('common.newTask')}
+                  </h2>
+                </TooltipTrigger>
+                <TooltipContent>{t('contextMenu.rename')}</TooltipContent>
+              </Tooltip>
+            )}
             <span
               className={cn(
                 'text-xs px-2 py-0.5 rounded-md',


### PR DESCRIPTION
### What's changed?

- Add "Rename" option to task right-click context menu (sidebar)
- Inline editing in sidebar TaskItem: Enter to commit, Escape to cancel, blur to commit
- Double-click on chat header title to rename inline
- i18n keys added for en/zh

### Why

- Users had no way to manually rename a task/session title — only auto-generated titles from first message were available