### PR TITLE
[Docs] Update README, architecture diagrams, website, and keynote slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,32 @@
 
 **A desktop workspace for [OpenClaw](https://github.com/openclaw/openclaw).**
 
-Parallel tasks, visible tool activity, and files you can actually find later.
+Parallel tasks, structured artifacts, scheduled automation — and files you can actually find later.
 
 [![GitHub release](https://img.shields.io/github/v/release/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork/releases/latest)
 [![License](https://img.shields.io/github/license/clawwork-ai/clawwork?style=flat-square)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork)
 
-[Download](#download) · [Quick start](#quick-start) · [Why ClawWork](#why-clawwork) · [What you get](#what-you-get) · [Roadmap](#roadmap) · [Contributing](#contributing)
+[Download](#download) · [Quick start](#quick-start) · [What you get](#what-you-get) · [What it stores](#what-clawwork-stores) · [How it works](#how-it-works) · [Repo layout](#repo-layout) · [Roadmap](#roadmap) · [Contributing](#contributing)
 
 </div>
 
 ## Why ClawWork
 
-Using OpenClaw through Telegram, Slack, or a plain chat UI works fine for small stuff. It gets annoying once the work stops being simple.
+OpenClaw is powerful. Plain chat is a bad container for the kind of work it can do.
 
-Status disappears into the message stream. Running several tasks means juggling tabs and trying to remember which session was using which model. Files show up in replies, then vanish into history.
+Once you have multiple sessions, long-running jobs, approval stops, generated files, recurring automation, and different gateways, chat history turns into mud. Status vanishes. Files vanish. Context vanishes.
 
-ClawWork fixes that by treating each task as its own workspace. You get a desktop UI where tasks stay separate, tool activity is visible while it happens, and output files stay attached to the work that produced them.
+ClawWork fixes that. Every task becomes a durable workspace with its own session, artifacts, controls, and history — laid out in a three-panel UI: tasks on the left, active work in the center, artifacts and context on the right.
 
 ## Why it feels better
 
 - Each task runs in its own OpenClaw session, so you can switch between parallel jobs without mixing context.
-- Streaming replies, tool call cards, progress, and artifacts live in one place instead of being buried in chat history.
+- Streaming replies, thinking traces, tool call cards, and artifacts live in one place instead of being buried in chat history.
 - Gateway, agent, model, and thinking settings are scoped per task.
 - Files produced by the agent are saved to a local workspace and stay easy to browse later.
 - Risky exec actions can stop for approval before they run.
+- Scheduled tasks run on their own cadence without you watching.
 
 ## Download
 
@@ -43,97 +44,130 @@ brew install --cask clawwork
 
 ### Releases
 
-Prebuilt macOS and Windows builds are available on the [Releases page](https://github.com/clawwork-ai/clawwork/releases/latest).
-
-If macOS blocks first launch because the app is unsigned:
-
-```bash
-sudo xattr -rd com.apple.quarantine "/Applications/ClawWork.app"
-```
+Prebuilt macOS and Windows builds are available on the [Releases page](https://github.com/clawwork-ai/clawwork/releases/latest). The app updates itself — new versions download in the background and install when you quit.
 
 ## Quick start
 
 1. Start an OpenClaw Gateway.
-2. Open ClawWork and add a gateway in Settings. The default local endpoint is `ws://127.0.0.1:18789`.
+2. Open ClawWork and add a gateway in Settings. Authenticate with a token, password, or pairing code. Default local endpoint: `ws://127.0.0.1:18789`.
 3. Create a task, pick a gateway and agent, and describe the work.
-4. Add images, `@` file context, or slash commands if you need them.
+4. Chat: send messages, attach images, `@` files for context, or use `/` commands.
 5. Follow the task as it runs, inspect tool activity, and keep the output files.
+6. Use search, artifacts, and cron when the work stops being small.
 
 ## What you get
 
-### Task-first workflow
+### ⚡ Task-first workflow
 
-- Parallel tasks with isolated OpenClaw sessions
+- Parallel tasks with isolated OpenClaw sessions — archived tasks can be reopened later
 - Per-gateway session catalogs
-- Session stop, reset, compact, and delete actions
+- Session controls that matter: stop, reset, compact, delete, and sync
 - Background work that stays readable instead of collapsing into one long thread
+- Set tasks on a schedule with `cron`, `every`, or `at` expressions — pick from presets or write your own, check run history, trigger manually anytime
+- Export any session as Markdown to keep a clean record outside the app
 
-### Better visibility
+### 👁 Better visibility
 
 - Streaming responses in real time
 - Inline tool call cards while the agent works
 - Progress and artifacts in a side panel
-- Usage, token, and cost tracking per session
+- See what you're spending — usage status per gateway, cost breakdown per session, 30-day rolling dashboard
 
-### Better control
+### 🎛 Better control
 
 - Multi-gateway support
 - Per-task agent and model switching
+- Manage your agents directly — create, edit, delete, and browse their workspace files without leaving the app
+- Browse the full tools catalog for each gateway so you know what the agent can reach
 - Thinking level controls and slash commands
 - Approval prompts for sensitive exec actions
+- Get notified when things happen in the background — task completions, approval requests, gateway disconnects — click a notification and it jumps back to the task. Per-event toggles so you control the noise.
 
-### Better file handling
+### 📂 Better file handling
 
-- Image messages and `@` file context
-- Session-bound folder context
+- Context that is actually useful: images, `@` file references, voice input, watched folders
+- Point the app at up to 10 folders and it watches for changes, re-indexing automatically so your context stays fresh
 - Local artifact storage
+- Code blocks and remote images in assistant replies are auto-extracted and saved to your workspace — no manual copy-paste
 - Full-text search across tasks, messages, and artifacts
 
-### Better desktop ergonomics
+### 🖥 Better desktop ergonomics
 
 - System tray support
-- Quick-launch window with a global shortcut
+- Quick-launch window with a global shortcut (`Alt+Space` by default, customizable)
 - Keyboard shortcuts throughout the app
-- Local voice input with [whisper.cpp](https://github.com/ggerganov/whisper.cpp)
+- The app updates itself in the background — you see progress in Settings and it installs on quit
+- Zoom in or out to your comfort level, and the app remembers your preference
 - Light and dark themes, plus English and Chinese UI
+
+### 🔧 Debugging
+
+- Export a debug bundle (logs, gateway status, sanitized config) when something goes wrong — useful for bug reports
+- See which Gateway server version you're connected to right in Settings
+
+## What ClawWork stores
+
+Everything lives in a local workspace directory you choose. No cloud sync, no external database.
+
+- **Tasks** — each one maps to an independent OpenClaw session, so parallel work never collides.
+- **Messages** — user, assistant, and system messages, including tool calls and image attachments, all persisted locally.
+- **Artifacts** — code blocks, images, and files the agent produces. Automatically extracted from assistant output so nothing gets lost.
+- **Full-text search** — search across all of the above. Find that one code snippet from three weeks ago without remembering which task it came from.
 
 ## How it works
 
-ClawWork talks to OpenClaw through the Gateway WebSocket API. Each task gets its own session key, which keeps concurrent work isolated. The desktop app stores task metadata, messages, and artifact indexes locally so you can search and revisit work without digging through chat logs.
+ClawWork talks to OpenClaw through a single Gateway WebSocket connection. Each task gets its own session key, which keeps concurrent work isolated. Everything — tasks, messages, artifacts, search indexes — is stored locally in your workspace directory.
 
-```text
-┌──────────────────────┐        WebSocket         ┌──────────────────────┐
-│  ClawWork Desktop    │ ◄──────────────────────► │  OpenClaw Gateway    │
-│                      │                          │                      │
-│  Task A              │   chat.send              │  Agent runtime       │
-│  Task B              │   chat stream            │  Session manager     │
-│  Task C              │   tool events            │  Parallel sessions   │
-│                      │   approval requests      │                      │
-│  React UI            │                          │                      │
-│  SQLite index        │   route by sessionKey    │                      │
-│  Local workspace     │                          │                      │
-└──────────────────────┘                          └──────────────────────┘
+<div align="center">
+<img src="./docs/architecture.svg" alt="ClawWork Architecture" width="840" />
+</div>
+
+## Repo layout
+
 ```
+packages/shared/       — protocol types, constants (zero deps)
+packages/desktop/
+  src/main/            — Electron main: gateway WS, IPC, DB, artifacts, OS integration
+  src/preload/         — typed window.clawwork bridge
+  src/renderer/        — React UI: components, layouts, stores, hooks, i18n
+website/               — project website (React + Vite)
+keynote/               — presentation slides (Slidev)
+```
+
+## Tech stack
+
+Electron 34, React 19, TypeScript, Tailwind CSS v4, Zustand, SQLite (Drizzle ORM + better-sqlite3), Framer Motion.
+
+## Platform notes
+
+- Voice input requires a local [whisper.cpp](https://github.com/ggerganov/whisper.cpp) binary and model.
+- Auto-updater works on packaged builds only; dev mode skips updates.
+- Context folder watcher: max 10 directories, 4 levels deep, files up to 10 MB.
 
 ## Roadmap
 
-Already shipping:
+✅ Already shipping:
 
 - Multi-task parallel execution
-- Multi-gateway support
+- Multi-gateway with token, password, and pairing code auth
 - Tool call cards and approval dialogs
 - Slash commands and thinking controls
-- File context attach and artifact browsing
+- File context, artifact browsing, and auto-extract
+- Agent management and tools catalog
+- Scheduled (cron) tasks
 - Usage and cost dashboard
-- Tray support and quick launch
-- Local voice input
+- Native desktop notifications
+- Folder watcher with auto-reindex
+- Session export and debug bundle export
+- Auto-update
+- Tray, quick launch, and voice input
+- Gateway server version display
 
-Next up:
+🔮 Next up:
 
 - Linux packages
 - Conversation branching
 - Artifact diff view
-- Desktop notifications for background completions
 - Custom themes
 
 ## Star History
@@ -147,6 +181,7 @@ The project is early and moving fast. If you want to help:
 - Read [DEVELOPMENT.md](DEVELOPMENT.md) for setup and project structure
 - Check [Issues](https://github.com/clawwork-ai/clawwork/issues)
 - Open a [Pull Request](https://github.com/clawwork-ai/clawwork/pulls)
+- Run `pnpm check` before submitting — it gates lint, architecture checks, formatting, typecheck, and tests.
 
 ## License
 
@@ -154,6 +189,6 @@ The project is early and moving fast. If you want to help:
 
 <div align="center">
 
-Built for [OpenClaw](https://github.com/openclaw/openclaw).
+Built for [OpenClaw](https://github.com/openclaw/openclaw). Inspired by the great work of [Peter Steinberger](https://github.com/steipete).
 
 </div>

--- a/docs/architecture-light.svg
+++ b/docs/architecture-light.svg
@@ -1,0 +1,170 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="840" height="540" viewBox="0 0 840 540">
+  <defs>
+    <radialGradient id="topGlowL" cx="50%" cy="0%" r="60%">
+      <stop offset="0%" stop-color="#0B8A0A" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#0B8A0A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="windowShadowL">
+      <feDropShadow dx="0" dy="2" stdDeviation="10" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="840" height="540" fill="#FAFAFA"/>
+  <rect width="840" height="300" fill="url(#topGlowL)"/>
+
+  <!-- ==================== APP WINDOW ==================== -->
+  <g transform="translate(90, 28)" filter="url(#windowShadowL)">
+    <!-- Window frame -->
+    <rect width="660" height="310" rx="10" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+
+    <!-- Title bar -->
+    <rect width="660" height="34" rx="10" fill="#F5F5F5"/>
+    <rect y="22" width="660" height="12" fill="#F5F5F5"/>
+    <line y1="34" x2="660" y2="34" stroke="#E0E0E0" stroke-width="1"/>
+
+    <!-- Traffic lights -->
+    <circle cx="18" cy="17" r="5.5" fill="#FF5F57"/>
+    <circle cx="36" cy="17" r="5.5" fill="#FEBC2E"/>
+    <circle cx="54" cy="17" r="5.5" fill="#28C840"/>
+
+    <!-- Logo + Title -->
+    <svg x="284" y="5" width="22" height="22" viewBox="0 0 128 128">
+      <g transform="translate(0,128) scale(0.1,-0.1)" fill="#D42020" stroke="none">
+        <path d="M749 1068 c-36 -13 -91 -39 -123 -58 -72 -43 -177 -153 -211 -220 -50 -98 -68 -215 -44 -290 6 -19 10 -62 10 -96 -2 -71 23 -118 79 -147 74 -39 194 0 262 84 18 22 48 48 68 57 126 60 211 240 182 392 -11 63 -47 150 -62 150 -4 0 -13 -13 -18 -29 -17 -48 -82 -111 -153 -146 -37 -19 -76 -46 -88 -61 -12 -15 -21 -22 -21 -16 0 19 49 69 80 82 16 7 30 17 30 22 0 6 14 39 32 75 22 46 53 84 106 134 41 38 72 72 69 75 -3 4 -34 8 -69 10 -48 4 -78 -1 -129 -18z"/>
+      </g>
+    </svg>
+    <text x="335" y="22" text-anchor="middle" fill="#555" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="500">ClawWork</text>
+
+    <!-- Panel dividers -->
+    <line x1="160" y1="34" x2="160" y2="310" stroke="#E8E8E8" stroke-width="1"/>
+    <line x1="475" y1="34" x2="475" y2="310" stroke="#E8E8E8" stroke-width="1"/>
+
+    <!-- ===== LEFT PANEL: Tasks ===== -->
+    <text x="14" y="57" fill="#666" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">TASKS</text>
+
+    <!-- Active task -->
+    <rect x="8" y="67" width="144" height="32" rx="6" fill="#E8F5E8"/>
+    <circle cx="21" cy="83" r="4" fill="#0B8A0A"/>
+    <text x="32" y="88" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">Research API docs</text>
+
+    <!-- Idle tasks -->
+    <rect x="8" y="105" width="144" height="32" rx="6" fill="#F3F3F3"/>
+    <circle cx="21" cy="121" r="4" fill="#CCC"/>
+    <text x="32" y="126" fill="#555" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Refactor auth flow</text>
+
+    <rect x="8" y="143" width="144" height="32" rx="6" fill="#F3F3F3"/>
+    <circle cx="21" cy="159" r="4" fill="#CCC"/>
+    <text x="32" y="164" fill="#555" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Write unit tests</text>
+
+    <!-- Cron section -->
+    <text x="14" y="200" fill="#666" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">SCHEDULED</text>
+
+    <rect x="8" y="210" width="144" height="28" rx="6" fill="#F0FAF0" stroke="#0B8A0A" stroke-width="0.8" stroke-opacity="0.3"/>
+    <text x="21" y="228" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Daily report</text>
+    <text x="134" y="228" text-anchor="end" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.6">09:00</text>
+
+    <rect x="8" y="244" width="144" height="28" rx="6" fill="#F0FAF0" stroke="#0B8A0A" stroke-width="0.8" stroke-opacity="0.3"/>
+    <text x="21" y="262" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Weekly digest</text>
+    <text x="134" y="262" text-anchor="end" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.6">Mon</text>
+
+    <!-- ===== CENTER PANEL: Active Work ===== -->
+    <text x="172" y="57" fill="#666" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ACTIVE WORK</text>
+
+    <!-- Streaming reply -->
+    <text x="172" y="80" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">I'll analyze the API endpoints and</text>
+    <text x="172" y="98" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">document the authentication flow</text>
+    <!-- Cursor -->
+    <rect x="387" y="88" width="2" height="14" rx="1" fill="#0B8A0A"/>
+
+    <!-- Tool call card -->
+    <rect x="172" y="114" width="290" height="46" rx="8" fill="#F5FAF5" stroke="#0B8A0A" stroke-width="0.5" stroke-opacity="0.25"/>
+    <circle cx="189" cy="132" r="4.5" fill="#0B8A0A"/>
+    <text x="200" y="136" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">read_file</text>
+    <text x="200" y="152" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">src/auth/middleware.ts</text>
+
+    <!-- Approval card -->
+    <rect x="172" y="168" width="290" height="46" rx="8" fill="#FFFAF0" stroke="#E8A817" stroke-width="0.5" stroke-opacity="0.4"/>
+    <circle cx="189" cy="186" r="4.5" fill="#E8A817"/>
+    <text x="200" y="190" fill="#B8860B" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">exec — approval needed</text>
+    <text x="200" y="206" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">npm run db:migrate</text>
+
+    <!-- Thinking trace -->
+    <rect x="172" y="224" width="290" height="32" rx="6" fill="#F7F7FA"/>
+    <text x="185" y="244" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" font-style="italic">Analyzing dependency graph...</text>
+
+    <!-- Cost bar -->
+    <rect x="172" y="270" width="290" height="24" rx="4" fill="#F3F3F3" stroke="#E0E0E0" stroke-width="0.5"/>
+    <text x="183" y="286" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12.4k tokens · $0.03 · Sonnet 4</text>
+
+    <!-- ===== RIGHT PANEL: Artifacts ===== -->
+    <text x="487" y="57" fill="#666" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ARTIFACTS</text>
+
+    <!-- Files -->
+    <rect x="483" y="67" width="168" height="30" rx="6" fill="#F3F3F3"/>
+    <text x="498" y="87" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">auth-flow.md</text>
+
+    <rect x="483" y="102" width="168" height="30" rx="6" fill="#F3F3F3"/>
+    <text x="498" y="122" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">diagram.png</text>
+
+    <rect x="483" y="137" width="168" height="30" rx="6" fill="#F3F3F3"/>
+    <text x="498" y="157" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">middleware.ts</text>
+
+    <rect x="483" y="172" width="168" height="30" rx="6" fill="#F3F3F3"/>
+    <text x="498" y="192" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">test-report.md</text>
+
+    <!-- Search bar -->
+    <rect x="483" y="218" width="168" height="28" rx="14" fill="#F7F7F7" stroke="#DDD" stroke-width="0.8"/>
+    <text x="504" y="236" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Search artifacts...</text>
+
+    <!-- Auto-extract badge -->
+    <rect x="483" y="264" width="168" height="28" rx="6" fill="#E8F5E8" stroke="#0B8A0A" stroke-width="0.6" stroke-opacity="0.3"/>
+    <text x="498" y="282" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Auto-extracted · 4 new</text>
+  </g>
+
+  <!-- ==================== CONNECTIONS ==================== -->
+
+  <!-- Left connections: Window → Gateways (fan out to 3) -->
+  <line x1="220" y1="342" x2="120" y2="400" stroke="#CCC" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="260" y1="342" x2="280" y2="400" stroke="#CCC" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="300" y1="342" x2="440" y2="400" stroke="#DDD" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <text x="140" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">WEBSOCKET</text>
+
+  <!-- Right connection: Window → Workspace -->
+  <line x1="620" y1="342" x2="680" y2="400" stroke="#0B8A0A" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="3,3"/>
+  <text x="640" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">LOCAL-FIRST</text>
+
+  <!-- ==================== GATEWAY INSTANCES ==================== -->
+
+  <!-- Gateway 1: Production -->
+  <rect x="30" y="400" width="180" height="75" rx="10" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+  <circle cx="48" cy="420" r="4" fill="#0B8A0A"/>
+  <text x="58" y="424" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Production</text>
+  <text x="48" y="444" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12 agents · 8 tools</text>
+  <text x="48" y="462" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 2: Staging -->
+  <rect x="220" y="400" width="180" height="75" rx="10" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+  <circle cx="238" cy="420" r="4" fill="#E8A817"/>
+  <text x="248" y="424" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Staging</text>
+  <text x="238" y="444" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">4 agents · 15 tools</text>
+  <text x="238" y="462" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 3: Local -->
+  <rect x="410" y="400" width="180" height="75" rx="10" fill="#FAFAFA" stroke="#E8E8E8" stroke-width="1"/>
+  <circle cx="428" cy="420" r="4" fill="#CCC"/>
+  <text x="438" y="424" fill="#555" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Local Dev</text>
+  <text x="428" y="444" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">2 agents · 3 tools</text>
+  <text x="428" y="462" fill="#BBB" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">localhost:18789</text>
+
+  <!-- Label under gateways -->
+  <text x="300" y="498" text-anchor="middle" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="1.5">OPENCLAW GATEWAYS</text>
+
+  <!-- ==================== WORKSPACE BOX ==================== -->
+  <rect x="600" y="400" width="210" height="75" rx="10" fill="#F0FAF0" stroke="#0B8A0A" stroke-width="0.8" stroke-opacity="0.3"/>
+  <text x="705" y="424" text-anchor="middle" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="600">Your Workspace</text>
+  <text x="705" y="444" text-anchor="middle" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">SQLite + FTS5 · Searchable</text>
+  <text x="705" y="462" text-anchor="middle" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Tasks · Messages · Artifacts</text>
+
+</svg>

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,174 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="840" height="540" viewBox="0 0 840 540">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#111"/>
+      <stop offset="100%" stop-color="#0A0A0A"/>
+    </linearGradient>
+    <radialGradient id="topGlow" cx="50%" cy="0%" r="60%">
+      <stop offset="0%" stop-color="#0FFD0D" stop-opacity="0.07"/>
+      <stop offset="100%" stop-color="#0FFD0D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="windowShadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="14" flood-color="#000" flood-opacity="0.5"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="840" height="540" fill="url(#bg)"/>
+  <rect width="840" height="300" fill="url(#topGlow)"/>
+
+  <!-- ==================== APP WINDOW ==================== -->
+  <g transform="translate(90, 28)" filter="url(#windowShadow)">
+    <!-- Window frame -->
+    <rect width="660" height="310" rx="10" fill="#1C1C1C" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- Title bar -->
+    <rect width="660" height="34" rx="10" fill="#171717"/>
+    <rect y="22" width="660" height="12" fill="#171717"/>
+    <line y1="34" x2="660" y2="34" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- Traffic lights -->
+    <circle cx="18" cy="17" r="5.5" fill="#FF5F57"/>
+    <circle cx="36" cy="17" r="5.5" fill="#FEBC2E"/>
+    <circle cx="54" cy="17" r="5.5" fill="#28C840"/>
+
+    <!-- Logo + Title -->
+    <svg x="284" y="5" width="22" height="22" viewBox="0 0 128 128">
+      <g transform="translate(0,128) scale(0.1,-0.1)" fill="#E03030" stroke="none">
+        <path d="M749 1068 c-36 -13 -91 -39 -123 -58 -72 -43 -177 -153 -211 -220 -50 -98 -68 -215 -44 -290 6 -19 10 -62 10 -96 -2 -71 23 -118 79 -147 74 -39 194 0 262 84 18 22 48 48 68 57 126 60 211 240 182 392 -11 63 -47 150 -62 150 -4 0 -13 -13 -18 -29 -17 -48 -82 -111 -153 -146 -37 -19 -76 -46 -88 -61 -12 -15 -21 -22 -21 -16 0 19 49 69 80 82 16 7 30 17 30 22 0 6 14 39 32 75 22 46 53 84 106 134 41 38 72 72 69 75 -3 4 -34 8 -69 10 -48 4 -78 -1 -129 -18z"/>
+      </g>
+    </svg>
+    <text x="335" y="22" text-anchor="middle" fill="#CCC" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="500">ClawWork</text>
+
+    <!-- Panel dividers -->
+    <line x1="160" y1="34" x2="160" y2="310" stroke="#3A3A3A" stroke-width="0.5"/>
+    <line x1="475" y1="34" x2="475" y2="310" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- ===== LEFT PANEL: Tasks ===== -->
+    <text x="14" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">TASKS</text>
+
+    <!-- Active task -->
+    <rect x="8" y="67" width="144" height="32" rx="6" fill="#1A3A1A"/>
+    <circle cx="21" cy="83" r="4" fill="#0FFD0D"/>
+    <text x="32" y="88" fill="#F5F5F7" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">Research API docs</text>
+
+    <!-- Idle tasks -->
+    <rect x="8" y="105" width="144" height="32" rx="6" fill="#242424"/>
+    <circle cx="21" cy="121" r="4" fill="#777"/>
+    <text x="32" y="126" fill="#BFBFBF" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Refactor auth flow</text>
+
+    <rect x="8" y="143" width="144" height="32" rx="6" fill="#242424"/>
+    <circle cx="21" cy="159" r="4" fill="#777"/>
+    <text x="32" y="164" fill="#BFBFBF" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Write unit tests</text>
+
+    <!-- Cron section -->
+    <text x="14" y="200" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">SCHEDULED</text>
+
+    <rect x="8" y="210" width="144" height="28" rx="6" fill="none" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.4"/>
+    <text x="21" y="228" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" opacity="0.8">Daily report</text>
+    <text x="134" y="228" text-anchor="end" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.5">09:00</text>
+
+    <rect x="8" y="244" width="144" height="28" rx="6" fill="none" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.4"/>
+    <text x="21" y="262" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" opacity="0.8">Weekly digest</text>
+    <text x="134" y="262" text-anchor="end" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.5">Mon</text>
+
+    <!-- ===== CENTER PANEL: Active Work ===== -->
+    <text x="172" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ACTIVE WORK</text>
+
+    <!-- Streaming reply -->
+    <text x="172" y="80" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">I'll analyze the API endpoints and</text>
+    <text x="172" y="98" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">document the authentication flow</text>
+    <!-- Cursor -->
+    <rect x="387" y="88" width="2" height="14" rx="1" fill="#0FFD0D"/>
+
+    <!-- Tool call card -->
+    <rect x="172" y="114" width="290" height="46" rx="8" fill="#1E1E1E" stroke="#3A3A3A" stroke-width="0.5"/>
+    <circle cx="189" cy="132" r="4.5" fill="#0FFD0D" opacity="0.9"/>
+    <text x="200" y="136" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">read_file</text>
+    <text x="200" y="152" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">src/auth/middleware.ts</text>
+
+    <!-- Approval card -->
+    <rect x="172" y="168" width="290" height="46" rx="8" fill="#2A2214" stroke="#FEBC2E" stroke-width="0.5" stroke-opacity="0.4"/>
+    <circle cx="189" cy="186" r="4.5" fill="#FEBC2E" opacity="0.9"/>
+    <text x="200" y="190" fill="#FEBC2E" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">exec — approval needed</text>
+    <text x="200" y="206" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">npm run db:migrate</text>
+
+    <!-- Thinking trace -->
+    <rect x="172" y="224" width="290" height="32" rx="6" fill="#1A1A1E"/>
+    <text x="185" y="244" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" font-style="italic">Analyzing dependency graph...</text>
+
+    <!-- Cost bar -->
+    <rect x="172" y="270" width="290" height="24" rx="4" fill="#1A1A1A" stroke="#333" stroke-width="0.5"/>
+    <text x="183" y="286" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12.4k tokens · $0.03 · Sonnet 4</text>
+
+    <!-- ===== RIGHT PANEL: Artifacts ===== -->
+    <text x="487" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ARTIFACTS</text>
+
+    <!-- Files -->
+    <rect x="483" y="67" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="87" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">auth-flow.md</text>
+
+    <rect x="483" y="102" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="122" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">diagram.png</text>
+
+    <rect x="483" y="137" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="157" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">middleware.ts</text>
+
+    <rect x="483" y="172" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="192" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">test-report.md</text>
+
+    <!-- Search bar -->
+    <rect x="483" y="218" width="168" height="28" rx="14" fill="#1A1A1A" stroke="#444" stroke-width="0.5"/>
+    <text x="504" y="236" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Search artifacts...</text>
+
+    <!-- Auto-extract badge -->
+    <rect x="483" y="264" width="168" height="28" rx="6" fill="#0FFD0D" fill-opacity="0.08" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.35"/>
+    <text x="498" y="282" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" opacity="0.8">Auto-extracted · 4 new</text>
+  </g>
+
+  <!-- ==================== CONNECTIONS ==================== -->
+
+  <!-- Left connections: Window → Gateways (fan out to 3) -->
+  <line x1="220" y1="342" x2="120" y2="400" stroke="#555" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="260" y1="342" x2="280" y2="400" stroke="#555" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="300" y1="342" x2="440" y2="400" stroke="#444" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <text x="140" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">WEBSOCKET</text>
+
+  <!-- Right connection: Window → Workspace -->
+  <line x1="620" y1="342" x2="680" y2="400" stroke="#0FFD0D" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="3,3"/>
+  <text x="640" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">LOCAL-FIRST</text>
+
+  <!-- ==================== GATEWAY INSTANCES ==================== -->
+
+  <!-- Gateway 1: Production (primary) -->
+  <rect x="30" y="400" width="180" height="75" rx="10" fill="#1A1A1A" stroke="#3A3A3A" stroke-width="0.5"/>
+  <circle cx="48" cy="420" r="4" fill="#0FFD0D"/>
+  <text x="58" y="424" fill="#E0E0E0" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Production</text>
+  <text x="48" y="444" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12 agents · 8 tools</text>
+  <text x="48" y="462" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 2: Staging -->
+  <rect x="220" y="400" width="180" height="75" rx="10" fill="#1A1A1A" stroke="#3A3A3A" stroke-width="0.5"/>
+  <circle cx="238" cy="420" r="4" fill="#FEBC2E"/>
+  <text x="248" y="424" fill="#E0E0E0" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Staging</text>
+  <text x="238" y="444" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">4 agents · 15 tools</text>
+  <text x="238" y="462" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 3: Local -->
+  <rect x="410" y="400" width="180" height="75" rx="10" fill="#161616" stroke="#333" stroke-width="0.5"/>
+  <circle cx="428" cy="420" r="4" fill="#777"/>
+  <text x="438" y="424" fill="#BBB" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Local Dev</text>
+  <text x="428" y="444" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">2 agents · 3 tools</text>
+  <text x="428" y="462" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">localhost:18789</text>
+
+  <!-- Label under gateways -->
+  <text x="300" y="498" text-anchor="middle" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="1.5">OPENCLAW GATEWAYS</text>
+
+  <!-- ==================== WORKSPACE BOX ==================== -->
+  <rect x="600" y="400" width="210" height="75" rx="10" fill="#0FFD0D" fill-opacity="0.05" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.3"/>
+  <text x="705" y="424" text-anchor="middle" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="600">Your Workspace</text>
+  <text x="705" y="444" text-anchor="middle" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">SQLite + FTS5 · Searchable</text>
+  <text x="705" y="462" text-anchor="middle" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Tasks · Messages · Artifacts</text>
+
+</svg>

--- a/keynote/public/images/architecture.svg
+++ b/keynote/public/images/architecture.svg
@@ -1,0 +1,174 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="840" height="540" viewBox="0 0 840 540">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#111"/>
+      <stop offset="100%" stop-color="#0A0A0A"/>
+    </linearGradient>
+    <radialGradient id="topGlow" cx="50%" cy="0%" r="60%">
+      <stop offset="0%" stop-color="#0FFD0D" stop-opacity="0.07"/>
+      <stop offset="100%" stop-color="#0FFD0D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="windowShadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="14" flood-color="#000" flood-opacity="0.5"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="840" height="540" fill="url(#bg)"/>
+  <rect width="840" height="300" fill="url(#topGlow)"/>
+
+  <!-- ==================== APP WINDOW ==================== -->
+  <g transform="translate(90, 28)" filter="url(#windowShadow)">
+    <!-- Window frame -->
+    <rect width="660" height="310" rx="10" fill="#1C1C1C" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- Title bar -->
+    <rect width="660" height="34" rx="10" fill="#171717"/>
+    <rect y="22" width="660" height="12" fill="#171717"/>
+    <line y1="34" x2="660" y2="34" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- Traffic lights -->
+    <circle cx="18" cy="17" r="5.5" fill="#FF5F57"/>
+    <circle cx="36" cy="17" r="5.5" fill="#FEBC2E"/>
+    <circle cx="54" cy="17" r="5.5" fill="#28C840"/>
+
+    <!-- Logo + Title -->
+    <svg x="284" y="5" width="22" height="22" viewBox="0 0 128 128">
+      <g transform="translate(0,128) scale(0.1,-0.1)" fill="#E03030" stroke="none">
+        <path d="M749 1068 c-36 -13 -91 -39 -123 -58 -72 -43 -177 -153 -211 -220 -50 -98 -68 -215 -44 -290 6 -19 10 -62 10 -96 -2 -71 23 -118 79 -147 74 -39 194 0 262 84 18 22 48 48 68 57 126 60 211 240 182 392 -11 63 -47 150 -62 150 -4 0 -13 -13 -18 -29 -17 -48 -82 -111 -153 -146 -37 -19 -76 -46 -88 -61 -12 -15 -21 -22 -21 -16 0 19 49 69 80 82 16 7 30 17 30 22 0 6 14 39 32 75 22 46 53 84 106 134 41 38 72 72 69 75 -3 4 -34 8 -69 10 -48 4 -78 -1 -129 -18z"/>
+      </g>
+    </svg>
+    <text x="335" y="22" text-anchor="middle" fill="#CCC" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="500">ClawWork</text>
+
+    <!-- Panel dividers -->
+    <line x1="160" y1="34" x2="160" y2="310" stroke="#3A3A3A" stroke-width="0.5"/>
+    <line x1="475" y1="34" x2="475" y2="310" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- ===== LEFT PANEL: Tasks ===== -->
+    <text x="14" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">TASKS</text>
+
+    <!-- Active task -->
+    <rect x="8" y="67" width="144" height="32" rx="6" fill="#1A3A1A"/>
+    <circle cx="21" cy="83" r="4" fill="#0FFD0D"/>
+    <text x="32" y="88" fill="#F5F5F7" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">Research API docs</text>
+
+    <!-- Idle tasks -->
+    <rect x="8" y="105" width="144" height="32" rx="6" fill="#242424"/>
+    <circle cx="21" cy="121" r="4" fill="#777"/>
+    <text x="32" y="126" fill="#BFBFBF" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Refactor auth flow</text>
+
+    <rect x="8" y="143" width="144" height="32" rx="6" fill="#242424"/>
+    <circle cx="21" cy="159" r="4" fill="#777"/>
+    <text x="32" y="164" fill="#BFBFBF" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Write unit tests</text>
+
+    <!-- Cron section -->
+    <text x="14" y="200" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">SCHEDULED</text>
+
+    <rect x="8" y="210" width="144" height="28" rx="6" fill="none" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.4"/>
+    <text x="21" y="228" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" opacity="0.8">Daily report</text>
+    <text x="134" y="228" text-anchor="end" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.5">09:00</text>
+
+    <rect x="8" y="244" width="144" height="28" rx="6" fill="none" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.4"/>
+    <text x="21" y="262" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" opacity="0.8">Weekly digest</text>
+    <text x="134" y="262" text-anchor="end" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.5">Mon</text>
+
+    <!-- ===== CENTER PANEL: Active Work ===== -->
+    <text x="172" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ACTIVE WORK</text>
+
+    <!-- Streaming reply -->
+    <text x="172" y="80" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">I'll analyze the API endpoints and</text>
+    <text x="172" y="98" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">document the authentication flow</text>
+    <!-- Cursor -->
+    <rect x="387" y="88" width="2" height="14" rx="1" fill="#0FFD0D"/>
+
+    <!-- Tool call card -->
+    <rect x="172" y="114" width="290" height="46" rx="8" fill="#1E1E1E" stroke="#3A3A3A" stroke-width="0.5"/>
+    <circle cx="189" cy="132" r="4.5" fill="#0FFD0D" opacity="0.9"/>
+    <text x="200" y="136" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">read_file</text>
+    <text x="200" y="152" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">src/auth/middleware.ts</text>
+
+    <!-- Approval card -->
+    <rect x="172" y="168" width="290" height="46" rx="8" fill="#2A2214" stroke="#FEBC2E" stroke-width="0.5" stroke-opacity="0.4"/>
+    <circle cx="189" cy="186" r="4.5" fill="#FEBC2E" opacity="0.9"/>
+    <text x="200" y="190" fill="#FEBC2E" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">exec — approval needed</text>
+    <text x="200" y="206" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">npm run db:migrate</text>
+
+    <!-- Thinking trace -->
+    <rect x="172" y="224" width="290" height="32" rx="6" fill="#1A1A1E"/>
+    <text x="185" y="244" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" font-style="italic">Analyzing dependency graph...</text>
+
+    <!-- Cost bar -->
+    <rect x="172" y="270" width="290" height="24" rx="4" fill="#1A1A1A" stroke="#333" stroke-width="0.5"/>
+    <text x="183" y="286" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12.4k tokens · $0.03 · Sonnet 4</text>
+
+    <!-- ===== RIGHT PANEL: Artifacts ===== -->
+    <text x="487" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ARTIFACTS</text>
+
+    <!-- Files -->
+    <rect x="483" y="67" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="87" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">auth-flow.md</text>
+
+    <rect x="483" y="102" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="122" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">diagram.png</text>
+
+    <rect x="483" y="137" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="157" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">middleware.ts</text>
+
+    <rect x="483" y="172" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="192" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">test-report.md</text>
+
+    <!-- Search bar -->
+    <rect x="483" y="218" width="168" height="28" rx="14" fill="#1A1A1A" stroke="#444" stroke-width="0.5"/>
+    <text x="504" y="236" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Search artifacts...</text>
+
+    <!-- Auto-extract badge -->
+    <rect x="483" y="264" width="168" height="28" rx="6" fill="#0FFD0D" fill-opacity="0.08" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.35"/>
+    <text x="498" y="282" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" opacity="0.8">Auto-extracted · 4 new</text>
+  </g>
+
+  <!-- ==================== CONNECTIONS ==================== -->
+
+  <!-- Left connections: Window → Gateways (fan out to 3) -->
+  <line x1="220" y1="342" x2="120" y2="400" stroke="#555" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="260" y1="342" x2="280" y2="400" stroke="#555" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="300" y1="342" x2="440" y2="400" stroke="#444" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <text x="140" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">WEBSOCKET</text>
+
+  <!-- Right connection: Window → Workspace -->
+  <line x1="620" y1="342" x2="680" y2="400" stroke="#0FFD0D" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="3,3"/>
+  <text x="640" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">LOCAL-FIRST</text>
+
+  <!-- ==================== GATEWAY INSTANCES ==================== -->
+
+  <!-- Gateway 1: Production (primary) -->
+  <rect x="30" y="400" width="180" height="75" rx="10" fill="#1A1A1A" stroke="#3A3A3A" stroke-width="0.5"/>
+  <circle cx="48" cy="420" r="4" fill="#0FFD0D"/>
+  <text x="58" y="424" fill="#E0E0E0" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Production</text>
+  <text x="48" y="444" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12 agents · 8 tools</text>
+  <text x="48" y="462" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 2: Staging -->
+  <rect x="220" y="400" width="180" height="75" rx="10" fill="#1A1A1A" stroke="#3A3A3A" stroke-width="0.5"/>
+  <circle cx="238" cy="420" r="4" fill="#FEBC2E"/>
+  <text x="248" y="424" fill="#E0E0E0" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Staging</text>
+  <text x="238" y="444" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">4 agents · 15 tools</text>
+  <text x="238" y="462" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 3: Local -->
+  <rect x="410" y="400" width="180" height="75" rx="10" fill="#161616" stroke="#333" stroke-width="0.5"/>
+  <circle cx="428" cy="420" r="4" fill="#777"/>
+  <text x="438" y="424" fill="#BBB" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Local Dev</text>
+  <text x="428" y="444" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">2 agents · 3 tools</text>
+  <text x="428" y="462" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">localhost:18789</text>
+
+  <!-- Label under gateways -->
+  <text x="300" y="498" text-anchor="middle" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="1.5">OPENCLAW GATEWAYS</text>
+
+  <!-- ==================== WORKSPACE BOX ==================== -->
+  <rect x="600" y="400" width="210" height="75" rx="10" fill="#0FFD0D" fill-opacity="0.05" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.3"/>
+  <text x="705" y="424" text-anchor="middle" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="600">Your Workspace</text>
+  <text x="705" y="444" text-anchor="middle" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">SQLite + FTS5 · Searchable</text>
+  <text x="705" y="462" text-anchor="middle" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Tasks · Messages · Artifacts</text>
+
+</svg>

--- a/keynote/slides.md
+++ b/keynote/slides.md
@@ -35,12 +35,11 @@ favicon: ''
 <div class="cw-gradient-border" style="margin-top:24px;padding:12px 24px;background:rgba(17,24,39,0.6);width:fit-content;">
 <p style="font-size:1rem;color:#d1d5db;font-weight:300;font-style:italic;margin:0;">"Not a better chat window —<br/>a <strong style="color:#4ade80;font-weight:600;">parallel task workbench</strong>."</p>
 </div>
-<div style="display:flex;gap:10px;margin-top:24px;flex-wrap:wrap;">
-<span style="padding:4px 12px;background:rgba(74,222,128,0.1);color:#4ade80;font-size:12px;border-radius:9999px;border:1px solid rgba(74,222,128,0.3);font-weight:600;">Electron 34</span>
-<span style="padding:4px 12px;background:rgba(34,211,238,0.1);color:#22d3ee;font-size:12px;border-radius:9999px;border:1px solid rgba(34,211,238,0.3);font-weight:600;">React 19</span>
-<span style="padding:4px 12px;background:rgba(192,132,252,0.1);color:#c084fc;font-size:12px;border-radius:9999px;border:1px solid rgba(192,132,252,0.3);font-weight:600;">Gateway Protocol</span>
-</div>
-<div style="display:flex;align-items:center;gap:12px;margin-top:32px;font-size:0.875rem;opacity:0.4;">
+<a href="https://github.com/clawwork-ai/clawwork" target="_blank" style="display:inline-flex;align-items:center;gap:8px;margin-top:24px;text-decoration:none !important;border-bottom:none !important;color:#9ca3af;font-size:0.8rem;font-family:monospace;">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+clawwork-ai/clawwork
+</a>
+<div style="display:flex;align-items:center;gap:12px;margin-top:12px;font-size:0.875rem;opacity:0.4;">
 <span>samzong</span><span>·</span><span>OpenClaw Community</span><span>·</span><span>2026</span>
 </div>
 </div>
@@ -52,21 +51,62 @@ favicon: ''
 
 ---
 
-## transition: fade-out
-
 # Community Signal
 
-<div class="grid grid-cols-2 gap-8 mt-8">
+<div class="grid grid-cols-2 gap-8 mt-4">
 
-<div class="bg-gray-800/50 rounded-xl p-6 border border-gray-700">
-  <div class="font-semibold mb-3 text-sm opacity-60">GitHub Star Notification</div>
-  <img src="/images/peter-github-star.png" class="rounded-lg border border-gray-600" alt="Peter starred ClawWork on GitHub" />
+<div class="bg-gray-800/50 rounded-xl p-6 border border-yellow-400/25" style="border-top:2px solid rgba(251,191,36,0.4);">
+<div class="font-semibold mb-3 text-sm text-yellow-400/70">GitHub Star Notification</div>
+<img src="/images/peter-github-star.png" class="rounded-lg border border-gray-600" style="max-height: 240px; width: auto; object-fit: contain;" alt="Peter starred ClawWork on GitHub" />
+<div class="mt-3 text-sm opacity-50 italic">The person who built OpenClaw thinks this project is worth watching.</div>
+</div>
+
+<div class="bg-gray-800/50 rounded-xl p-6 border border-green-400/25" style="border-top:2px solid rgba(74,222,128,0.4);">
+<div class="font-semibold mb-3 text-sm text-green-400/70">Star History</div>
+<img src="https://api.star-history.com/svg?repos=clawwork-ai/ClawWork&type=Date" class="rounded-lg" style="max-height: 240px; width: 100%; object-fit: contain;" alt="Star History Chart" />
 </div>
 
 </div>
 
-<div class="mt-8 text-center text-sm opacity-50 italic">
-  The person who built OpenClaw thinks this project is worth watching.
+---
+
+# About Me
+
+<div style="display:grid;grid-template-columns:200px 1fr;gap:32px;margin-top:8px;height:85%;">
+<div style="display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;">
+<img src="https://github.com/samzong.png" style="width:120px;height:120px;border-radius:50%;border:3px solid rgba(74,222,128,0.3);box-shadow:0 0 30px rgba(74,222,128,0.08);" alt="Samzong" />
+<div style="font-size:22px;font-weight:700;color:#4ade80;margin-top:4px;">Samzong</div>
+<div style="font-size:13px;opacity:0.4;margin-top:-4px;">(船长)</div>
+<a href="https://github.com/samzong" target="_blank" style="font-size:12px;opacity:0.4;color:#9ca3af;text-decoration:none !important;border-bottom:none !important;">github.com/samzong</a>
+<div style="font-size:11px;opacity:0.35;text-align:center;line-height:1.6;margin-top:8px;">Inference scheduling<br/>Multi-model routing<br/>Production LLMOps<br/>Cloud-native AI</div>
+</div>
+<div style="display:flex;flex-direction:column;gap:10px;">
+<div style="display:flex;align-items:center;gap:14px;padding:16px 20px;border-radius:12px;border:1.5px solid rgba(74,222,128,0.35);background:rgba(74,222,128,0.06);">
+<img src="/images/clawwork-logo.png" style="width:40px;height:40px;border-radius:10px;" alt="ClawWork" />
+<div style="flex:1;">
+<div style="display:flex;align-items:center;gap:8px;"><span style="font-size:16px;font-weight:700;color:#4ade80;">Author of ClawWork</span><span style="font-size:13px;opacity:0.5;">⭐ 287</span></div>
+<div style="font-size:12px;opacity:0.5;margin-top:4px;">Open Source OpenClaw Desktop Client — parallel tasks, structured artifacts, scheduled automation</div>
+</div>
+</div>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;flex:1;margin-top:6px;">
+<div style="display:flex;flex-direction:column;gap:6px;">
+<div style="font-size:15px;font-weight:700;color:#22d3ee;">Open Source</div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://github.com/vllm-project.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#4ade80;font-weight:600;">Committer</span><span style="color:#d1d5db;">semantic-router</span><span style="opacity:0.35;margin-left:auto;">⭐ 3.5k</span></div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://github.com/llm-d.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#22d3ee;font-weight:600;">Contrib</span><span style="color:#d1d5db;">llm-d</span><span style="opacity:0.35;margin-left:auto;">⭐ 2.7k</span></div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://github.com/Project-HAMi.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#22d3ee;font-weight:600;">Contrib</span><span style="color:#d1d5db;">HAMi · Kueue</span><span style="opacity:0.35;margin-left:auto;">⭐ 3.1k · 2.4k</span></div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://github.com/istio.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#22d3ee;font-weight:600;">Contrib</span><span style="color:#d1d5db;">Istio · Karmada · K8s</span><span style="opacity:0.35;margin-left:auto;">⭐ 38k+</span></div>
+</div>
+<div style="display:flex;flex-direction:column;gap:6px;">
+<div style="font-size:15px;font-weight:700;color:#c084fc;">Side Projects</div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://raw.githubusercontent.com/samzong/chrome-tabboost/main/src/assets/icons/icon128.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#d1d5db;font-weight:600;">Chrome TabBoost</span><span style="opacity:0.35;margin-left:auto;">⭐ 81</span></div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://raw.githubusercontent.com/samzong/MacMusicPlayer/main/MacMusicPlayer/Assets.xcassets/AppIcon.appiconset/icon_256x256_2x.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#d1d5db;font-weight:600;">MacMusicPlayer</span><span style="opacity:0.35;margin-left:auto;">⭐ 75</span></div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://raw.githubusercontent.com/samzong/ConfigForge/main/ConfigForge/Assets.xcassets/Logo.imageset/logo.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#d1d5db;font-weight:600;">ConfigForge</span><span style="opacity:0.35;margin-left:auto;">⭐ 41</span></div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://raw.githubusercontent.com/samzong/gmc/main/logo.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#d1d5db;font-weight:600;">gmc</span><span style="opacity:0.35;margin-left:auto;">⭐ 10</span></div>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:rgba(31,41,55,0.4);border-radius:6px;border:1px solid rgba(55,65,81,0.5);font-size:13px;"><img src="https://raw.githubusercontent.com/samzong/hf-model-downloader/main/assets/icon.png" style="width:20px;height:20px;border-radius:4px;" /><span style="color:#d1d5db;font-weight:600;">hf-model-downloader</span><span style="opacity:0.35;margin-left:auto;">⭐ 23</span></div>
+<div style="display:flex;align-items:center;gap:8px;margin-top:2px;opacity:0.45;"><img src="https://raw.githubusercontent.com/samzong/mdctl/main/mdctl.png" style="width:20px;height:20px;border-radius:4px;" title="mdctl" /><img src="https://raw.githubusercontent.com/samzong/ai-icon-generator/main/public/logo.png" style="width:20px;height:20px;border-radius:4px;" title="ai-icon-generator" /><img src="https://raw.githubusercontent.com/samzong/SaveEye/main/SaveEye/Resources/Assets.xcassets/Logo.imageset/logo.png" style="width:20px;height:20px;border-radius:4px;" title="SaveEye" /><img src="https://raw.githubusercontent.com/samzong/LogoWallpaper/main/LogoWallpaper/Assets.xcassets/AppIcon.appiconset/logo-256.png" style="width:20px;height:20px;border-radius:4px;" title="LogoWallpaper" /><span style="font-size:11px;color:#9ca3af;">+5 more</span></div>
+</div>
+</div>
+</div>
 </div>
 
 ---
@@ -136,47 +176,29 @@ A desktop client for OpenClaw, **built for parallel work**.
 
 # Architecture at a Glance
 
-Single WebSocket, **Multiple Sessions**
+<div class="grid grid-cols-2 gap-8 mt-4" style="align-items: start;">
 
-<div class="grid grid-cols-2 gap-12 mt-6">
-
-<div class="flex flex-col items-center gap-4">
-  <div class="px-6 py-3 rounded-xl border-2 border-green-400 bg-gray-800/60 font-mono text-sm shadow-lg shadow-green-400/10">
-    🖥 ClawWork Desktop
-  </div>
-  <div class="text-green-400 text-xl">⇅</div>
-  <div class="text-xs font-mono opacity-50">WebSocket</div>
-  <div class="px-6 py-3 rounded-xl border border-gray-600 bg-gray-800/40 font-mono text-sm">
-    Gateway :18789
-  </div>
-  <div class="flex gap-3 mt-2">
-    <div class="px-4 py-2 rounded-lg border border-green-400/50 bg-gray-800/40 text-xs text-center">
-      Session A<br/><span class="opacity-50">Task 1</span>
-    </div>
-    <div class="px-4 py-2 rounded-lg border border-cyan-400/50 bg-gray-800/40 text-xs text-center">
-      Session B<br/><span class="opacity-50">Task 2</span>
-    </div>
-    <div class="px-4 py-2 rounded-lg border border-purple-400/50 bg-gray-800/40 text-xs text-center">
-      Session C<br/><span class="opacity-50">Task 3</span>
-    </div>
-  </div>
+<div>
+  <img src="/images/architecture.svg" class="rounded-xl" style="max-height: 380px; width: 100%; object-fit: contain;" alt="ClawWork Architecture" />
 </div>
 
 <div>
 
-**Session Key Format**
+Single WebSocket, **Multiple Gateways, Parallel Sessions**
 
-```
-agent:<agentId>:clawwork:task:<taskId>
-```
-
-- One connection multiplexes all sessions
-- Each task gets isolated message stream
-- Streaming events routed by `sessionKey`
-- No cross-talk between tasks
-
-<div class="mt-4 p-4 bg-green-400/5 border border-green-400/20 rounded-xl text-sm">
-  <strong class="text-green-400">Desktop vs Text Client:</strong> ClawWork uses dedicated RPC (<code>exec.approval.resolve</code>) for tool approvals — not chat messages.
+<div class="mt-4 space-y-3">
+  <div class="px-3 py-2 bg-green-400/5 border border-green-400/20 rounded-lg text-xs">
+    <strong class="text-green-400">Session Key</strong>
+    <p class="m-0 mt-1 opacity-70"><code>agent:&lt;id&gt;:clawwork:task:&lt;taskId&gt;</code></p>
+  </div>
+  <div class="px-3 py-2 bg-cyan-400/5 border border-cyan-400/20 rounded-lg text-xs">
+    <strong class="text-cyan-400">Isolation</strong>
+    <p class="m-0 mt-1 opacity-70">Events routed by sessionKey — no cross-talk between tasks</p>
+  </div>
+  <div class="px-3 py-2 bg-purple-400/5 border border-purple-400/20 rounded-lg text-xs">
+    <strong class="text-purple-400">Desktop RPC</strong>
+    <p class="m-0 mt-1 opacity-70">Dedicated <code>exec.approval.resolve</code> — not chat messages</p>
+  </div>
 </div>
 
 </div>
@@ -185,52 +207,78 @@ agent:<agentId>:clawwork:task:<taskId>
 
 ---
 
-## layout: default
-
 # Three-Panel Layout
+
+<div class="grid grid-cols-2 gap-8 mt-4" style="align-items: start;">
+
+<div>
+  <img src="/images/three-panel-full.png" class="rounded-xl border border-gray-700 shadow-2xl" style="max-height: 380px; width: 100%; object-fit: contain;" alt="ClawWork three-panel layout" />
+</div>
+
+<div>
 
 Left — Center — Right, everything visible at once
 
-<div class="mt-4">
-  <img src="/images/three-panel-full.png" class="rounded-xl border border-gray-700 shadow-2xl" alt="ClawWork three-panel layout" />
-</div>
-
-<div class="mt-3 grid grid-cols-3 gap-4 text-center text-sm">
-  <div class="p-2 bg-gray-800/40 rounded-lg border border-gray-700/50">
+<div class="mt-4 space-y-3">
+  <div class="p-3 bg-gray-800/40 rounded-lg border border-gray-700/50">
     <strong class="text-green-400">Left Nav</strong>
-    <p class="text-xs opacity-50 mt-1">Task list + gateway selector</p>
+    <p class="text-xs opacity-60 mt-1 m-0">Task list + gateway selector + cron jobs</p>
   </div>
-  <div class="p-2 bg-gray-800/40 rounded-lg border border-gray-700/50">
+  <div class="p-3 bg-gray-800/40 rounded-lg border border-gray-700/50">
     <strong class="text-cyan-400">Center</strong>
-    <p class="text-xs opacity-50 mt-1">Chat / File browser / Archive</p>
+    <p class="text-xs opacity-60 mt-1 m-0">Chat with streaming, tool cards, approval prompts</p>
   </div>
-  <div class="p-2 bg-gray-800/40 rounded-lg border border-gray-700/50">
+  <div class="p-3 bg-gray-800/40 rounded-lg border border-gray-700/50">
     <strong class="text-purple-400">Right Panel</strong>
-    <p class="text-xs opacity-50 mt-1">Progress + Artifacts</p>
+    <p class="text-xs opacity-60 mt-1 m-0">Progress tracking + artifact browser</p>
   </div>
 </div>
 
-<div class="mt-3 flex items-center gap-4 text-sm opacity-60">
-  <span>Resizable drag dividers</span>
+<div class="mt-4 flex items-center gap-3 text-sm opacity-50">
+  <span>Resizable dividers</span>
   <kbd class="px-2 py-0.5 bg-gray-800 border border-gray-600 rounded text-xs font-mono">⌘K</kbd>
   <span>Collapse sidebar</span>
+</div>
+
+</div>
+
 </div>
 
 ---
 
 # Multi-Session in Action
 
-Three tasks running in parallel — each with isolated context
+<div class="grid grid-cols-2 gap-8 mt-4" style="align-items: start;">
 
-<div class="mt-6">
-  <img src="/images/multi-session-parallel.png" class="rounded-xl border border-gray-700 shadow-2xl" alt="Three tasks running in parallel" />
+<div>
+  <img src="/images/multi-session-parallel.png" class="rounded-xl border border-gray-700 shadow-2xl" style="max-height: 380px; width: 100%; object-fit: contain;" alt="Three tasks running in parallel" />
 </div>
 
-<div class="mt-4 p-4 bg-white/2 border border-gray-700 rounded-xl flex gap-8 text-sm">
-  <div class="flex items-center gap-2"><div class="w-2 h-2 rounded-full bg-green-400"></div> Status badges</div>
-  <div class="flex items-center gap-2"><div class="w-2 h-2 rounded-full bg-cyan-400"></div> Animated spinners</div>
-  <div class="flex items-center gap-2"><div class="w-2 h-2 rounded-full bg-purple-400"></div> Unread indicators</div>
-  <div class="flex items-center gap-2"><div class="w-2 h-2 rounded-full bg-yellow-400"></div> Relative timestamps</div>
+<div>
+
+Three tasks running in parallel — each with isolated context
+
+<div class="mt-4 space-y-3">
+  <div class="flex items-center gap-3 p-3 bg-gray-800/40 rounded-lg border border-gray-700/50">
+    <div class="w-2.5 h-2.5 rounded-full bg-green-400 shrink-0"></div>
+    <span class="text-sm">Status badges — running, idle, done</span>
+  </div>
+  <div class="flex items-center gap-3 p-3 bg-gray-800/40 rounded-lg border border-gray-700/50">
+    <div class="w-2.5 h-2.5 rounded-full bg-cyan-400 shrink-0"></div>
+    <span class="text-sm">Animated spinners for active sessions</span>
+  </div>
+  <div class="flex items-center gap-3 p-3 bg-gray-800/40 rounded-lg border border-gray-700/50">
+    <div class="w-2.5 h-2.5 rounded-full bg-purple-400 shrink-0"></div>
+    <span class="text-sm">Unread indicators per task</span>
+  </div>
+  <div class="flex items-center gap-3 p-3 bg-gray-800/40 rounded-lg border border-gray-700/50">
+    <div class="w-2.5 h-2.5 rounded-full bg-yellow-400 shrink-0"></div>
+    <span class="text-sm">Relative timestamps</span>
+  </div>
+</div>
+
+</div>
+
 </div>
 
 ---
@@ -285,7 +333,7 @@ Every file the Agent produces, automatically collected
 
 <div>
   <h3 class="text-green-400 font-semibold mb-3">File Browser</h3>
-  <img src="/images/file-browser.png" class="rounded-xl border border-gray-700" alt="Artifact file browser" />
+  <img src="/images/file-browser.png" class="rounded-xl border border-gray-700" style="max-height: 300px; width: auto; object-fit: contain;" alt="Artifact file browser" />
 </div>
 
 <div>
@@ -313,7 +361,7 @@ You always know how much runway you have
 <div class="grid grid-cols-2 gap-8 mt-6">
 
 <div>
-  <img src="/images/token-usage.png" class="rounded-xl border border-gray-700" alt="Token usage dashboard" />
+  <img src="/images/token-usage.png" class="rounded-xl border border-gray-700" style="max-height: 300px; width: auto; object-fit: contain;" alt="Token usage dashboard" />
 </div>
 
 <div>
@@ -375,64 +423,73 @@ You always know how much runway you have
 
 Things we learned the hard way — so you don't have to
 
-<div class="mt-6 space-y-3 max-w-3xl">
-  <div class="flex items-center gap-4 bg-gray-800/40 rounded-xl p-4 border border-gray-700/50">
-    <div class="w-9 h-9 rounded-lg bg-red-400/15 flex items-center justify-center shrink-0">⚠</div>
-    <p class="text-sm"><strong>Gateway broadcasts ALL session events</strong> — client must filter by sessionKey</p>
+<div class="grid grid-cols-2 gap-3 mt-4">
+
+<div class="space-y-3">
+  <div class="flex items-center gap-3 bg-gray-800/40 rounded-xl p-3 border border-gray-700/50">
+    <div class="w-8 h-8 rounded-lg bg-red-400/15 flex items-center justify-center shrink-0 text-sm">⚠</div>
+    <p class="text-xs m-0"><strong>Gateway broadcasts ALL events</strong> — client must filter by sessionKey</p>
   </div>
-  <div class="flex items-center gap-4 bg-gray-800/40 rounded-xl p-4 border border-gray-700/50">
-    <div class="w-9 h-9 rounded-lg bg-yellow-400/15 flex items-center justify-center shrink-0">⚠</div>
-    <p class="text-sm"><code>chat.history</code> has <strong>no per-message ID</strong> — timestamps are the closest stable identifier</p>
+  <div class="flex items-center gap-3 bg-gray-800/40 rounded-xl p-3 border border-gray-700/50">
+    <div class="w-8 h-8 rounded-lg bg-yellow-400/15 flex items-center justify-center shrink-0 text-sm">⚠</div>
+    <p class="text-xs m-0">Streaming content may <strong>differ from history</strong> (whitespace, encoding)</p>
   </div>
-  <div class="flex items-center gap-4 bg-gray-800/40 rounded-xl p-4 border border-gray-700/50">
-    <div class="w-9 h-9 rounded-lg bg-yellow-400/15 flex items-center justify-center shrink-0">⚠</div>
-    <p class="text-sm">Streaming content may <strong>differ from history content</strong> (whitespace, encoding)</p>
-  </div>
-  <div class="flex items-center gap-4 bg-gray-800/40 rounded-xl p-4 border border-gray-700/50">
-    <div class="w-9 h-9 rounded-lg bg-green-400/15 flex items-center justify-center shrink-0">💡</div>
-    <p class="text-sm"><code class="text-green-400">deliver: false</code> is essential — otherwise messages get sent to external channels</p>
-  </div>
-  <div class="flex items-center gap-4 bg-gray-800/40 rounded-xl p-4 border border-gray-700/50">
-    <div class="w-9 h-9 rounded-lg bg-green-400/15 flex items-center justify-center shrink-0">💡</div>
-    <p class="text-sm">Single-writer architecture is <strong>not optional</strong> for reliable message persistence</p>
+  <div class="flex items-center gap-3 bg-gray-800/40 rounded-xl p-3 border border-gray-700/50">
+    <div class="w-8 h-8 rounded-lg bg-green-400/15 flex items-center justify-center shrink-0 text-sm">💡</div>
+    <p class="text-xs m-0"><strong>Single-writer</strong> architecture is not optional for reliable persistence</p>
   </div>
 </div>
 
-<p class="mt-4 text-sm opacity-40 italic">Real issues. Some with open GitHub issues. Happy to discuss after.</p>
+<div class="space-y-3">
+  <div class="flex items-center gap-3 bg-gray-800/40 rounded-xl p-3 border border-gray-700/50">
+    <div class="w-8 h-8 rounded-lg bg-yellow-400/15 flex items-center justify-center shrink-0 text-sm">⚠</div>
+    <p class="text-xs m-0"><code>chat.history</code> has <strong>no per-message ID</strong> — timestamps are the closest stable identifier</p>
+  </div>
+  <div class="flex items-center gap-3 bg-gray-800/40 rounded-xl p-3 border border-gray-700/50">
+    <div class="w-8 h-8 rounded-lg bg-green-400/15 flex items-center justify-center shrink-0 text-sm">💡</div>
+    <p class="text-xs m-0"><code class="text-green-400">deliver: false</code> is essential — otherwise messages get sent to external channels</p>
+  </div>
+</div>
+
+</div>
+
+<p class="mt-3 text-xs opacity-40 italic">Real issues. Some with open GitHub issues. Happy to discuss after.</p>
 
 ---
 
 # Current Status & What's Next
 
-<div class="grid grid-cols-2 gap-10 mt-6">
+<div class="grid grid-cols-2 gap-10 mt-4">
 
 <div>
-  <h3 class="text-green-400 font-semibold mb-4">✓ Done</h3>
-  <ul class="space-y-2 text-sm">
-    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Full three-panel layout with resize & collapse</li>
+  <h3 class="text-green-400 font-semibold mb-3">✓ Shipping (v0.0.10)</h3>
+  <ul class="space-y-1.5 text-sm">
+    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Three-panel layout with resize & collapse</li>
     <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Multi-session parallel task execution</li>
-    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Streaming with real-time progress extraction</li>
-    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Artifact aggregation with file browser & search</li>
-    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> SQLite persistence, Gateway reconnect recovery</li>
-    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> macOS Universal Binary packaging</li>
+    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Streaming, tool cards, approval prompts</li>
+    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Artifact auto-extract, file browser & FTS</li>
+    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Agent management & tools catalog</li>
+    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Usage & cost dashboard</li>
+    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> In-app auto-update & session export</li>
+    <li class="flex items-center gap-2"><span class="text-green-400 font-bold">✓</span> Cron scheduling, desktop notifications</li>
   </ul>
 </div>
 
 <div>
-  <h3 class="text-cyan-400 font-semibold mb-4">○ Next</h3>
-  <ul class="space-y-2 text-sm opacity-70">
-    <li class="flex items-center gap-2"><span class="opacity-40">○</span> Artifact version tracking (Git-backed)</li>
-    <li class="flex items-center gap-2"><span class="opacity-40">○</span> Cross-task artifact referencing</li>
-    <li class="flex items-center gap-2"><span class="opacity-40">○</span> Plugin system for custom artifact handlers</li>
-    <li class="flex items-center gap-2"><span class="opacity-40">○</span> Windows / Linux builds</li>
+  <h3 class="text-cyan-400 font-semibold mb-3">○ Next</h3>
+  <ul class="space-y-1.5 text-sm opacity-70">
+    <li class="flex items-center gap-2"><span class="opacity-40">○</span> Linux packages</li>
+    <li class="flex items-center gap-2"><span class="opacity-40">○</span> Conversation branching</li>
+    <li class="flex items-center gap-2"><span class="opacity-40">○</span> Artifact diff view</li>
+    <li class="flex items-center gap-2"><span class="opacity-40">○</span> Custom themes</li>
   </ul>
 
-  <div class="mt-6 p-4 bg-green-400/5 border border-green-400/15 rounded-xl">
+  <div class="mt-4 p-3 bg-green-400/5 border border-green-400/15 rounded-xl">
     <div class="text-[10px] uppercase tracking-wider opacity-50 mb-1">Dev Velocity</div>
     <div class="text-2xl font-extrabold bg-gradient-to-r from-green-400 to-cyan-400 bg-clip-text text-transparent">
-      10 Days, 13 Releases
+      12 Days, 10 Releases
     </div>
-    <p class="text-sm opacity-50">v0.0.1 → v0.0.9 (Mar 13–22)</p>
+    <p class="text-sm opacity-50">v0.0.1 → v0.0.10 (Mar 13–24)</p>
   </div>
 </div>
 
@@ -445,31 +502,40 @@ class: text-center
 
 ---
 
-# Stop Switching Tabs.<br/>Start Running Tasks.
+# Stop Switching Tabs, Start Running Tasks.
 
-<div class="mt-6 inline-block px-8 py-4 bg-gray-800 rounded-xl border border-gray-600 font-mono text-lg">
-  github.com/<span class="text-green-400">samzong</span>/<span class="text-cyan-400">clawwork</span>
+<div class="mt-8">
+  <a href="https://github.com/clawwork-ai/clawwork" target="_blank" style="text-decoration:none;">
+    <div style="display:inline-flex;align-items:center;gap:20px;padding:24px 40px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.12);border-radius:16px;transition:border-color 0.2s;">
+      <svg width="32" height="32" viewBox="0 0 16 16" fill="#f3f4f4"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      <div style="text-align:left;">
+        <div style="font-family:monospace;font-size:1.1rem;color:#f3f4f4;font-weight:600;">clawwork-ai/clawwork</div>
+        <div style="font-size:0.8rem;color:#9ca3af;margin-top:4px;">Open Source OpenClaw Desktop Client</div>
+      </div>
+      <div style="display:flex;gap:16px;margin-left:20px;">
+        <div style="display:flex;align-items:center;gap:4px;color:#fbbf24;font-size:0.85rem;">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>
+          Star
+        </div>
+        <div style="display:flex;align-items:center;gap:4px;color:#9ca3af;font-size:0.85rem;">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-.878a2.25 2.25 0 111.5 0v.878a2.25 2.25 0 01-2.25 2.25h-1.5v2.128a2.251 2.251 0 11-1.5 0V8.5h-1.5A2.25 2.25 0 013.5 6.25v-.878a2.25 2.25 0 111.5 0zM5 3.25a.75.75 0 10-1.5 0 .75.75 0 001.5 0zm6.75.75a.75.75 0 10 0-1.5.75.75 0 000 1.5zM8 12.25a.75.75 0 10-1.5 0 .75.75 0 001.5 0z"/></svg>
+          Fork
+        </div>
+      </div>
+    </div>
+  </a>
 </div>
 
-<div class="mt-8 flex gap-12 justify-center">
-  <div class="flex flex-col items-center gap-2">
-    <div class="w-12 h-12 rounded-xl bg-green-400/10 flex items-center justify-center text-2xl">🔌</div>
-    <span class="text-sm opacity-50">Point to :18789</span>
-  </div>
-  <div class="text-gray-600 text-2xl self-center">→</div>
-  <div class="flex flex-col items-center gap-2">
-    <div class="w-12 h-12 rounded-xl bg-cyan-400/10 flex items-center justify-center text-2xl">⚡</div>
-    <span class="text-sm opacity-50">Run parallel tasks</span>
-  </div>
-  <div class="text-gray-600 text-2xl self-center">→</div>
-  <div class="flex flex-col items-center gap-2">
-    <div class="w-12 h-12 rounded-xl bg-purple-400/10 flex items-center justify-center text-2xl">🤝</div>
-    <span class="text-sm opacity-50">PRs welcome</span>
-  </div>
-</div>
-
-<div class="mt-8 text-sm opacity-50 italic">
+<div class="mt-6 text-sm opacity-40 italic">
   "Not a chat window — a task workbench."
+</div>
+
+<div class="mt-6 flex gap-8 justify-center text-sm opacity-50">
+  <span>Apache 2.0</span>
+  <span>·</span>
+  <span>macOS & Windows</span>
+  <span>·</span>
+  <span>PRs welcome</span>
 </div>
 
 ---
@@ -501,13 +567,13 @@ class: text-center
 
 ---
 
-# Bonus: 10 Days, 13 Releases
+# Release History
 
-v0.0.1 → v0.0.9 · Mar 13–22, 2026
+v0.0.1 → v0.0.10 · Mar 13 – Mar 24, 2026
 
-<div class="grid grid-cols-2 gap-10 mt-6 text-sm">
+<div class="grid grid-cols-2 gap-6 mt-4 text-sm">
 
-<div class="space-y-3">
+<div class="space-y-2">
   <div class="flex gap-3 items-start">
     <div class="w-2 h-2 rounded-full bg-green-400 mt-1.5 shrink-0"></div>
     <div><span class="text-green-400 font-mono font-semibold">v0.0.1</span> <span class="opacity-60">Three-panel layout, multi-task, streaming</span></div>
@@ -530,14 +596,14 @@ v0.0.1 → v0.0.9 · Mar 13–22, 2026
   </div>
 </div>
 
-<div class="space-y-3">
+<div class="space-y-2">
   <div class="flex gap-3 items-start">
     <div class="w-2 h-2 rounded-full bg-green-400 mt-1.5 shrink-0"></div>
     <div><span class="text-green-400 font-mono font-semibold">v0.0.6</span> <span class="opacity-60">System tray, tool approval, stop generating</span></div>
   </div>
   <div class="flex gap-3 items-start">
     <div class="w-2 h-2 rounded-full bg-green-400 mt-1.5 shrink-0"></div>
-    <div><span class="text-green-400 font-mono font-semibold">v0.0.7</span> <span class="opacity-60">@ file context, tools catalog, usage dashboard, Apple notarization</span></div>
+    <div><span class="text-green-400 font-mono font-semibold">v0.0.7</span> <span class="opacity-60">@ file context, tools catalog, usage dashboard</span></div>
   </div>
   <div class="flex gap-3 items-start">
     <div class="w-2 h-2 rounded-full bg-green-400 mt-1.5 shrink-0"></div>
@@ -545,12 +611,21 @@ v0.0.1 → v0.0.9 · Mar 13–22, 2026
   </div>
   <div class="flex gap-3 items-start">
     <div class="w-2 h-2 rounded-full bg-green-400 mt-1.5 shrink-0"></div>
-    <div><span class="text-green-400 font-mono font-semibold">v0.0.9</span> <span class="opacity-60">Device-scoped sessions, 9 security fixes, sync stability</span></div>
+    <div><span class="text-green-400 font-mono font-semibold">v0.0.9</span> <span class="opacity-60">9 security fixes, device-scoped sessions, sync stability</span></div>
+  </div>
+  <div class="flex gap-3 items-start">
+    <div class="w-2 h-2 rounded-full bg-cyan-400 mt-1.5 shrink-0"></div>
+    <div><span class="text-cyan-400 font-mono font-semibold">v0.0.10</span> <span class="opacity-60">Auto-update, agent management, session export, debug bundle</span></div>
   </div>
 </div>
 
 </div>
 
-<div class="mt-6 inline-block p-3 bg-green-400/5 border border-green-400/15 rounded-xl text-sm">
-  Community contributions from <strong class="text-green-400">day 2</strong>. Two external contributors merged PRs.
+<div class="mt-4 flex gap-4">
+  <div class="p-2 bg-green-400/5 border border-green-400/15 rounded-lg text-xs">
+    Community contributions from <strong class="text-green-400">day 2</strong> — external PRs merged
+  </div>
+  <div class="p-2 bg-cyan-400/5 border border-cyan-400/15 rounded-lg text-xs">
+    <strong class="text-cyan-400">Next:</strong> Cron tasks, notifications, gateway version display
+  </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "postinstall": "node scripts/ensure-electron.mjs",
     "prepare": "husky",
     "dev": "pnpm --filter @clawwork/desktop dev",
+    "dev:website": "pnpm --filter @clawwork/website dev",
     "dev:slides": "pnpm --filter @clawwork/keynote dev",
     "build": "pnpm -r build",
     "check:architecture": "node scripts/check-architecture.mjs",

--- a/website/public/architecture-light.svg
+++ b/website/public/architecture-light.svg
@@ -1,0 +1,170 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="840" height="540" viewBox="0 0 840 540">
+  <defs>
+    <radialGradient id="topGlowL" cx="50%" cy="0%" r="60%">
+      <stop offset="0%" stop-color="#0B8A0A" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#0B8A0A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="windowShadowL">
+      <feDropShadow dx="0" dy="2" stdDeviation="10" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="840" height="540" fill="#FAFAFA"/>
+  <rect width="840" height="300" fill="url(#topGlowL)"/>
+
+  <!-- ==================== APP WINDOW ==================== -->
+  <g transform="translate(90, 28)" filter="url(#windowShadowL)">
+    <!-- Window frame -->
+    <rect width="660" height="310" rx="10" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+
+    <!-- Title bar -->
+    <rect width="660" height="34" rx="10" fill="#F5F5F5"/>
+    <rect y="22" width="660" height="12" fill="#F5F5F5"/>
+    <line y1="34" x2="660" y2="34" stroke="#E0E0E0" stroke-width="1"/>
+
+    <!-- Traffic lights -->
+    <circle cx="18" cy="17" r="5.5" fill="#FF5F57"/>
+    <circle cx="36" cy="17" r="5.5" fill="#FEBC2E"/>
+    <circle cx="54" cy="17" r="5.5" fill="#28C840"/>
+
+    <!-- Logo + Title -->
+    <svg x="284" y="5" width="22" height="22" viewBox="0 0 128 128">
+      <g transform="translate(0,128) scale(0.1,-0.1)" fill="#D42020" stroke="none">
+        <path d="M749 1068 c-36 -13 -91 -39 -123 -58 -72 -43 -177 -153 -211 -220 -50 -98 -68 -215 -44 -290 6 -19 10 -62 10 -96 -2 -71 23 -118 79 -147 74 -39 194 0 262 84 18 22 48 48 68 57 126 60 211 240 182 392 -11 63 -47 150 -62 150 -4 0 -13 -13 -18 -29 -17 -48 -82 -111 -153 -146 -37 -19 -76 -46 -88 -61 -12 -15 -21 -22 -21 -16 0 19 49 69 80 82 16 7 30 17 30 22 0 6 14 39 32 75 22 46 53 84 106 134 41 38 72 72 69 75 -3 4 -34 8 -69 10 -48 4 -78 -1 -129 -18z"/>
+      </g>
+    </svg>
+    <text x="335" y="22" text-anchor="middle" fill="#555" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="500">ClawWork</text>
+
+    <!-- Panel dividers -->
+    <line x1="160" y1="34" x2="160" y2="310" stroke="#E8E8E8" stroke-width="1"/>
+    <line x1="475" y1="34" x2="475" y2="310" stroke="#E8E8E8" stroke-width="1"/>
+
+    <!-- ===== LEFT PANEL: Tasks ===== -->
+    <text x="14" y="57" fill="#666" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">TASKS</text>
+
+    <!-- Active task -->
+    <rect x="8" y="67" width="144" height="32" rx="6" fill="#E8F5E8"/>
+    <circle cx="21" cy="83" r="4" fill="#0B8A0A"/>
+    <text x="32" y="88" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">Research API docs</text>
+
+    <!-- Idle tasks -->
+    <rect x="8" y="105" width="144" height="32" rx="6" fill="#F3F3F3"/>
+    <circle cx="21" cy="121" r="4" fill="#CCC"/>
+    <text x="32" y="126" fill="#555" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Refactor auth flow</text>
+
+    <rect x="8" y="143" width="144" height="32" rx="6" fill="#F3F3F3"/>
+    <circle cx="21" cy="159" r="4" fill="#CCC"/>
+    <text x="32" y="164" fill="#555" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Write unit tests</text>
+
+    <!-- Cron section -->
+    <text x="14" y="200" fill="#666" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">SCHEDULED</text>
+
+    <rect x="8" y="210" width="144" height="28" rx="6" fill="#F0FAF0" stroke="#0B8A0A" stroke-width="0.8" stroke-opacity="0.3"/>
+    <text x="21" y="228" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Daily report</text>
+    <text x="134" y="228" text-anchor="end" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.6">09:00</text>
+
+    <rect x="8" y="244" width="144" height="28" rx="6" fill="#F0FAF0" stroke="#0B8A0A" stroke-width="0.8" stroke-opacity="0.3"/>
+    <text x="21" y="262" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Weekly digest</text>
+    <text x="134" y="262" text-anchor="end" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.6">Mon</text>
+
+    <!-- ===== CENTER PANEL: Active Work ===== -->
+    <text x="172" y="57" fill="#666" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ACTIVE WORK</text>
+
+    <!-- Streaming reply -->
+    <text x="172" y="80" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">I'll analyze the API endpoints and</text>
+    <text x="172" y="98" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">document the authentication flow</text>
+    <!-- Cursor -->
+    <rect x="387" y="88" width="2" height="14" rx="1" fill="#0B8A0A"/>
+
+    <!-- Tool call card -->
+    <rect x="172" y="114" width="290" height="46" rx="8" fill="#F5FAF5" stroke="#0B8A0A" stroke-width="0.5" stroke-opacity="0.25"/>
+    <circle cx="189" cy="132" r="4.5" fill="#0B8A0A"/>
+    <text x="200" y="136" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">read_file</text>
+    <text x="200" y="152" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">src/auth/middleware.ts</text>
+
+    <!-- Approval card -->
+    <rect x="172" y="168" width="290" height="46" rx="8" fill="#FFFAF0" stroke="#E8A817" stroke-width="0.5" stroke-opacity="0.4"/>
+    <circle cx="189" cy="186" r="4.5" fill="#E8A817"/>
+    <text x="200" y="190" fill="#B8860B" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">exec — approval needed</text>
+    <text x="200" y="206" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">npm run db:migrate</text>
+
+    <!-- Thinking trace -->
+    <rect x="172" y="224" width="290" height="32" rx="6" fill="#F7F7FA"/>
+    <text x="185" y="244" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" font-style="italic">Analyzing dependency graph...</text>
+
+    <!-- Cost bar -->
+    <rect x="172" y="270" width="290" height="24" rx="4" fill="#F3F3F3" stroke="#E0E0E0" stroke-width="0.5"/>
+    <text x="183" y="286" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12.4k tokens · $0.03 · Sonnet 4</text>
+
+    <!-- ===== RIGHT PANEL: Artifacts ===== -->
+    <text x="487" y="57" fill="#666" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ARTIFACTS</text>
+
+    <!-- Files -->
+    <rect x="483" y="67" width="168" height="30" rx="6" fill="#F3F3F3"/>
+    <text x="498" y="87" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">auth-flow.md</text>
+
+    <rect x="483" y="102" width="168" height="30" rx="6" fill="#F3F3F3"/>
+    <text x="498" y="122" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">diagram.png</text>
+
+    <rect x="483" y="137" width="168" height="30" rx="6" fill="#F3F3F3"/>
+    <text x="498" y="157" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">middleware.ts</text>
+
+    <rect x="483" y="172" width="168" height="30" rx="6" fill="#F3F3F3"/>
+    <text x="498" y="192" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">test-report.md</text>
+
+    <!-- Search bar -->
+    <rect x="483" y="218" width="168" height="28" rx="14" fill="#F7F7F7" stroke="#DDD" stroke-width="0.8"/>
+    <text x="504" y="236" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Search artifacts...</text>
+
+    <!-- Auto-extract badge -->
+    <rect x="483" y="264" width="168" height="28" rx="6" fill="#E8F5E8" stroke="#0B8A0A" stroke-width="0.6" stroke-opacity="0.3"/>
+    <text x="498" y="282" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Auto-extracted · 4 new</text>
+  </g>
+
+  <!-- ==================== CONNECTIONS ==================== -->
+
+  <!-- Left connections: Window → Gateways (fan out to 3) -->
+  <line x1="220" y1="342" x2="120" y2="400" stroke="#CCC" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="260" y1="342" x2="280" y2="400" stroke="#CCC" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="300" y1="342" x2="440" y2="400" stroke="#DDD" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <text x="140" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">WEBSOCKET</text>
+
+  <!-- Right connection: Window → Workspace -->
+  <line x1="620" y1="342" x2="680" y2="400" stroke="#0B8A0A" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="3,3"/>
+  <text x="640" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">LOCAL-FIRST</text>
+
+  <!-- ==================== GATEWAY INSTANCES ==================== -->
+
+  <!-- Gateway 1: Production -->
+  <rect x="30" y="400" width="180" height="75" rx="10" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+  <circle cx="48" cy="420" r="4" fill="#0B8A0A"/>
+  <text x="58" y="424" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Production</text>
+  <text x="48" y="444" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12 agents · 8 tools</text>
+  <text x="48" y="462" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 2: Staging -->
+  <rect x="220" y="400" width="180" height="75" rx="10" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+  <circle cx="238" cy="420" r="4" fill="#E8A817"/>
+  <text x="248" y="424" fill="#1A1A1A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Staging</text>
+  <text x="238" y="444" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">4 agents · 15 tools</text>
+  <text x="238" y="462" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 3: Local -->
+  <rect x="410" y="400" width="180" height="75" rx="10" fill="#FAFAFA" stroke="#E8E8E8" stroke-width="1"/>
+  <circle cx="428" cy="420" r="4" fill="#CCC"/>
+  <text x="438" y="424" fill="#555" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Local Dev</text>
+  <text x="428" y="444" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">2 agents · 3 tools</text>
+  <text x="428" y="462" fill="#BBB" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">localhost:18789</text>
+
+  <!-- Label under gateways -->
+  <text x="300" y="498" text-anchor="middle" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="1.5">OPENCLAW GATEWAYS</text>
+
+  <!-- ==================== WORKSPACE BOX ==================== -->
+  <rect x="600" y="400" width="210" height="75" rx="10" fill="#F0FAF0" stroke="#0B8A0A" stroke-width="0.8" stroke-opacity="0.3"/>
+  <text x="705" y="424" text-anchor="middle" fill="#0B8A0A" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="600">Your Workspace</text>
+  <text x="705" y="444" text-anchor="middle" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">SQLite + FTS5 · Searchable</text>
+  <text x="705" y="462" text-anchor="middle" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Tasks · Messages · Artifacts</text>
+
+</svg>

--- a/website/public/architecture.svg
+++ b/website/public/architecture.svg
@@ -1,0 +1,174 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="840" height="540" viewBox="0 0 840 540">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#111"/>
+      <stop offset="100%" stop-color="#0A0A0A"/>
+    </linearGradient>
+    <radialGradient id="topGlow" cx="50%" cy="0%" r="60%">
+      <stop offset="0%" stop-color="#0FFD0D" stop-opacity="0.07"/>
+      <stop offset="100%" stop-color="#0FFD0D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="windowShadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="14" flood-color="#000" flood-opacity="0.5"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="840" height="540" fill="url(#bg)"/>
+  <rect width="840" height="300" fill="url(#topGlow)"/>
+
+  <!-- ==================== APP WINDOW ==================== -->
+  <g transform="translate(90, 28)" filter="url(#windowShadow)">
+    <!-- Window frame -->
+    <rect width="660" height="310" rx="10" fill="#1C1C1C" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- Title bar -->
+    <rect width="660" height="34" rx="10" fill="#171717"/>
+    <rect y="22" width="660" height="12" fill="#171717"/>
+    <line y1="34" x2="660" y2="34" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- Traffic lights -->
+    <circle cx="18" cy="17" r="5.5" fill="#FF5F57"/>
+    <circle cx="36" cy="17" r="5.5" fill="#FEBC2E"/>
+    <circle cx="54" cy="17" r="5.5" fill="#28C840"/>
+
+    <!-- Logo + Title -->
+    <svg x="284" y="5" width="22" height="22" viewBox="0 0 128 128">
+      <g transform="translate(0,128) scale(0.1,-0.1)" fill="#E03030" stroke="none">
+        <path d="M749 1068 c-36 -13 -91 -39 -123 -58 -72 -43 -177 -153 -211 -220 -50 -98 -68 -215 -44 -290 6 -19 10 -62 10 -96 -2 -71 23 -118 79 -147 74 -39 194 0 262 84 18 22 48 48 68 57 126 60 211 240 182 392 -11 63 -47 150 -62 150 -4 0 -13 -13 -18 -29 -17 -48 -82 -111 -153 -146 -37 -19 -76 -46 -88 -61 -12 -15 -21 -22 -21 -16 0 19 49 69 80 82 16 7 30 17 30 22 0 6 14 39 32 75 22 46 53 84 106 134 41 38 72 72 69 75 -3 4 -34 8 -69 10 -48 4 -78 -1 -129 -18z"/>
+      </g>
+    </svg>
+    <text x="335" y="22" text-anchor="middle" fill="#CCC" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="500">ClawWork</text>
+
+    <!-- Panel dividers -->
+    <line x1="160" y1="34" x2="160" y2="310" stroke="#3A3A3A" stroke-width="0.5"/>
+    <line x1="475" y1="34" x2="475" y2="310" stroke="#3A3A3A" stroke-width="0.5"/>
+
+    <!-- ===== LEFT PANEL: Tasks ===== -->
+    <text x="14" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">TASKS</text>
+
+    <!-- Active task -->
+    <rect x="8" y="67" width="144" height="32" rx="6" fill="#1A3A1A"/>
+    <circle cx="21" cy="83" r="4" fill="#0FFD0D"/>
+    <text x="32" y="88" fill="#F5F5F7" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">Research API docs</text>
+
+    <!-- Idle tasks -->
+    <rect x="8" y="105" width="144" height="32" rx="6" fill="#242424"/>
+    <circle cx="21" cy="121" r="4" fill="#777"/>
+    <text x="32" y="126" fill="#BFBFBF" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Refactor auth flow</text>
+
+    <rect x="8" y="143" width="144" height="32" rx="6" fill="#242424"/>
+    <circle cx="21" cy="159" r="4" fill="#777"/>
+    <text x="32" y="164" fill="#BFBFBF" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">Write unit tests</text>
+
+    <!-- Cron section -->
+    <text x="14" y="200" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">SCHEDULED</text>
+
+    <rect x="8" y="210" width="144" height="28" rx="6" fill="none" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.4"/>
+    <text x="21" y="228" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" opacity="0.8">Daily report</text>
+    <text x="134" y="228" text-anchor="end" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.5">09:00</text>
+
+    <rect x="8" y="244" width="144" height="28" rx="6" fill="none" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.4"/>
+    <text x="21" y="262" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" opacity="0.8">Weekly digest</text>
+    <text x="134" y="262" text-anchor="end" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9" opacity="0.5">Mon</text>
+
+    <!-- ===== CENTER PANEL: Active Work ===== -->
+    <text x="172" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ACTIVE WORK</text>
+
+    <!-- Streaming reply -->
+    <text x="172" y="80" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">I'll analyze the API endpoints and</text>
+    <text x="172" y="98" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12.5">document the authentication flow</text>
+    <!-- Cursor -->
+    <rect x="387" y="88" width="2" height="14" rx="1" fill="#0FFD0D"/>
+
+    <!-- Tool call card -->
+    <rect x="172" y="114" width="290" height="46" rx="8" fill="#1E1E1E" stroke="#3A3A3A" stroke-width="0.5"/>
+    <circle cx="189" cy="132" r="4.5" fill="#0FFD0D" opacity="0.9"/>
+    <text x="200" y="136" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">read_file</text>
+    <text x="200" y="152" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">src/auth/middleware.ts</text>
+
+    <!-- Approval card -->
+    <rect x="172" y="168" width="290" height="46" rx="8" fill="#2A2214" stroke="#FEBC2E" stroke-width="0.5" stroke-opacity="0.4"/>
+    <circle cx="189" cy="186" r="4.5" fill="#FEBC2E" opacity="0.9"/>
+    <text x="200" y="190" fill="#FEBC2E" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="500">exec — approval needed</text>
+    <text x="200" y="206" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">npm run db:migrate</text>
+
+    <!-- Thinking trace -->
+    <rect x="172" y="224" width="290" height="32" rx="6" fill="#1A1A1E"/>
+    <text x="185" y="244" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11" font-style="italic">Analyzing dependency graph...</text>
+
+    <!-- Cost bar -->
+    <rect x="172" y="270" width="290" height="24" rx="4" fill="#1A1A1A" stroke="#333" stroke-width="0.5"/>
+    <text x="183" y="286" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12.4k tokens · $0.03 · Sonnet 4</text>
+
+    <!-- ===== RIGHT PANEL: Artifacts ===== -->
+    <text x="487" y="57" fill="#AAA" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" letter-spacing="1">ARTIFACTS</text>
+
+    <!-- Files -->
+    <rect x="483" y="67" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="87" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">auth-flow.md</text>
+
+    <rect x="483" y="102" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="122" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">diagram.png</text>
+
+    <rect x="483" y="137" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="157" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">middleware.ts</text>
+
+    <rect x="483" y="172" width="168" height="30" rx="6" fill="#242424"/>
+    <text x="498" y="192" fill="#F0F0F2" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12">test-report.md</text>
+
+    <!-- Search bar -->
+    <rect x="483" y="218" width="168" height="28" rx="14" fill="#1A1A1A" stroke="#444" stroke-width="0.5"/>
+    <text x="504" y="236" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11">Search artifacts...</text>
+
+    <!-- Auto-extract badge -->
+    <rect x="483" y="264" width="168" height="28" rx="6" fill="#0FFD0D" fill-opacity="0.08" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.35"/>
+    <text x="498" y="282" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" opacity="0.8">Auto-extracted · 4 new</text>
+  </g>
+
+  <!-- ==================== CONNECTIONS ==================== -->
+
+  <!-- Left connections: Window → Gateways (fan out to 3) -->
+  <line x1="220" y1="342" x2="120" y2="400" stroke="#555" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="260" y1="342" x2="280" y2="400" stroke="#555" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="300" y1="342" x2="440" y2="400" stroke="#444" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <text x="140" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">WEBSOCKET</text>
+
+  <!-- Right connection: Window → Workspace -->
+  <line x1="620" y1="342" x2="680" y2="400" stroke="#0FFD0D" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="3,3"/>
+  <text x="640" y="374" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="0.8">LOCAL-FIRST</text>
+
+  <!-- ==================== GATEWAY INSTANCES ==================== -->
+
+  <!-- Gateway 1: Production (primary) -->
+  <rect x="30" y="400" width="180" height="75" rx="10" fill="#1A1A1A" stroke="#3A3A3A" stroke-width="0.5"/>
+  <circle cx="48" cy="420" r="4" fill="#0FFD0D"/>
+  <text x="58" y="424" fill="#E0E0E0" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Production</text>
+  <text x="48" y="444" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">12 agents · 8 tools</text>
+  <text x="48" y="462" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 2: Staging -->
+  <rect x="220" y="400" width="180" height="75" rx="10" fill="#1A1A1A" stroke="#3A3A3A" stroke-width="0.5"/>
+  <circle cx="238" cy="420" r="4" fill="#FEBC2E"/>
+  <text x="248" y="424" fill="#E0E0E0" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Staging</text>
+  <text x="238" y="444" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">4 agents · 15 tools</text>
+  <text x="238" y="462" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Multi-model routing</text>
+
+  <!-- Gateway 3: Local -->
+  <rect x="410" y="400" width="180" height="75" rx="10" fill="#161616" stroke="#333" stroke-width="0.5"/>
+  <circle cx="428" cy="420" r="4" fill="#777"/>
+  <text x="438" y="424" fill="#BBB" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="12" font-weight="600">Local Dev</text>
+  <text x="428" y="444" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">2 agents · 3 tools</text>
+  <text x="428" y="462" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">localhost:18789</text>
+
+  <!-- Label under gateways -->
+  <text x="300" y="498" text-anchor="middle" fill="#777" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" letter-spacing="1.5">OPENCLAW GATEWAYS</text>
+
+  <!-- ==================== WORKSPACE BOX ==================== -->
+  <rect x="600" y="400" width="210" height="75" rx="10" fill="#0FFD0D" fill-opacity="0.05" stroke="#0FFD0D" stroke-width="0.6" stroke-opacity="0.3"/>
+  <text x="705" y="424" text-anchor="middle" fill="#0FFD0D" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="600">Your Workspace</text>
+  <text x="705" y="444" text-anchor="middle" fill="#999" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">SQLite + FTS5 · Searchable</text>
+  <text x="705" y="462" text-anchor="middle" fill="#888" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5">Tasks · Messages · Artifacts</text>
+
+</svg>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -3,6 +3,7 @@ import { Header } from './components/Header';
 import { Hero } from './components/Hero';
 import { InstallBlock } from './components/InstallBlock';
 import { Features } from './components/Features';
+import { Architecture } from './components/Architecture';
 import { QuickStart } from './components/QuickStart';
 import { Footer } from './components/Footer';
 
@@ -14,6 +15,7 @@ export function App() {
         <Hero />
         <InstallBlock />
         <Features />
+        <Architecture />
         <QuickStart />
       </main>
       <Footer />

--- a/website/src/components/Architecture.tsx
+++ b/website/src/components/Architecture.tsx
@@ -1,0 +1,56 @@
+import { useI18n } from '../i18n/context';
+import { useScrollReveal } from '../hooks/useScrollReveal';
+
+export function Architecture() {
+  const { t } = useI18n();
+  const titleRef = useScrollReveal();
+  const imgRef = useScrollReveal(120);
+
+  return (
+    <section id="architecture" style={{ padding: '80px 24px', background: '#111' }}>
+      <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+        <div ref={titleRef}>
+          <h2
+            style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono Variable", monospace)',
+              fontSize: '28px',
+              fontWeight: 700,
+              color: '#f3f4f4',
+              margin: '0 0 12px 0',
+              textAlign: 'center',
+            }}
+          >
+            {t.architecture.title}
+          </h2>
+          <p
+            style={{
+              fontSize: '16px',
+              color: '#9ca3af',
+              textAlign: 'center',
+              margin: '0 0 40px 0',
+              maxWidth: '640px',
+              marginLeft: 'auto',
+              marginRight: 'auto',
+              lineHeight: 1.6,
+            }}
+          >
+            {t.architecture.subtitle}
+          </p>
+        </div>
+        <div ref={imgRef} style={{ textAlign: 'center' }}>
+          <img
+            src={`${import.meta.env.BASE_URL}architecture.svg`}
+            alt="ClawWork Architecture"
+            style={{
+              display: 'block',
+              width: '100%',
+              maxWidth: '840px',
+              margin: '0 auto',
+              borderRadius: '12px',
+            }}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useI18n } from '../i18n/context';
 
 const NAV_LINKS = [
   { key: 'features' as const, href: '#features' },
+  { key: 'architecture' as const, href: '#architecture' },
   { key: 'quickStart' as const, href: '#quick-start' },
 ];
 

--- a/website/src/i18n/en.ts
+++ b/website/src/i18n/en.ts
@@ -1,6 +1,7 @@
 export interface Translations {
   nav: {
     features: string;
+    architecture: string;
     quickStart: string;
     github: string;
   };
@@ -15,6 +16,10 @@ export interface Translations {
     title: string;
     orDownload: string;
     githubReleases: string;
+  };
+  architecture: {
+    title: string;
+    subtitle: string;
   };
   features: {
     title: string;
@@ -35,6 +40,7 @@ export interface Translations {
 export const en: Translations = {
   nav: {
     features: 'Features',
+    architecture: 'Architecture',
     quickStart: 'Quick Start',
     github: 'GitHub',
   },
@@ -49,6 +55,11 @@ export const en: Translations = {
     title: 'Install',
     orDownload: 'Or download from',
     githubReleases: 'GitHub Releases',
+  },
+  architecture: {
+    title: 'How It Works',
+    subtitle:
+      'A single WebSocket connects to one or more OpenClaw Gateways. Each task gets its own session. Everything is stored locally.',
   },
   features: {
     title: 'Why ClawWork',

--- a/website/src/i18n/zh.ts
+++ b/website/src/i18n/zh.ts
@@ -3,6 +3,7 @@ import type { Translations } from './en';
 export const zh: Translations = {
   nav: {
     features: '功能',
+    architecture: '架构',
     quickStart: '快速开始',
     github: 'GitHub',
   },
@@ -17,6 +18,10 @@ export const zh: Translations = {
     title: '安装',
     orDownload: '或从',
     githubReleases: 'GitHub Releases',
+  },
+  architecture: {
+    title: '工作原理',
+    subtitle: '通过单一 WebSocket 连接一个或多个 OpenClaw 网关。每个任务拥有独立会话。所有数据本地存储。',
   },
   features: {
     title: '为什么选择 ClawWork',


### PR DESCRIPTION
## Summary

Comprehensive documentation refresh: rewrite README with product-focused language and new features, add architecture SVG diagrams (dark + light), integrate architecture section into the website, and update keynote slides with new content and layout fixes.

## Type of change

- [x] `[Docs]` documentation-only change

## Why is this needed?

README was outdated — missing cron scheduling, notifications, agent management, auto-extract, auto-update, and other shipped features. Architecture was shown as ASCII art. Website had no architecture section. Keynote slides had image overflow issues and outdated version references.

## What changed?

- **README.md**: Rewritten with product-focused language, updated features list, new "What it stores" / "Repo layout" / "Tech stack" / "Platform notes" sections, updated roadmap (v0.0.10), architecture SVG replacing ASCII diagram
- **docs/architecture.svg** + **docs/architecture-light.svg**: New product-showcase SVG diagrams with three-panel app wireframe, multi-gateway visualization, vector logo, dark and light variants
- **website/src/components/Architecture.tsx**: New Architecture section between Features and QuickStart
- **website/src/components/Header.tsx**: Added "Architecture" nav link
- **website/src/i18n/en.ts** + **zh.ts**: Added architecture translations and nav key
- **website/src/App.tsx**: Integrated Architecture component
- **website/public/**: Copied both SVG variants
- **keynote/slides.md**: Updated architecture slide (left-right layout), added About Me slide, updated Current Status to v0.0.10, added GitHub card CTA, replaced release history, fixed image overflow on all screenshot slides
- **keynote/public/images/architecture.svg**: Copied dark SVG
- **package.json**: Added `pnpm dev:website` script

## Architecture impact

- Owning layer: shared (none) / main (none) / preload (none) / renderer (none)
- Cross-layer impact: none — documentation and website only
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: no code changes to desktop app

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
Lint and architecture check passed via pre-commit hook.
Website typecheck passed: pnpm --filter @clawwork/website exec tsc --noEmit
```

## Screenshots or recordings

Architecture diagram (dark):
![architecture](https://raw.githubusercontent.com/clawwork-ai/ClawWork/docs/readme-architecture-keynote-update/docs/architecture.svg)

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Docs]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate