### PR TITLE
[Feat] Display OpenClaw server version in Gateway settings

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -194,12 +194,13 @@ export function registerWsHandlers(): void {
 
   ipcMain.handle('ws:gateway-status', () => {
     const clients = getAllGatewayClients();
-    const statusMap: Record<string, { connected: boolean; name: string; error?: string }> = {};
+    const statusMap: Record<string, { connected: boolean; name: string; error?: string; serverVersion?: string }> = {};
     for (const [id, client] of clients) {
       statusMap[id] = {
         connected: client.isConnected,
         name: client.name,
         error: client.lastConnectionError ?? undefined,
+        serverVersion: client.version,
       };
     }
     return statusMap;

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -68,6 +68,7 @@ export class GatewayClient {
   private deviceIdentity: DeviceIdentity;
   private lastError: string | null = null;
   private lastErrorCode: string | null = null;
+  private serverVersion: string | undefined;
   private onPairingSuccess?: (gatewayId: string) => void;
 
   constructor(config: GatewayClientConfig, opts?: GatewayClientOptions) {
@@ -144,6 +145,7 @@ export class GatewayClient {
         },
       });
       this.authenticated = false;
+      this.serverVersion = undefined;
       this.stopHeartbeat();
       if (this.mainWindow) {
         sendToWindow(this.mainWindow, 'gateway-status', {
@@ -331,12 +333,16 @@ export class GatewayClient {
           this.reconnectAttempts = 0;
           this.lastError = null;
           this.lastErrorCode = null;
+          const server = payload['server'] as Record<string, unknown> | undefined;
+          const rawVersion = server?.['version'];
+          this.serverVersion = typeof rawVersion === 'string' ? rawVersion : undefined;
           this.storeDeviceTokenFromPayload(payload);
           this.startHeartbeat();
           if (this.mainWindow) {
             sendToWindow(this.mainWindow, 'gateway-status', {
               gatewayId: this.gatewayId,
               connected: true,
+              serverVersion: this.serverVersion,
             });
           }
         } else {
@@ -649,6 +655,10 @@ export class GatewayClient {
 
   get lastConnectionErrorCode(): string | null {
     return this.lastErrorCode;
+  }
+
+  get version(): string | undefined {
+    return this.serverVersion;
   }
 
   private startHeartbeat(): void {

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -23,6 +23,7 @@ interface GatewayStatusEvent {
   gatewayId: string;
   connected: boolean;
   error?: string;
+  serverVersion?: string;
   reconnectAttempt?: number;
   maxAttempts?: number;
   gaveUp?: boolean;
@@ -58,7 +59,7 @@ export interface GatewayServerConfig {
 }
 
 interface GatewayStatusMap {
-  [gatewayId: string]: { connected: boolean; name: string; error?: string };
+  [gatewayId: string]: { connected: boolean; name: string; error?: string; serverVersion?: string };
 }
 
 interface GatewayListItem extends GatewayServerConfig {

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcher.ts
@@ -543,6 +543,9 @@ export function useGatewayEventDispatcher(): void {
             ? ('disconnected' as const)
             : ('connecting' as const);
         setGatewayStatusByGateway(gwId, status);
+        if (info.serverVersion) {
+          useUiStore.getState().setGatewayVersion(gwId, info.serverVersion);
+        }
         if (info.connected) {
           connectedGatewaysRef.current.add(gwId);
         }
@@ -575,6 +578,7 @@ export function useGatewayEventDispatcher(): void {
       const wasConnected = connectedGatewaysRef.current.has(s.gatewayId);
       const next = s.connected ? ('connected' as const) : s.error ? ('disconnected' as const) : ('connecting' as const);
       setGatewayStatusByGateway(s.gatewayId, next);
+      useUiStore.getState().setGatewayVersion(s.gatewayId, s.serverVersion);
 
       if (s.reconnectAttempt !== undefined && s.maxAttempts !== undefined) {
         useUiStore.getState().setGatewayReconnectInfo(s.gatewayId, {

--- a/packages/desktop/src/renderer/layouts/Settings/sections/GatewaysSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GatewaysSection.tsx
@@ -89,6 +89,7 @@ function GatewayCard({
   status,
   isDefault,
   isEditing,
+  serverVersion,
   onEdit,
   onRemove,
   onSetDefault,
@@ -97,6 +98,7 @@ function GatewayCard({
   status: GatewayConnectionStatus;
   isDefault: boolean;
   isEditing: boolean;
+  serverVersion?: string;
   onEdit: () => void;
   onRemove: () => void;
   onSetDefault: () => void;
@@ -136,6 +138,11 @@ function GatewayCard({
             <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-[var(--bg-tertiary)] text-[var(--text-muted)] font-medium">
               {typeLabel}
             </span>
+            {serverVersion && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-[var(--info)]/10 text-[var(--info)] font-mono font-medium">
+                v{serverVersion}
+              </span>
+            )}
           </div>
           <p className="text-xs text-[var(--text-muted)] font-mono mt-0.5 truncate">{gw.url}</p>
         </div>
@@ -387,6 +394,7 @@ function GatewayForm({
 export default function GatewaysSection() {
   const { t } = useTranslation();
   const gatewayStatusMap = useUiStore((s) => s.gatewayStatusMap);
+  const gatewayVersionMap = useUiStore((s) => s.gatewayVersionMap);
   const setDefaultGatewayId = useUiStore((s) => s.setDefaultGatewayId);
   const setGatewayInfoMap = useUiStore((s) => s.setGatewayInfoMap);
 
@@ -598,6 +606,7 @@ export default function GatewaysSection() {
                   status={gatewayStatusMap[gw.id] ?? 'disconnected'}
                   isDefault={gw.id === defaultGwId}
                   isEditing={editingId === gw.id && showForm}
+                  serverVersion={gatewayVersionMap[gw.id]}
                   onEdit={() => openEditForm(gw)}
                   onRemove={() => setDeletingGwId(gw.id)}
                   onSetDefault={() => handleSetDefault(gw.id)}

--- a/packages/desktop/src/renderer/stores/uiStore.ts
+++ b/packages/desktop/src/renderer/stores/uiStore.ts
@@ -64,6 +64,9 @@ interface UiState {
   gatewayStatusMap: Record<string, GatewayConnectionStatus>;
   setGatewayStatusByGateway: (gatewayId: string, status: GatewayConnectionStatus) => void;
 
+  gatewayVersionMap: Record<string, string>;
+  setGatewayVersion: (gatewayId: string, version: string | undefined) => void;
+
   gatewayReconnectInfo: Record<string, { attempt: number; max: number; gaveUp: boolean }>;
   setGatewayReconnectInfo: (gatewayId: string, info: { attempt: number; max: number; gaveUp: boolean } | null) => void;
 
@@ -144,6 +147,20 @@ export const useUiStore = create<UiState>((set, get) => ({
     set((s) => ({
       gatewayStatusMap: { ...s.gatewayStatusMap, [gatewayId]: status },
     })),
+
+  gatewayVersionMap: {},
+  setGatewayVersion: (gatewayId, version) =>
+    set((s) => {
+      const current = s.gatewayVersionMap[gatewayId];
+      if (!version) {
+        if (current === undefined) return s;
+        const next = { ...s.gatewayVersionMap };
+        delete next[gatewayId];
+        return { gatewayVersionMap: next };
+      }
+      if (current === version) return s;
+      return { gatewayVersionMap: { ...s.gatewayVersionMap, [gatewayId]: version } };
+    }),
 
   gatewayReconnectInfo: {},
   setGatewayReconnectInfo: (gatewayId, info) =>


### PR DESCRIPTION
## Summary

Extract the OpenClaw server version from the Gateway WebSocket `hello-ok` handshake response and display it as a badge in the Settings → Gateways list, next to the gateway type label.

## Type of change

- [x] `[Feat]` new feature

## Why is this needed?

Users managing multiple Gateway connections have no way to see which OpenClaw version each server is running. This information is already sent by the server during handshake but was being discarded.

## What changed?

- `gateway-client.ts`: extract `server.version` from `hello-ok` payload using a `typeof` guard, store as `serverVersion`, include in `gateway-status` IPC event, clear on disconnect
- `ws-handlers.ts`: expose `serverVersion` in `ws:gateway-status` IPC response
- `clawwork.d.ts`: add `serverVersion` to `GatewayStatusEvent` and `GatewayStatusMap` types
- `uiStore.ts`: add `gatewayVersionMap` with no-op-guarded `setGatewayVersion` setter
- `useGatewayDispatcher.ts`: populate version from both init (`gatewayStatus()`) and push (`onGatewayStatus`) paths
- `GatewaysSection.tsx`: render version badge with `--info` color next to gateway type label

## Architecture impact

- Owning layer: main (extraction) / preload (types) / renderer (display)
- Cross-layer impact: yes — version flows main → preload → renderer via existing `gateway-status` IPC channel
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: read-only data addition, no write-path changes

## Linked issues

Closes #104

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check (lint + architecture + format + typecheck + test) — all green, 88 tests passed
```

## Screenshots or recordings

Version badge appears as a blue (`--info`) mono badge next to the "OpenClaw" type label on each gateway card, visible only when connected and version is known.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Display the connected OpenClaw server version in Settings → Gateways.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate