### PR TITLE
[Build] split macOS universal binary into separate arm64 and x64 builds

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -21,9 +21,15 @@ jobs:
         include:
           - os: macos-latest
             platform: mac
-            build_args: '--mac --universal'
+            arch: arm64
+            build_args: '--mac --arm64'
+          - os: macos-latest
+            platform: mac
+            arch: x64
+            build_args: '--mac --x64'
           - os: windows-latest
             platform: win
+            arch: x64
             build_args: '--win --x64'
 
     runs-on: ${{ matrix.os }}
@@ -88,7 +94,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dev-${{ matrix.platform }}
+          name: dev-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
             packages/desktop/dist/*.dmg
             packages/desktop/dist/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,15 @@ jobs:
         include:
           - os: macos-latest
             platform: mac
-            build_args: '--mac --universal'
+            arch: arm64
+            build_args: '--mac --arm64'
+          - os: macos-latest
+            platform: mac
+            arch: x64
+            build_args: '--mac --x64'
           - os: windows-latest
             platform: win
+            arch: x64
             build_args: '--win --x64'
 
     runs-on: ${{ matrix.os }}
@@ -113,7 +119,8 @@ jobs:
           ASSETS=$(gh release view "$RELEASE_TAG" --repo clawwork-ai/clawwork --json assets -q '.assets[].name')
           echo "Release assets:"
           echo "$ASSETS"
-          echo "$ASSETS" | grep -q "latest-mac.yml" || { echo "::error::latest-mac.yml missing from release"; exit 1; }
+          echo "$ASSETS" | grep -q "latest-mac-arm64.yml" || { echo "::error::latest-mac-arm64.yml missing from release"; exit 1; }
+          echo "$ASSETS" | grep -q "latest-mac.yml" || { echo "::error::latest-mac.yml (x64) missing from release"; exit 1; }
           echo "$ASSETS" | grep -q "latest.yml" || { echo "::error::latest.yml missing from release"; exit 1; }
           echo "All update metadata files present"
         env:

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -21,10 +21,12 @@ mac:
   target:
     - target: dmg
       arch:
-        - universal
+        - arm64
+        - x64
     - target: zip
       arch:
-        - universal
+        - arm64
+        - x64
   category: public.app-category.developer-tools
   icon: build/icon.icns
   hardenedRuntime: true

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
-    "build:mac": "electron-vite build && electron-builder --mac --universal",
+    "build:mac": "electron-vite build && electron-builder --mac --arm64",
+    "build:mac:x64": "electron-vite build && electron-builder --mac --x64",
     "build:win": "electron-vite build && electron-builder --win --x64",
     "preview": "electron-vite preview",
     "test": "vitest run",

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -11,38 +11,51 @@ if [[ -z "${RELEASE_TAG}" ]]; then
   exit 1
 fi
 
-asset_json="$(gh release view "${RELEASE_TAG}" -R "${CLAWWORK_REPO}" --json assets --jq '.assets[] | select(.name | endswith("-mac-universal.dmg"))' | head -n 1)"
-
-if [[ -z "${asset_json}" ]]; then
-  echo "No macOS universal DMG asset found for ${RELEASE_TAG}" >&2
-  exit 1
-fi
-
-asset_name="$(jq -r '.name' <<<"${asset_json}")"
-asset_url="$(jq -r '.url' <<<"${asset_json}")"
-asset_digest="$(jq -r '.digest // empty' <<<"${asset_json}")"
-sha256="${asset_digest#sha256:}"
 version="${RELEASE_TAG#v}"
 
-if [[ -z "${sha256}" ]]; then
-  tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "${tmp_dir}"' EXIT
+fetch_sha256() {
+  local arch="$1"
+  local asset_json
+  asset_json="$(gh release view "${RELEASE_TAG}" -R "${CLAWWORK_REPO}" --json assets --jq ".assets[] | select(.name | endswith(\"-mac-${arch}.dmg\"))" | head -n 1)"
 
-  gh release download "${RELEASE_TAG}" -R "${CLAWWORK_REPO}" --pattern "${asset_name}" --dir "${tmp_dir}"
-  sha256="$(shasum -a 256 "${tmp_dir}/${asset_name}" | awk '{print $1}')"
-fi
+  if [[ -z "${asset_json}" ]]; then
+    echo "No macOS ${arch} DMG asset found for ${RELEASE_TAG}" >&2
+    exit 1
+  fi
+
+  local asset_name asset_digest sha256
+  asset_name="$(jq -r '.name' <<<"${asset_json}")"
+  asset_digest="$(jq -r '.digest // empty' <<<"${asset_json}")"
+  sha256="${asset_digest#sha256:}"
+
+  if [[ -z "${sha256}" ]]; then
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "${tmp_dir}"' EXIT
+    gh release download "${RELEASE_TAG}" -R "${CLAWWORK_REPO}" --pattern "${asset_name}" --dir "${tmp_dir}"
+    sha256="$(shasum -a 256 "${tmp_dir}/${asset_name}" | awk '{print $1}')"
+  fi
+
+  echo "${sha256}"
+}
+
+sha256_arm64="$(fetch_sha256 arm64)"
+sha256_x64="$(fetch_sha256 x64)"
 
 mkdir -p "${TAP_DIR}/Casks"
 
 cat > "${TAP_DIR}/Casks/clawwork.rb" <<EOF
 cask "clawwork" do
-  version "${version}"
-  sha256 "${sha256}"
+  arch arm: "arm64", intel: "x64"
 
-  url "${asset_url}"
+  version "${version}"
+  sha256 arm:   "${sha256_arm64}",
+         intel: "${sha256_x64}"
+
+  url "https://github.com/${CLAWWORK_REPO}/releases/download/v#{version}/ClawWork-#{version}-mac-#{arch}.dmg"
   name "ClawWork"
   desc "Desktop client for OpenClaw"
-  homepage "https://github.com/clawwork-ai/clawwork"
+  homepage "https://github.com/${CLAWWORK_REPO}"
 
   app "ClawWork.app"
 


### PR DESCRIPTION
## Summary

This updates desktop packaging and release automation to publish separate macOS arm64 and x64 artifacts instead of a universal build. It also keeps release verification and Homebrew tap generation aligned with the new artifact layout.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [x] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Universal macOS packaging no longer matches the desired release strategy. Shipping architecture-specific builds reduces ambiguity in release assets and ensures update metadata and Homebrew distribution target the correct macOS binaries.

## What changed?

- Split macOS CI and release jobs into separate arm64 and x64 matrix entries
- Update `electron-builder` config and desktop package scripts to build per-architecture macOS artifacts
- Adjust release verification to require both macOS update metadata files
- Rewrite the Homebrew tap update script to resolve and checksum arm64 and x64 DMGs separately

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none directly; task/session isolation and process boundaries remain unchanged
- Why those invariants remain protected: the change is limited to packaging config, CI workflows, and release automation scripts without changing runtime session routing or renderer/main boundaries

## Linked issues

None.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
Not run in this PR flow.
```

## Screenshots or recordings

No UI changes.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
macOS releases now publish separate arm64 and x64 desktop installers and update metadata instead of a universal build.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate