### PR TITLE
[Fix] Add explicit accelerators for macOS menu keyboard shortcuts

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -64,22 +64,55 @@ function setupDevScreenshot(win: BrowserWindow): void {
 function buildAppMenu(): Menu {
   const isMac = process.platform === 'darwin';
   const template: Electron.MenuItemConstructorOptions[] = [
-    ...(isMac ? [{ role: 'appMenu' as const }] : []),
+    ...(isMac
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: 'about' as const },
+              { type: 'separator' as const },
+              { role: 'services' as const },
+              { type: 'separator' as const },
+              { role: 'hide' as const, accelerator: 'Command+H' },
+              { role: 'hideOthers' as const, accelerator: 'Command+Alt+H' },
+              { role: 'unhide' as const },
+              { type: 'separator' as const },
+              { role: 'quit' as const, accelerator: 'Command+Q' },
+            ],
+          },
+        ]
+      : []),
+    {
+      label: 'File',
+      submenu: [isMac ? { role: 'close' as const, accelerator: 'Command+W' } : { role: 'quit' as const }],
+    },
     { role: 'editMenu' as const },
     {
       label: 'View',
       submenu: [
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
-        { type: 'separator' },
-        { role: 'reload' },
-        { role: 'toggleDevTools' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' },
+        { role: 'resetZoom' as const },
+        { role: 'zoomIn' as const },
+        { role: 'zoomOut' as const },
+        { type: 'separator' as const },
+        { role: 'reload' as const },
+        { role: 'toggleDevTools' as const },
+        { type: 'separator' as const },
+        { role: 'togglefullscreen' as const },
       ],
     },
-    ...(isMac ? [{ role: 'windowMenu' as const }] : []),
+    ...(isMac
+      ? [
+          {
+            label: 'Window',
+            submenu: [
+              { role: 'minimize' as const, accelerator: 'Command+M' },
+              { role: 'zoom' as const },
+              { type: 'separator' as const },
+              { role: 'front' as const },
+            ],
+          },
+        ]
+      : []),
   ];
   return Menu.buildFromTemplate(template);
 }


### PR DESCRIPTION
## Summary

macOS keyboard shortcuts (Cmd+H, Cmd+W, Cmd+Q) were all non-functional. The app menu relied on Electron's role-based macro expansion (`role: 'appMenu'`, `role: 'windowMenu'`) which leaves `accelerator=null` and depends on native macOS fallback — a fallback that stopped working on macOS 16 Tahoe. Additionally, `fileMenu` was never included, so Cmd+W (Close Window) had no menu item at all.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Users on macOS cannot use standard system shortcuts: Cmd+H (hide), Cmd+W (close window), Cmd+Q (quit), Cmd+M (minimize). This makes the app feel broken and forces users to use the mouse for basic window management.

## What changed?

- Replaced `role: 'appMenu'` macro with an explicit submenu containing About, Services, Hide, Hide Others, Unhide, Quit — each with explicit `accelerator` values
- Added a `File` menu with `Close Window (Cmd+W)` (was completely missing before)
- Replaced `role: 'windowMenu'` macro with an explicit Window submenu containing Minimize, Zoom, Bring All to Front — with explicit `accelerator` for Minimize

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is isolated to the Electron app menu definition

## Linked issues

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — pass
pnpm test — 95/95 pass
Verified menu structure via `pnpm exec electron` test script:
  Cmd+H → Hide (accelerator: Command+H)
  Cmd+Q → Quit (accelerator: Command+Q)
  Cmd+W → Close Window (accelerator: Command+W)
  Cmd+M → Minimize (accelerator: Command+M)
  Cmd+Alt+H → Hide Others (accelerator: Command+Alt+H)
```

## Screenshots or recordings

N/A — no UI change, only native macOS menu bar behavior.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fix macOS keyboard shortcuts (Cmd+H, Cmd+W, Cmd+Q, Cmd+M) that stopped working due to missing explicit accelerators in the app menu.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate