### PR TITLE
[Feat] Add Local tab to @ mention picker for workspace files

### DIFF
--- a/packages/desktop/src/renderer/components/ChatInput.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput.tsx
@@ -15,6 +15,7 @@ import {
   Minimize2,
   RotateCcw,
   File,
+  FileCode,
   FolderPlus,
   ListTodo,
 } from 'lucide-react';
@@ -25,6 +26,7 @@ import type {
   Task,
   Artifact,
   FileIndexEntry,
+  FileReadResult,
 } from '@clawwork/shared';
 import { toast } from 'sonner';
 import { markAbortedByUser } from '@/hooks/useGatewayDispatcher';
@@ -148,6 +150,8 @@ export default function ChatInput() {
   const [mentionTab, setMentionTab] = useState<MentionTab>('tasks');
   const [selectedTasks, setSelectedTasks] = useState<Task[]>([]);
   const [selectedArtifacts, setSelectedArtifacts] = useState<Artifact[]>([]);
+  const [selectedLocalFiles, setSelectedLocalFiles] = useState<FileIndexEntry[]>([]);
+  const [localFilesForPicker, setLocalFilesForPicker] = useState<FileIndexEntry[]>([]);
   const mentionItemsRef = useRef<MentionItem[]>([]);
   const mentionWasVisible = useRef(false);
 
@@ -409,6 +413,7 @@ export default function ChatInput() {
     prevTaskIdRef.current = key;
     setSelectedTasks([]);
     setSelectedArtifacts([]);
+    setSelectedLocalFiles([]);
   }, [activeTaskId, refreshContextFiles]);
 
   useEffect(() => {
@@ -485,6 +490,21 @@ export default function ChatInput() {
     });
   }, []);
 
+  const loadLocalFiles = useCallback(
+    async (query?: string) => {
+      if (contextFolders.length === 0) {
+        setLocalFilesForPicker([]);
+        return;
+      }
+      const res = await window.clawwork.listContextFiles(contextFolders, query);
+      if (res.ok && res.result) {
+        const files = res.result as unknown as FileIndexEntry[];
+        setLocalFilesForPicker(files.filter((f) => f.tier === 'text'));
+      }
+    },
+    [contextFolders],
+  );
+
   const updateMentionPicker = useCallback(() => {
     const ta = textareaRef.current;
     if (!ta) return;
@@ -493,8 +513,13 @@ export default function ChatInput() {
     const atMatch = before.match(/@([^\s@]*)$/);
     if (atMatch) {
       if (!mentionWasVisible.current) {
-        const hasArtifacts = useFileStore.getState().artifacts.length > 0;
-        setMentionTab(hasArtifacts ? 'files' : 'tasks');
+        if (contextFolders.length > 0) {
+          setMentionTab('local');
+        } else {
+          const hasArtifacts = useFileStore.getState().artifacts.length > 0;
+          setMentionTab(hasArtifacts ? 'files' : 'tasks');
+        }
+        loadLocalFiles();
       }
       mentionWasVisible.current = true;
       setMentionVisible(true);
@@ -504,7 +529,7 @@ export default function ChatInput() {
       mentionWasVisible.current = false;
       setMentionVisible(false);
     }
-  }, []);
+  }, [contextFolders, loadLocalFiles]);
 
   const closeMentionPicker = useCallback(() => {
     mentionWasVisible.current = false;
@@ -538,6 +563,13 @@ export default function ChatInput() {
         }
         stripAtQuery();
         setSelectedTasks((prev) => [...prev, item.task]);
+      } else if (item.kind === 'local') {
+        if (selectedLocalFiles.some((f) => f.absolutePath === item.file.absolutePath)) {
+          closeMentionPicker();
+          return;
+        }
+        stripAtQuery();
+        setSelectedLocalFiles((prev) => [...prev, item.file]);
       } else {
         if (selectedArtifacts.some((a) => a.id === item.artifact.id)) {
           closeMentionPicker();
@@ -548,7 +580,7 @@ export default function ChatInput() {
       }
       closeMentionPicker();
     },
-    [selectedTasks, selectedArtifacts, closeMentionPicker, stripAtQuery],
+    [selectedTasks, selectedArtifacts, selectedLocalFiles, closeMentionPicker, stripAtQuery],
   );
 
   const removeSelectedTask = useCallback((taskId: string) => {
@@ -557,6 +589,10 @@ export default function ChatInput() {
 
   const removeSelectedArtifact = useCallback((id: string) => {
     setSelectedArtifacts((prev) => prev.filter((a) => a.id !== id));
+  }, []);
+
+  const removeSelectedLocalFile = useCallback((path: string) => {
+    setSelectedLocalFiles((prev) => prev.filter((f) => f.absolutePath !== path));
   }, []);
 
   const handleMentionItemsChange = useCallback((items: MentionItem[]) => {
@@ -590,9 +626,11 @@ export default function ChatInput() {
     const images = [...pendingImages];
     const taskMentions = [...selectedTasks];
     const artifactMentions = [...selectedArtifacts];
+    const localFileMentions = [...selectedLocalFiles];
     setPendingImages([]);
     setSelectedTasks([]);
     setSelectedArtifacts([]);
+    setSelectedLocalFiles([]);
 
     try {
       let finalContent = content || '';
@@ -661,6 +699,36 @@ export default function ChatInput() {
         }
       }
 
+      if (localFileMentions.length > 0) {
+        const readResults = await Promise.all(
+          localFileMentions.map((f) =>
+            window.clawwork.readContextFile(f.absolutePath, contextFolders).then((res) => ({ file: f, res })),
+          ),
+        );
+
+        const localBlocks: string[] = [];
+        let totalLocalSize = 0;
+
+        for (const { file: f, res } of readResults) {
+          if (!res.ok || !res.result) continue;
+          const read = res.result as unknown as FileReadResult;
+
+          if (read.tier === 'text') {
+            const blockSize = new TextEncoder().encode(read.content).length;
+            totalLocalSize += blockSize;
+            if (totalLocalSize > MAX_TEXT_TOTAL) {
+              toast.error('Total file context exceeds 500KB limit');
+              break;
+            }
+            localBlocks.push(`<file path="${f.relativePath}">\n${read.content}\n</file>`);
+          }
+        }
+
+        if (localBlocks.length > 0) {
+          finalContent = localBlocks.join('\n\n') + '\n\n' + finalContent;
+        }
+      }
+
       const msgImages: MessageImageAttachment[] | undefined = images.length
         ? images.map((img) => ({ fileName: img.file.name, dataUrl: img.previewUrl }))
         : undefined;
@@ -671,6 +739,7 @@ export default function ChatInput() {
       if (!task.title) {
         const titleSource =
           content ||
+          (localFileMentions.length ? `[@${localFileMentions[0].fileName}]` : '') ||
           (taskMentions.length ? `[@${taskMentions[0].title}]` : '') ||
           (artifactMentions.length ? `[@${artifactMentions[0].name}]` : '') ||
           (images.length ? `[${t('chatInput.image')}]` : '');
@@ -772,6 +841,8 @@ export default function ChatInput() {
     pendingImages,
     selectedTasks,
     selectedArtifacts,
+    selectedLocalFiles,
+    contextFolders,
     stopVoiceInput,
     commitPendingTask,
     updateTaskMetadata,
@@ -885,10 +956,17 @@ export default function ChatInput() {
       }
 
       if (mentionVisible) {
-        if (e.key === 'Tab') {
+        if (e.key === 'Tab' || e.key === 'ArrowRight') {
           e.preventDefault();
-          const tabs: MentionTab[] = ['tasks', 'files'];
+          const tabs: MentionTab[] = contextFolders.length > 0 ? ['local', 'tasks', 'files'] : ['tasks', 'files'];
           setMentionTab((cur) => tabs[(tabs.indexOf(cur) + 1) % tabs.length]);
+          setMentionIndex(0);
+          return;
+        }
+        if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const tabs: MentionTab[] = contextFolders.length > 0 ? ['local', 'tasks', 'files'] : ['tasks', 'files'];
+          setMentionTab((cur) => tabs[(tabs.indexOf(cur) - 1 + tabs.length) % tabs.length]);
           setMentionIndex(0);
           return;
         }
@@ -986,6 +1064,7 @@ export default function ChatInput() {
       mentionIndex,
       commitMention,
       closeMentionPicker,
+      contextFolders,
       argPickerVisible,
       argPickerOptions,
       argPickerIndex,
@@ -1281,10 +1360,13 @@ export default function ChatInput() {
             visible={mentionVisible}
             query={mentionQuery}
             tasks={mentionableTasks}
+            localFiles={localFilesForPicker}
+            hasContextFolders={contextFolders.length > 0}
             activeTab={mentionTab}
             selectedIndex={mentionIndex}
             onSelectTask={(task) => commitMention({ kind: 'task', task })}
             onSelectArtifact={(a) => commitMention({ kind: 'file', artifact: a })}
+            onSelectLocalFile={(f) => commitMention({ kind: 'local', file: f })}
             onTabChange={(tab) => {
               setMentionTab(tab);
               setMentionIndex(0);
@@ -1342,8 +1424,26 @@ export default function ChatInput() {
             </motion.div>
 
             <div className="flex-1 relative min-h-[24px]">
-              {(selectedTasks.length > 0 || selectedArtifacts.length > 0) && (
+              {(selectedTasks.length > 0 || selectedArtifacts.length > 0 || selectedLocalFiles.length > 0) && (
                 <div className="flex flex-wrap gap-1.5 pb-2">
+                  {selectedLocalFiles.map((f) => (
+                    <span
+                      key={f.absolutePath}
+                      className={cn(
+                        'inline-flex items-center gap-1 text-xs px-2 py-1 rounded-lg',
+                        'bg-[var(--accent)]/10 text-[var(--accent)]',
+                      )}
+                    >
+                      <FileCode size={14} className="flex-shrink-0" />
+                      {f.relativePath}
+                      <button
+                        onClick={() => removeSelectedLocalFile(f.absolutePath)}
+                        className="ml-0.5 opacity-50 hover:opacity-100"
+                      >
+                        <X size={12} />
+                      </button>
+                    </span>
+                  ))}
                   {selectedTasks.map((task) => (
                     <span
                       key={`task-${task.id}`}

--- a/packages/desktop/src/renderer/components/MentionPicker.tsx
+++ b/packages/desktop/src/renderer/components/MentionPicker.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useRef, useMemo } from 'react';
-import { File, FileCode, Image as ImageIcon, ListTodo } from 'lucide-react';
-import type { Task, Artifact } from '@clawwork/shared';
+import { File, FileCode, FolderOpen, Image as ImageIcon, ListTodo } from 'lucide-react';
+import type { Task, Artifact, FileIndexEntry } from '@clawwork/shared';
 import { useFileStore } from '@/stores/fileStore';
 import { cn, formatFileSize } from '@/lib/utils';
 
-export type MentionTab = 'tasks' | 'files';
+export type MentionTab = 'local' | 'tasks' | 'files';
 
-export type MentionItem = { kind: 'task'; task: Task } | { kind: 'file'; artifact: Artifact };
+export type MentionItem =
+  | { kind: 'task'; task: Task }
+  | { kind: 'file'; artifact: Artifact }
+  | { kind: 'local'; file: FileIndexEntry };
 
-const TABS: { id: MentionTab; label: string; icon: typeof ListTodo }[] = [
+const ALL_TABS: { id: MentionTab; label: string; icon: typeof ListTodo }[] = [
+  { id: 'local', label: 'Local', icon: FolderOpen },
   { id: 'tasks', label: 'Tasks', icon: ListTodo },
   { id: 'files', label: 'Files', icon: File },
 ];
@@ -17,10 +21,13 @@ interface MentionPickerProps {
   visible: boolean;
   query: string;
   tasks: Task[];
+  localFiles: FileIndexEntry[];
+  hasContextFolders: boolean;
   activeTab: MentionTab;
   selectedIndex: number;
   onSelectTask: (task: Task) => void;
   onSelectArtifact: (artifact: Artifact) => void;
+  onSelectLocalFile: (file: FileIndexEntry) => void;
   onTabChange: (tab: MentionTab) => void;
   onHoverIndex: (index: number) => void;
   onItemsChange?: (items: MentionItem[]) => void;
@@ -36,10 +43,13 @@ export default function MentionPicker({
   visible,
   query,
   tasks,
+  localFiles,
+  hasContextFolders,
   activeTab,
   selectedIndex,
   onSelectTask,
   onSelectArtifact,
+  onSelectLocalFile,
   onTabChange,
   onHoverIndex,
   onItemsChange,
@@ -63,15 +73,26 @@ export default function MentionPicker({
     });
   }, [visible, artifacts.length, setArtifacts]);
 
+  const tabs = useMemo(() => {
+    if (hasContextFolders) return ALL_TABS;
+    return ALL_TABS.filter((t) => t.id !== 'local');
+  }, [hasContextFolders]);
+
   const items = useMemo<MentionItem[]>(() => {
     const q = query.toLowerCase();
+    if (activeTab === 'local') {
+      const filtered = q
+        ? localFiles.filter((f) => f.fileName.toLowerCase().includes(q) || f.relativePath.toLowerCase().includes(q))
+        : localFiles;
+      return filtered.map((f) => ({ kind: 'local' as const, file: f }));
+    }
     if (activeTab === 'tasks') {
       const filtered = q ? tasks.filter((t) => t.title.toLowerCase().includes(q)) : tasks;
       return filtered.map((t) => ({ kind: 'task' as const, task: t }));
     }
     const filtered = q ? artifacts.filter((a) => a.name.toLowerCase().includes(q)) : artifacts;
     return filtered.map((a) => ({ kind: 'file' as const, artifact: a }));
-  }, [activeTab, query, tasks, artifacts]);
+  }, [activeTab, query, tasks, artifacts, localFiles]);
 
   useEffect(() => {
     onItemsChange?.(items);
@@ -94,7 +115,7 @@ export default function MentionPicker({
       )}
     >
       <div className="flex border-b border-[var(--border-subtle)]">
-        {TABS.map((tab) => {
+        {tabs.map((tab) => {
           const Icon = tab.icon;
           return (
             <button
@@ -118,9 +139,37 @@ export default function MentionPicker({
       <div ref={listRef} className="max-h-56 overflow-y-auto py-1">
         {items.length === 0 && (
           <div className="px-3 py-4 text-center text-xs text-[var(--text-muted)]">
-            {activeTab === 'tasks' ? 'No matching tasks' : 'No matching files'}
+            {activeTab === 'local'
+              ? 'No matching local files'
+              : activeTab === 'tasks'
+                ? 'No matching tasks'
+                : 'No matching files'}
           </div>
         )}
+
+        {activeTab === 'local' &&
+          items.map((item, i) => {
+            if (item.kind !== 'local') return null;
+            const f = item.file;
+            return (
+              <button
+                key={f.absolutePath}
+                data-mention-selected={i === selectedIndex ? '' : undefined}
+                className={cn(
+                  'w-full flex items-center gap-2.5 px-3 py-2 text-left text-sm',
+                  'hover:bg-[var(--bg-hover)] transition-colors',
+                  i === selectedIndex && 'bg-[var(--bg-hover)]',
+                )}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => onSelectLocalFile(f)}
+                onMouseEnter={() => onHoverIndex(i)}
+              >
+                <FileCode size={14} className="text-[var(--accent)] flex-shrink-0" />
+                <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{f.relativePath}</span>
+                <span className="flex-shrink-0 text-xs text-[var(--text-muted)]">{formatFileSize(f.size)}</span>
+              </button>
+            );
+          })}
 
         {activeTab === 'tasks' &&
           items.map((item, i) => {
@@ -174,7 +223,7 @@ export default function MentionPicker({
 
       <div className="flex items-center gap-2 border-t border-[var(--border-subtle)] px-3 py-1.5 text-[11px] text-[var(--text-muted)]">
         <span>
-          <kbd className="px-1 py-0.5 rounded bg-[var(--bg-tertiary)] font-mono">Tab</kbd> switch
+          <kbd className="px-1 py-0.5 rounded bg-[var(--bg-tertiary)] font-mono">←→</kbd> switch
         </span>
         <span>
           <kbd className="px-1 py-0.5 rounded bg-[var(--bg-tertiary)] font-mono">↑↓</kbd> navigate


### PR DESCRIPTION
## Summary

Add a "Local" tab to the @ mention picker that lists files from linked context folders, prioritizing local workspace files when folders are associated with a task.

## Type of change

- [x] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

When users link a context folder to a task, pressing `@` only shows Tasks and Files (artifacts from File Manager). There is no way to reference local workspace files from the linked folder via the mention picker. Users expect the linked folder's files to appear first — that's the whole point of linking a folder.

## What changed?

- Extended `MentionTab` type to include `'local'` and `MentionItem` to include `{ kind: 'local'; file: FileIndexEntry }`
- MentionPicker dynamically shows Local/Tasks/Files tabs when context folders exist, otherwise Tasks/Files only
- Local tab filters by `relativePath` and `fileName`, displays relative path + file size
- ChatInput loads local files via `listContextFiles` IPC when the picker opens
- Selected local files read via `readContextFile` on send, injected as `<file>` XML context
- Left/Right arrow keys now switch tabs (in addition to Tab key)
- Selected local files display as green accent pills with `FileCode` icon

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none — uses existing `listContextFiles` / `readContextFile` IPC APIs already exposed in preload
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: no new IPC channels, no DB writes, no message persistence changes

## Linked issues

## Validation

- [x] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passes (only pre-existing file-watcher.ts:35 error)
eslint + prettier — passed via pre-commit hook
```

## Screenshots or recordings

N/A — requires running Electron app with Gateway connection.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
The @ mention picker now shows a "Local" tab when context folders are linked, letting you reference workspace files directly. Arrow keys switch between tabs.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate