### PR TITLE
[Feat] Export session as Markdown to local file or workspace

### DIFF
--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,9 +1,9 @@
-import { ipcMain, BrowserWindow, net } from 'electron';
-import { readFileSync } from 'fs';
+import { ipcMain, BrowserWindow, dialog, net } from 'electron';
+import { readFileSync, writeFileSync } from 'fs';
 import { resolve, sep } from 'path';
 import { eq } from 'drizzle-orm';
 import { getDb, getSqlite } from '../db/index.js';
-import { artifacts } from '../db/schema.js';
+import { artifacts, tasks, messages } from '../db/schema.js';
 import { saveArtifact, saveArtifactFromBuffer } from '../artifact/save.js';
 import { getWorkspacePath } from '../workspace/config.js';
 import { searchArtifacts } from '../db/search.js';
@@ -193,6 +193,50 @@ export function registerArtifactHandlers(): void {
       return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
     }
   });
+
+  ipcMain.handle('session:export-markdown', async (_event, params: { taskId: string }) => {
+    const workspacePath = getWorkspacePath();
+    if (!workspacePath) return { ok: false, error: 'workspace not configured' };
+    try {
+      const { md, safeName, lastMessageId } = loadSessionMarkdown(params.taskId);
+      const buffer = Buffer.from(md, 'utf-8');
+
+      const artifact = await saveArtifactFromBuffer({
+        workspacePath,
+        taskId: params.taskId,
+        messageId: lastMessageId ?? params.taskId,
+        fileName: `${safeName}.md`,
+        buffer,
+        artifactType: 'file',
+        contentText: md,
+      });
+
+      const win = BrowserWindow.getAllWindows()[0];
+      if (win) win.webContents.send('artifact:saved', artifact);
+      return { ok: true, result: artifact };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
+    }
+  });
+
+  ipcMain.handle('session:export-markdown-as', async (_event, params: { taskId: string }) => {
+    try {
+      const { md, safeName } = loadSessionMarkdown(params.taskId);
+      const win = BrowserWindow.getAllWindows()[0];
+      if (!win) return { ok: false, error: 'no window' };
+
+      const { canceled, filePath } = await dialog.showSaveDialog(win, {
+        defaultPath: `${safeName}.md`,
+        filters: [{ name: 'Markdown', extensions: ['md'] }],
+      });
+      if (canceled || !filePath) return { ok: false, error: 'cancelled' };
+
+      writeFileSync(filePath, md, 'utf-8');
+      return { ok: true, result: { filePath } };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
+    }
+  });
 }
 
 const TEXT_EXTS = new Set([
@@ -224,4 +268,96 @@ function isTextFile(localPath: string): boolean {
   const dot = localPath.lastIndexOf('.');
   if (dot === -1) return true;
   return TEXT_EXTS.has(localPath.slice(dot).toLowerCase());
+}
+
+type TaskRow = typeof tasks.$inferSelect;
+type MessageRow = typeof messages.$inferSelect;
+
+interface ExportResult {
+  md: string;
+  safeName: string;
+  lastMessageId: string | undefined;
+}
+
+function loadSessionMarkdown(taskId: string): ExportResult {
+  const db = getDb();
+  const taskRows = db.select().from(tasks).where(eq(tasks.id, taskId)).all();
+  if (taskRows.length === 0) throw new Error('task not found');
+  const task = taskRows[0];
+
+  const msgRows = db.select().from(messages).where(eq(messages.taskId, taskId)).orderBy(messages.timestamp).all();
+
+  const md = buildSessionMarkdown(task, msgRows);
+  const safeName =
+    task.title
+      .replace(/[<>:"/\\|?*]/g, '_')
+      .replace(/[\t\n\r]/g, '_')
+      .trim() || 'session';
+  const lastMessageId = msgRows.length > 0 ? msgRows[msgRows.length - 1].id : undefined;
+  return { md, safeName, lastMessageId };
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  const Y = d.getFullYear();
+  const M = String(d.getMonth() + 1).padStart(2, '0');
+  const D = String(d.getDate()).padStart(2, '0');
+  const h = String(d.getHours()).padStart(2, '0');
+  const m = String(d.getMinutes()).padStart(2, '0');
+  return `${Y}-${M}-${D} ${h}:${m}`;
+}
+
+const ROLE_LABEL: Record<string, string> = {
+  user: 'User',
+  assistant: 'Assistant',
+  system: 'System',
+};
+
+function buildSessionMarkdown(task: TaskRow, msgs: MessageRow[]): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${task.title || 'Untitled Session'}`);
+  lines.push('');
+  lines.push(`**Created:** ${formatTimestamp(task.createdAt)}`);
+  if (task.model) {
+    const provider = task.modelProvider ? ` (${task.modelProvider})` : '';
+    lines.push(`**Model:** ${task.model}${provider}`);
+  }
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const msg of msgs) {
+    const label = ROLE_LABEL[msg.role] ?? msg.role;
+    lines.push(`## ${label}`);
+    lines.push(`*${formatTimestamp(msg.timestamp)}*`);
+    lines.push('');
+    lines.push(msg.content);
+
+    if (msg.toolCalls) {
+      let calls: { name?: string; status?: string }[] = [];
+      try {
+        calls = JSON.parse(msg.toolCalls as string);
+      } catch {}
+      if (calls.length > 0) {
+        lines.push('');
+        lines.push('<details>');
+        lines.push('<summary>Tool Calls</summary>');
+        lines.push('');
+        for (const tc of calls) {
+          const status = tc.status ? ` [${tc.status}]` : '';
+          lines.push(`- \`${tc.name ?? 'unknown'}\`${status}`);
+        }
+        lines.push('');
+        lines.push('</details>');
+      }
+    }
+
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+
+  return lines.join('\n');
 }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -259,6 +259,8 @@ export interface ClawWorkAPI {
   }) => Promise<IpcResult>;
   saveImageFromUrl: (params: { taskId: string; messageId: string; url: string; alt?: string }) => Promise<IpcResult>;
   searchArtifacts: (query: string) => Promise<IpcResult>;
+  exportSessionMarkdown: (taskId: string) => Promise<IpcResult>;
+  exportSessionMarkdownAs: (taskId: string) => Promise<IpcResult>;
 
   // Workspace
   openWorkspaceFolder: () => Promise<void>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -89,6 +89,8 @@ function buildApi(): ClawWorkAPI {
     saveCodeBlock: (params) => ipcRenderer.invoke('artifact:save-content', params),
     saveImageFromUrl: (params) => ipcRenderer.invoke('artifact:save-image-url', params),
     searchArtifacts: (query: string) => ipcRenderer.invoke('artifact:search', { query }),
+    exportSessionMarkdown: (taskId: string) => ipcRenderer.invoke('session:export-markdown', { taskId }),
+    exportSessionMarkdownAs: (taskId: string) => ipcRenderer.invoke('session:export-markdown-as', { taskId }),
 
     openWorkspaceFolder: () => ipcRenderer.invoke('workspace:open-folder'),
     isWorkspaceConfigured: () => ipcRenderer.invoke('workspace:is-configured') as Promise<boolean>,

--- a/packages/desktop/src/renderer/components/ContextMenu.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu.tsx
@@ -28,6 +28,8 @@ export interface SessionActions {
   compact: (taskId: string) => void;
   reset: (taskId: string) => void;
   deleteTask: (taskId: string) => void;
+  exportMarkdown: (taskId: string) => void;
+  exportMarkdownAs: (taskId: string) => void;
   isConnected: (taskId: string) => boolean;
 }
 
@@ -78,6 +80,14 @@ export function useTaskContextMenu(
       label: i18n.t('contextMenu.resetSession'),
       action: () => sessionActions.reset(state.taskId),
       disabled: !connected,
+    });
+    items.push({
+      label: i18n.t('contextMenu.saveToMarkdown'),
+      action: () => sessionActions.exportMarkdownAs(state.taskId),
+    });
+    items.push({
+      label: i18n.t('contextMenu.exportToFiles'),
+      action: () => sessionActions.exportMarkdown(state.taskId),
     });
     items.push({
       label: i18n.t('contextMenu.deleteTask'),

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -30,6 +30,7 @@
     "welcomeDesc2": "Files produced along the way are auto-archived.",
     "starOnGithub": "Enjoying ClawWork? Give us a star on GitHub",
     "toggleContextPanel": "Toggle context panel",
+    "moreActions": "More actions",
     "selectGateway": "Select server",
     "selectAgent": "Select agent",
     "defaultAgent": "Default"
@@ -182,7 +183,9 @@
     "reactivate": "Reactivate",
     "compactSession": "Compact Session",
     "resetSession": "Reset Session",
-    "deleteTask": "Delete Task"
+    "deleteTask": "Delete Task",
+    "saveToMarkdown": "Save to Markdown",
+    "exportToFiles": "Export to Files"
   },
   "connection": {
     "connected": "Connected",
@@ -328,5 +331,8 @@
     "retry": "Retry",
     "approved": "Device approved! Connection established.",
     "stillPending": "Not approved yet. Please check the Devices page in OpenClaw Web UI."
+  },
+  "export": {
+    "exportedToFiles": "Exported to Files"
   }
 }

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -30,6 +30,7 @@
     "welcomeDesc2": "过程中产生的文件会自动归档管理。",
     "starOnGithub": "觉得好用？在 GitHub 上给我们一颗 Star",
     "toggleContextPanel": "切换上下文面板",
+    "moreActions": "更多操作",
     "selectGateway": "选择服务器",
     "selectAgent": "选择智能体",
     "defaultAgent": "默认"
@@ -182,7 +183,9 @@
     "reactivate": "重新激活",
     "compactSession": "压缩会话",
     "resetSession": "重置会话",
-    "deleteTask": "删除任务"
+    "deleteTask": "删除任务",
+    "saveToMarkdown": "保存为 Markdown",
+    "exportToFiles": "导出到文件管理"
   },
   "connection": {
     "connected": "已连接",
@@ -328,5 +331,8 @@
     "retry": "重试",
     "approved": "设备已批准！连接成功。",
     "stillPending": "尚未批准。请检查 OpenClaw Web UI 的设备页面。"
+  },
+  "export": {
+    "exportedToFiles": "已导出到文件管理"
   }
 }

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -44,6 +44,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog';
+import { exportToFiles, exportToLocal } from '@/lib/export-session';
 import TaskItem from './TaskItem';
 import ConnectionStatus from './ConnectionStatus';
 import type { TaskStatus } from '@clawwork/shared';
@@ -210,6 +211,8 @@ export default function LeftNav() {
         setConfirmTaskId(taskId);
         setConfirmAction('delete');
       },
+      exportMarkdown: exportToFiles,
+      exportMarkdownAs: exportToLocal,
       isConnected: (taskId: string) => {
         const task = findTask(taskId);
         return task ? gwStatusMap[task.gatewayId] === 'connected' : false;

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -17,6 +17,9 @@ import {
   DollarSign,
   RefreshCw,
   AlertTriangle,
+  MoreHorizontal,
+  FileDown,
+  FolderDown,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useTaskStore } from '@/stores/taskStore';
@@ -28,6 +31,12 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
 import ChatMessage from '@/components/ChatMessage';
 import StreamingMessage from '@/components/StreamingMessage';
 import ThinkingIndicator from '@/components/ThinkingIndicator';
@@ -36,6 +45,7 @@ import ImageLightbox from '@/components/ImageLightbox';
 import FilePreviewModal from '@/components/FilePreviewModal';
 import FileBrowser from '../FileBrowser';
 import logo from '@/assets/logo.png';
+import { exportToFiles, exportToLocal } from '@/lib/export-session';
 import { useUsageStore } from '@/stores/usageStore';
 import { fetchAgentsForGateway } from '@/hooks/useGatewayDispatcher';
 
@@ -541,14 +551,40 @@ function ChatHeader({ onTogglePanel }: { onTogglePanel: () => void }) {
           <h2 className="font-medium text-[var(--text-muted)]">ClawWork</h2>
         )}
       </div>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" onClick={onTogglePanel} className="titlebar-no-drag">
-            {rightPanelOpen ? <PanelRightClose size={18} /> : <PanelRightOpen size={18} />}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{t('mainArea.toggleContextPanel')}</TooltipContent>
-      </Tooltip>
+      <div className="titlebar-no-drag flex items-center gap-1">
+        {activeTask && (
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon">
+                    <MoreHorizontal size={18} />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>{t('mainArea.moreActions')}</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => exportToLocal(activeTask.id)}>
+                <FileDown size={14} />
+                {t('contextMenu.saveToMarkdown')}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => exportToFiles(activeTask.id)}>
+                <FolderDown size={14} />
+                {t('contextMenu.exportToFiles')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" onClick={onTogglePanel}>
+              {rightPanelOpen ? <PanelRightClose size={18} /> : <PanelRightOpen size={18} />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('mainArea.toggleContextPanel')}</TooltipContent>
+        </Tooltip>
+      </div>
     </header>
   );
 }

--- a/packages/desktop/src/renderer/lib/export-session.ts
+++ b/packages/desktop/src/renderer/lib/export-session.ts
@@ -1,0 +1,15 @@
+import { toast } from 'sonner';
+import i18n from '../i18n';
+
+export function exportToFiles(taskId: string): void {
+  window.clawwork
+    .exportSessionMarkdown(taskId)
+    .then((res) => {
+      if (res.ok) toast.success(i18n.t('export.exportedToFiles'));
+    })
+    .catch(() => {});
+}
+
+export function exportToLocal(taskId: string): void {
+  window.clawwork.exportSessionMarkdownAs(taskId).catch(() => {});
+}


### PR DESCRIPTION
### What's changed?

- Add **Save to Markdown** action — opens native save dialog, user picks local path
- Add **Export to Files** action — saves Markdown as artifact in workspace file manager with toast confirmation
- Both actions available from chat header `⋯` dropdown and task context menu (right-click)
- New `lib/export-session.ts` shared module deduplicates renderer-side export logic
- IPC handlers `session:export-markdown` and `session:export-markdown-as` in main process
- i18n keys for EN and ZH

### Why

- Users need a way to export full session conversations as readable Markdown files
- Two distinct use cases: quick save to workspace (stays in app) vs. save to arbitrary local path (for sharing/archiving)