### PR TITLE
Add three quality gates and update PR Check to include coverage

### DIFF
--- a/keynote/components/DeckQualityGatesSlide.vue
+++ b/keynote/components/DeckQualityGatesSlide.vue
@@ -1,6 +1,24 @@
 <script setup lang="ts">
 const guards = [
   {
+    cmd: 'knip',
+    zh: '死代码/无引用导出扫描接入 check 与 CI',
+    en: 'Dead-code + unused-export scan wired into check and CI',
+    tone: 'red' as const,
+  },
+  {
+    cmd: 'test:coverage',
+    zh: 'Vitest 覆盖率纳入 CI 测试环节',
+    en: 'Vitest coverage included in CI test stage',
+    tone: 'purple' as const,
+  },
+  {
+    cmd: 'VSCode workspace',
+    zh: '保存即格式化 + ESLint 修复 + 工作区 TS SDK',
+    en: 'Format-on-save + ESLint fixes + workspace TS SDK',
+    tone: 'cyan' as const,
+  },
+  {
     cmd: 'check:architecture',
     zh: '会话 Key 必须走 buildSessionKey()',
     en: 'Session key via buildSessionKey() only',
@@ -45,7 +63,12 @@ const pipeline = [
     en: 'Husky: lint-staged + arch check',
     tone: 'green' as const,
   },
-  { stage: 'PR Check', zh: '8 项质量门 + 3 平台构建', en: '8 quality gates + 3-platform build', tone: 'cyan' as const },
+  {
+    stage: 'PR Check',
+    zh: '9 项质量门 + coverage 测试 + 3 平台构建',
+    en: '9 quality gates + coverage tests + 3-platform build',
+    tone: 'cyan' as const,
+  },
   {
     stage: 'E2E',
     zh: 'Playwright: Smoke + Gateway (Docker)',


### PR DESCRIPTION
### Motivation

- Surface additional quality gates and developer workspace requirements in the presentation slide to reflect new checks and CI policies. 
- Clarify that coverage is now part of the PR validation stage and increment the count of quality gates. 

### Description

- Updated `keynote/components/DeckQualityGatesSlide.vue` to add three new guards: `knip` (dead-code / unused-export scan), `test:coverage` (Vitest coverage in CI), and `VSCode workspace` (format-on-save + ESLint fixes + workspace TS SDK). 
- Adjusted the `pipeline` entry for `PR Check` to change the messaging from `8 quality gates` to `9 quality gates` and added `coverage tests` to the English and Chinese labels. 
- Kept existing guard entries and presentation markup intact; changes are strictly content/strings in the slide component. 

### Testing

- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b50e01e4833084f013ddcbe404cd)