### PR TITLE
[Refactor] Simplify notification code after review

### DIFF
--- a/packages/desktop/src/main/notifications.ts
+++ b/packages/desktop/src/main/notifications.ts
@@ -8,11 +8,11 @@ export function sendDesktopNotification(params: { title: string; body: string; t
   if (params.taskId) {
     n.on('click', () => {
       const win = BrowserWindow.getAllWindows()[0];
-      if (win) {
-        win.show();
-        win.focus();
-        win.webContents.send('notification:navigate-task', params.taskId);
-      }
+      if (!win || win.isDestroyed()) return;
+      if (win.isMinimized()) win.restore();
+      if (!win.isVisible()) win.show();
+      win.focus();
+      win.webContents.send('notification:navigate-task', params.taskId);
     });
   }
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -193,23 +193,20 @@ export default function App() {
   }, [createTask, updateTaskTitle, addMessage, setProcessing]);
 
   useEffect(() => {
-    const cleanupNav = window.clawwork.onTrayNavigateTask((taskId) => {
+    const navigateToTask = (taskId: string): void => {
       setActiveTask(taskId);
       setSettingsOpen(false);
       setMainView('chat');
-    });
+    };
+    const cleanupNav = window.clawwork.onTrayNavigateTask(navigateToTask);
+    const cleanupNotification = window.clawwork.onNotificationNavigateTask(navigateToTask);
     const cleanupSettings = window.clawwork.onTrayOpenSettings(() => {
       setSettingsOpen(true);
     });
-    const cleanupNotification = window.clawwork.onNotificationNavigateTask((taskId) => {
-      setActiveTask(taskId);
-      setSettingsOpen(false);
-      setMainView('chat');
-    });
     return () => {
       cleanupNav();
-      cleanupSettings();
       cleanupNotification();
+      cleanupSettings();
     };
   }, [setActiveTask, setSettingsOpen, setMainView]);
 

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
@@ -166,6 +166,21 @@ interface AgentEvent {
  * Subscribes to Gateway events and dispatches into Zustand stores.
  * Mount once at App root level.
  */
+type NotificationSettingKey = 'taskComplete' | 'approvalRequest' | 'gatewayDisconnect';
+
+function maybeNotify(
+  settingKey: NotificationSettingKey,
+  params: { title: string; body: string; taskId?: string },
+): void {
+  window.clawwork
+    .getSettings()
+    .then((settings) => {
+      if (settings?.notifications?.[settingKey] === false) return;
+      window.clawwork.sendNotification(params);
+    })
+    .catch(() => {});
+}
+
 export function useGatewayEventDispatcher(): void {
   const activeTaskId = useTaskStore((s) => s.activeTaskId);
   const activeTaskIdRef = useRef(activeTaskId);
@@ -193,13 +208,10 @@ export function useGatewayEventDispatcher(): void {
         const approvalSessionKey = approvalReq.request?.sessionKey;
         const approvalTaskId = approvalSessionKey ? parseTaskIdFromSessionKey(approvalSessionKey) : null;
         if (approvalTaskId && (!document.hasFocus() || activeTaskIdRef.current !== approvalTaskId)) {
-          window.clawwork.getSettings().then((settings) => {
-            if (settings?.notifications?.approvalRequest === false) return;
-            window.clawwork.sendNotification({
-              title: i18n.t('notifications.approvalRequired'),
-              body: approvalReq.request?.commandPreview || approvalReq.request?.command || '',
-              taskId: approvalTaskId,
-            });
+          maybeNotify('approvalRequest', {
+            title: i18n.t('notifications.approvalRequired'),
+            body: approvalReq.request?.commandPreview || approvalReq.request?.command || '',
+            taskId: approvalTaskId,
           });
         }
       } else if (data.event === 'exec.approval.resolved') {
@@ -265,14 +277,11 @@ export function useGatewayEventDispatcher(): void {
         debugEvent('renderer.chat.finalized', { taskId, sessionKey });
         autoTitleIfNeeded(taskId);
         if (!document.hasFocus() || activeTaskIdRef.current !== taskId) {
-          window.clawwork.getSettings().then((settings) => {
-            if (settings?.notifications?.taskComplete === false) return;
-            const task = useTaskStore.getState().tasks.find((t) => t.id === taskId);
-            window.clawwork.sendNotification({
-              title: i18n.t('notifications.taskComplete'),
-              body: task?.title || taskId,
-              taskId,
-            });
+          const task = useTaskStore.getState().tasks.find((t) => t.id === taskId);
+          maybeNotify('taskComplete', {
+            title: i18n.t('notifications.taskComplete'),
+            body: task?.title || taskId,
+            taskId,
           });
         }
         syncSessionMessages(taskId).catch((err) => {
@@ -589,13 +598,10 @@ export function useGatewayEventDispatcher(): void {
       } else if (!s.connected && wasConnected) {
         connectedGatewaysRef.current.delete(s.gatewayId);
         toast.warning(i18n.t('connection.lostConnection'), { description: i18n.t('connection.reconnecting') });
-        window.clawwork.getSettings().then((settings) => {
-          if (settings?.notifications?.gatewayDisconnect === false) return;
-          const gwInfo = useUiStore.getState().gatewayInfoMap[s.gatewayId];
-          window.clawwork.sendNotification({
-            title: i18n.t('notifications.gatewayDisconnected'),
-            body: gwInfo?.name || s.gatewayId,
-          });
+        const gwInfo = useUiStore.getState().gatewayInfoMap[s.gatewayId];
+        maybeNotify('gatewayDisconnect', {
+          title: i18n.t('notifications.gatewayDisconnected'),
+          body: gwInfo?.name || s.gatewayId,
         });
       }
     });

--- a/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
@@ -68,29 +68,40 @@ export default function GeneralSection() {
     [rightPanelShortcut, setRightPanelShortcut, t],
   );
 
-  const [notifyTaskComplete, setNotifyTaskComplete] = useState(true);
-  const [notifyApproval, setNotifyApproval] = useState(true);
-  const [notifyDisconnect, setNotifyDisconnect] = useState(true);
+  const [notifyState, setNotifyState] = useState({
+    taskComplete: true,
+    approvalRequest: true,
+    gatewayDisconnect: true,
+  });
 
   useEffect(() => {
     window.clawwork.getSettings().then((settings) => {
-      if (!settings) return;
+      if (!settings?.notifications) return;
       const n = settings.notifications;
-      if (n?.taskComplete === false) setNotifyTaskComplete(false);
-      if (n?.approvalRequest === false) setNotifyApproval(false);
-      if (n?.gatewayDisconnect === false) setNotifyDisconnect(false);
+      setNotifyState((prev) => ({
+        taskComplete: n.taskComplete ?? prev.taskComplete,
+        approvalRequest: n.approvalRequest ?? prev.approvalRequest,
+        gatewayDisconnect: n.gatewayDisconnect ?? prev.gatewayDisconnect,
+      }));
     });
   }, []);
 
   const handleNotificationToggle = useCallback(
-    async (key: 'taskComplete' | 'approvalRequest' | 'gatewayDisconnect', value: boolean) => {
-      const settings = await window.clawwork.getSettings();
-      await window.clawwork.updateSettings({
-        notifications: { ...settings?.notifications, [key]: value },
+    (key: 'taskComplete' | 'approvalRequest' | 'gatewayDisconnect', value: boolean) => {
+      setNotifyState((prev) => {
+        const next = { ...prev, [key]: value };
+        window.clawwork.updateSettings({ notifications: next });
+        return next;
       });
     },
     [],
   );
+
+  const notificationToggles = [
+    { key: 'taskComplete' as const, i18nKey: 'settings.notifyTaskComplete' },
+    { key: 'approvalRequest' as const, i18nKey: 'settings.notifyApproval' },
+    { key: 'gatewayDisconnect' as const, i18nKey: 'settings.notifyDisconnect' },
+  ];
 
   return (
     <div>
@@ -191,63 +202,24 @@ export default function GeneralSection() {
       <h3 className="text-base font-semibold text-[var(--text-primary)] mt-8">{t('settings.notifications')}</h3>
       <p className="text-sm text-[var(--text-muted)] mt-1 mb-4">{t('settings.notificationsDesc')}</p>
       <div className="rounded-xl bg-[var(--bg-elevated)] shadow-[var(--shadow-card)] border border-[var(--border-subtle)] divide-y divide-[var(--border-subtle)]">
-        <div className="px-5 py-4">
-          <SettingRow
-            label={
-              <div className="flex items-center gap-3">
-                <Bell size={14} className="text-[var(--text-muted)] flex-shrink-0" />
-                <span className="text-sm text-[var(--text-primary)]">{t('settings.notifyTaskComplete')}</span>
-              </div>
-            }
-          >
-            <Toggle
-              checked={notifyTaskComplete}
-              onChange={(v) => {
-                setNotifyTaskComplete(v);
-                handleNotificationToggle('taskComplete', v);
-              }}
-              ariaLabel={t('settings.notifyTaskComplete')}
-            />
-          </SettingRow>
-        </div>
-        <div className="px-5 py-4">
-          <SettingRow
-            label={
-              <div className="flex items-center gap-3">
-                <Bell size={14} className="text-[var(--text-muted)] flex-shrink-0" />
-                <span className="text-sm text-[var(--text-primary)]">{t('settings.notifyApproval')}</span>
-              </div>
-            }
-          >
-            <Toggle
-              checked={notifyApproval}
-              onChange={(v) => {
-                setNotifyApproval(v);
-                handleNotificationToggle('approvalRequest', v);
-              }}
-              ariaLabel={t('settings.notifyApproval')}
-            />
-          </SettingRow>
-        </div>
-        <div className="px-5 py-4">
-          <SettingRow
-            label={
-              <div className="flex items-center gap-3">
-                <Bell size={14} className="text-[var(--text-muted)] flex-shrink-0" />
-                <span className="text-sm text-[var(--text-primary)]">{t('settings.notifyDisconnect')}</span>
-              </div>
-            }
-          >
-            <Toggle
-              checked={notifyDisconnect}
-              onChange={(v) => {
-                setNotifyDisconnect(v);
-                handleNotificationToggle('gatewayDisconnect', v);
-              }}
-              ariaLabel={t('settings.notifyDisconnect')}
-            />
-          </SettingRow>
-        </div>
+        {notificationToggles.map(({ key, i18nKey }) => (
+          <div key={key} className="px-5 py-4">
+            <SettingRow
+              label={
+                <div className="flex items-center gap-3">
+                  <Bell size={14} className="text-[var(--text-muted)] flex-shrink-0" />
+                  <span className="text-sm text-[var(--text-primary)]">{t(i18nKey)}</span>
+                </div>
+              }
+            >
+              <Toggle
+                checked={notifyState[key]}
+                onChange={(v) => handleNotificationToggle(key, v)}
+                ariaLabel={t(i18nKey)}
+              />
+            </SettingRow>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Post-merge cleanup of #157 — extract helpers, remove duplication, fix edge cases found during code review.

## Type of change

- [x] `[Refactor]` internal cleanup

## Why is this needed?

Code review of #157 identified copy-paste blocks, missing window guards, and duplicate state that should be cleaned up before the code grows further.

## What changed?

- Extract `maybeNotify()` helper in `useGatewayDispatcher` — collapses three identical async-settings-check-then-send blocks into one-liners, adds `.catch()` for unhandled rejection safety
- Add `isDestroyed()` / `isMinimized()` / `isVisible()` guards in `notifications.ts` click handler — aligns with the tray's `focusMainWindow` pattern
- Unify `navigateToTask` callback in `App.tsx` — tray and notification click handlers share one function instead of two identical lambdas
- Data-drive notification toggle rows in `GeneralSection.tsx` via `notificationToggles.map()` — replaces three copy-paste JSX blocks
- Merge three `useState` booleans into single `notifyState` object, write full state on toggle to eliminate read-then-write race

## Architecture impact

- Owning layer: renderer (dispatcher + settings UI), main (notification service)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: pure refactor, no behavior change

## Linked issues

Follow-up to #157

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check  # lint + architecture + format + typecheck + test — all pass
```

## Screenshots or recordings

No UI change — same toggles, same behavior.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate