### PR TITLE
[Fix] Delete stale dev release assets before uploading

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -110,6 +110,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Delete existing dev release
+        run: gh release delete dev --yes || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Force-update dev tag to current commit
         run: |
           git tag -f dev


### PR DESCRIPTION
## Summary

Fix the dev-release workflow to delete the existing `dev` release before uploading new build artifacts, preventing unbounded asset accumulation.

## Type of change

- [x] `[Fix]` bug fix
- [x] `[Build]` CI, packaging, or tooling change

## Why is this needed?

`softprops/action-gh-release` only appends assets — it never removes old ones. Every push to `main` added a new set of `.dmg`/`.zip`/`.exe`/`.blockmap` files to the `dev` release, causing the asset list to grow indefinitely.

## What changed?

- Added a `gh release delete dev --yes || true` step before the tag force-update and release creation, so each run starts with a clean slate.

## Architecture impact

- Owning layer: CI (GitHub Actions)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: N/A — CI-only change

## Linked issues

N/A

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [x] Not run

CI workflow change — will be validated on next push to `main`.

```text
N/A
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate