### PR TITLE
[Fix] Simplify the right sidebar artifacts panel

### DIFF
--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -153,10 +153,7 @@
   },
   "rightPanel": {
     "context": "Context",
-    "progress": "Progress",
     "artifacts": "Artifacts",
-    "noProgress": "No progress info yet",
-    "xOfYCompleted": "{{done}}/{{total}} completed",
     "inputTokens": "Input",
     "outputTokens": "Output",
     "contextUsage": "Context",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -153,10 +153,7 @@
   },
   "rightPanel": {
     "context": "上下文",
-    "progress": "进度",
     "artifacts": "产物",
-    "noProgress": "暂无进度信息",
-    "xOfYCompleted": "{{done}}/{{total}} 已完成",
     "inputTokens": "输入",
     "outputTokens": "输出",
     "contextUsage": "上下文",

--- a/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
+++ b/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
@@ -1,62 +1,16 @@
 import { useEffect, useState } from 'react';
-import { motion } from 'framer-motion';
-import { FileText, CheckSquare, Square, Loader2, Cpu, ArrowUp, ArrowDown, Brain } from 'lucide-react';
+import { FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useTaskStore } from '@/stores/taskStore';
-import { useMessageStore, EMPTY_MESSAGES } from '@/stores/messageStore';
-import { cn, formatTokenCount } from '@/lib/utils';
-import { motion as motionPresets } from '@/styles/design-tokens';
+import { useMessageStore } from '@/stores/messageStore';
+import { cn } from '@/lib/utils';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import type { ProgressStep, Artifact } from '@clawwork/shared';
-
-function extractProgressSteps(messages: { role: string; content: string }[]): ProgressStep[] {
-  const steps: ProgressStep[] = [];
-  for (const msg of messages) {
-    if (msg.role !== 'assistant') continue;
-    const lines = msg.content.split('\n');
-    for (const line of lines) {
-      const checked = line.match(/^\s*[-*]\s*\[x\]\s+(.+)/i);
-      if (checked) {
-        steps.push({ label: checked[1].trim(), status: 'completed' });
-        continue;
-      }
-      const unchecked = line.match(/^\s*[-*]\s*\[\s\]\s+(.+)/);
-      if (unchecked) {
-        steps.push({ label: unchecked[1].trim(), status: 'pending' });
-        continue;
-      }
-      const numbered = line.match(/^\s*\d+\.\s+(.+)/);
-      if (numbered && lines.filter((l) => /^\s*\d+\./.test(l)).length >= 3) {
-        steps.push({ label: numbered[1].trim(), status: 'pending' });
-      }
-    }
-  }
-  return steps;
-}
-
-function StepIcon({ status }: { status: ProgressStep['status'] }) {
-  switch (status) {
-    case 'completed':
-      return <CheckSquare size={15} className="text-[var(--accent)] flex-shrink-0" />;
-    case 'in_progress':
-      return <Loader2 size={15} className="animate-spin text-[var(--accent)] flex-shrink-0" />;
-    case 'pending':
-      return <Square size={15} className="text-[var(--text-muted)] flex-shrink-0" />;
-  }
-}
+import type { Artifact } from '@clawwork/shared';
 
 export default function RightPanel() {
   const { t } = useTranslation();
   const activeTaskId = useTaskStore((s) => s.activeTaskId);
-  const activeTask = useTaskStore((s) => s.tasks.find((task) => task.id === s.activeTaskId));
   const setHighlightedMessage = useMessageStore((s) => s.setHighlightedMessage);
-  const messages = useMessageStore((s) =>
-    activeTaskId ? (s.messagesByTask[activeTaskId] ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
-  );
-
-  const steps = extractProgressSteps(messages);
-  const doneCount = steps.filter((s) => s.status === 'completed').length;
 
   const [taskArtifacts, setTaskArtifacts] = useState<Artifact[]>([]);
 
@@ -85,113 +39,50 @@ export default function RightPanel() {
 
   return (
     <div className="flex flex-col h-full">
-      <Tabs defaultValue="progress" className="flex flex-col flex-1 min-h-0">
-        <TabsList className="mx-4 mt-10">
-          <TabsTrigger value="progress">{t('rightPanel.progress')}</TabsTrigger>
-          <TabsTrigger value="artifacts">{t('rightPanel.artifacts')}</TabsTrigger>
-        </TabsList>
+      <div className="px-4 pt-10 pb-3 border-b border-[var(--border)]">
+        <div className="text-sm font-medium text-[var(--text-primary)]">{t('rightPanel.artifacts')}</div>
+      </div>
 
-        <ScrollArea className="flex-1">
-          <TabsContent value="progress" className="p-4">
-            {activeTask && (activeTask.model || activeTask.inputTokens != null) && (
-              <div className="mb-3 p-3 rounded-lg bg-[var(--bg-tertiary)] border border-[var(--border)] space-y-2">
-                {activeTask.model && (
-                  <div className="flex items-center gap-1.5 text-sm text-[var(--text-secondary)]">
-                    <Cpu size={13} className="text-[var(--text-muted)] flex-shrink-0" />
-                    <span className="truncate">{activeTask.model}</span>
-                  </div>
-                )}
-                {activeTask.thinkingLevel && activeTask.thinkingLevel !== 'off' && (
-                  <div className="flex items-center gap-1.5 text-sm text-[var(--text-secondary)]">
-                    <Brain size={13} className="text-[var(--text-muted)] flex-shrink-0" />
-                    <span>
-                      {t('chatInput.thinking')}:{' '}
-                      {t(
-                        `chatInput.thinking${activeTask.thinkingLevel.charAt(0).toUpperCase()}${activeTask.thinkingLevel.slice(1)}`,
-                      )}
-                    </span>
-                  </div>
-                )}
-                {(activeTask.inputTokens != null || activeTask.outputTokens != null) && (
-                  <div className="flex items-center gap-3 text-xs text-[var(--text-muted)]">
-                    {activeTask.inputTokens != null && (
-                      <span className="inline-flex items-center gap-0.5">
-                        <ArrowUp size={10} />
-                        {t('rightPanel.inputTokens')}: {formatTokenCount(activeTask.inputTokens)}
-                      </span>
-                    )}
-                    {activeTask.outputTokens != null && (
-                      <span className="inline-flex items-center gap-0.5">
-                        <ArrowDown size={10} />
-                        {t('rightPanel.outputTokens')}: {formatTokenCount(activeTask.outputTokens)}
-                      </span>
-                    )}
-                  </div>
-                )}
-                {activeTask.contextTokens != null && activeTask.contextTokens > 0 && (
-                  <div className="text-xs text-[var(--text-muted)]">
-                    <div className="flex items-center justify-between mb-1">
-                      <span>{t('rightPanel.contextUsage')}</span>
-                      <span>{Math.round((activeTask.contextTokens / 200_000) * 100)}%</span>
-                    </div>
-                    <div className="h-1.5 rounded-full bg-[var(--bg-secondary)] overflow-hidden">
-                      <div
-                        className="h-full rounded-full bg-[var(--accent)] transition-all duration-300"
-                        style={{ width: `${Math.min(100, (activeTask.contextTokens / 200_000) * 100)}%` }}
+      <ScrollArea className="flex-1">
+        <div className="p-3">
+          <div className="space-y-2">
+            {taskArtifacts.length === 0 ? (
+              <div className="flex min-h-24 flex-col items-center justify-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--bg-tertiary)] px-4 py-5 text-center">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[var(--bg-secondary)] border border-[var(--border-subtle)]">
+                  <FileText size={16} className="text-[var(--text-muted)]" />
+                </div>
+                <span className="text-sm text-[var(--text-secondary)]">{t('common.noFiles')}</span>
+              </div>
+            ) : (
+              taskArtifacts.map((a) => (
+                <button
+                  key={a.id}
+                  onClick={() => setHighlightedMessage(a.messageId)}
+                  className={cn(
+                    'group block w-full min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-tertiary)] px-3 py-2.5 text-left',
+                    'transition-all duration-150 hover:border-[var(--border)] hover:bg-[var(--bg-hover)] hover:translate-y-[-1px]',
+                  )}
+                  title={a.localPath}
+                >
+                  <div className="flex w-full min-w-0 items-center gap-2.5 overflow-hidden">
+                    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--bg-secondary)] border border-[var(--border-subtle)]">
+                      <FileText
+                        size={15}
+                        className="text-[var(--text-muted)] group-hover:text-[var(--text-secondary)] transition-colors"
                       />
                     </div>
+                    <div className="min-w-0 flex-1 overflow-hidden">
+                      <div className="block w-full truncate text-sm font-medium text-[var(--text-primary)]">
+                        {a.name}
+                      </div>
+                    </div>
                   </div>
-                )}
-              </div>
+                </button>
+              ))
             )}
-            {steps.length === 0 ? (
-              <p className="text-sm text-[var(--text-muted)] text-center py-4">{t('rightPanel.noProgress')}</p>
-            ) : (
-              <div className="space-y-1">
-                <p className="text-sm text-[var(--text-muted)] mb-2">
-                  {t('rightPanel.xOfYCompleted', { done: doneCount, total: steps.length })}
-                </p>
-                {steps.map((step, i) => (
-                  <motion.div
-                    key={i}
-                    {...motionPresets.listItem}
-                    className={cn('flex items-start gap-2 px-2 py-1.5 rounded text-sm text-[var(--text-secondary)]')}
-                  >
-                    <StepIcon status={step.status} />
-                    <span className={step.status === 'completed' ? 'line-through opacity-60' : ''}>{step.label}</span>
-                  </motion.div>
-                ))}
-              </div>
-            )}
-          </TabsContent>
-
-          <TabsContent value="artifacts" className="p-4">
-            <div className="space-y-1.5">
-              {taskArtifacts.length === 0 ? (
-                <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--bg-tertiary)] text-sm text-[var(--text-secondary)]">
-                  <FileText size={15} className="opacity-60" />
-                  <span className="truncate">{t('common.noFiles')}</span>
-                </div>
-              ) : (
-                taskArtifacts.map((a) => (
-                  <button
-                    key={a.id}
-                    onClick={() => setHighlightedMessage(a.messageId)}
-                    className={cn(
-                      'w-full flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--bg-tertiary)]',
-                      'text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors text-left',
-                    )}
-                    title={a.localPath}
-                  >
-                    <FileText size={15} className="opacity-60 flex-shrink-0" />
-                    <span className="truncate flex-1">{a.name}</span>
-                  </button>
-                ))
-              )}
-            </div>
-          </TabsContent>
-        </ScrollArea>
-      </Tabs>
+          </div>
+        </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -128,15 +128,6 @@ export interface IpcResult<T = unknown> {
 }
 
 // ------------------------------------------------------------
-// Progress tracking (extracted from AI responses)
-// ------------------------------------------------------------
-
-export interface ProgressStep {
-  label: string;
-  status: 'pending' | 'in_progress' | 'completed';
-}
-
-// ------------------------------------------------------------
 // Chat Attachments (for Gateway chat.send)
 // ------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Remove the fake Progress experience from the right sidebar and keep that panel focused on artifacts only. This avoids presenting model-generated checklist text and metadata as if it were real execution progress.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The existing Progress panel was not backed by a real progress system. It inferred steps from assistant text and mixed that with task metadata, which created misleading status signals in the UI.

## What changed?

- Removed progress parsing, progress tab UI, and the unused shared progress type
- Removed obsolete progress locale strings
- Simplified the right sidebar to an artifacts-only panel with a tighter layout

## Architecture impact

- Owning layer: shared / renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`:
- The three-panel layout is a core product affordance
- The renderer owns UI state and presentation
- Why those invariants remain protected:
- The three-panel layout remains intact, and the change is limited to renderer presentation plus removal of an unused shared type

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
pnpm typecheck
```

## Screenshots or recordings

UI change in the right sidebar only. The panel now shows artifacts without the fake Progress section or task metadata card.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate