### PR TITLE
docs(keynote): polish slides with version tags, data refresh, and layout fixes

### DIFF
--- a/keynote/components/DeckCoverSlide.vue
+++ b/keynote/components/DeckCoverSlide.vue
@@ -32,10 +32,8 @@
       <div class="cw-meta-row">
         <span>samzong</span>
         <span>·</span>
-        <span class="en">OpenClaw Community</span>
-        <span class="zh">OpenClaw 社区</span>
-        <span>·</span>
-        <span>2026</span>
+        <span class="en">Updated 2026-03-26</span>
+        <span class="zh">更新于 2026-03-26</span>
       </div>
     </div>
 

--- a/keynote/components/DeckFeatureMatrixSlide.vue
+++ b/keynote/components/DeckFeatureMatrixSlide.vue
@@ -1,25 +1,25 @@
 <script setup lang="ts">
 const features = [
-  { icon: '🛡', zh: '工具审批', en: 'Tool Approval', tone: 'red' as const, stars: 2 },
-  { icon: '🔗', zh: '多网关', en: 'Multi-Gateway', tone: 'green' as const, stars: 2 },
-  { icon: '⏰', zh: '定时任务', en: 'Cron Jobs', tone: 'yellow' as const, stars: 2 },
-  { icon: '📊', zh: '用量面板', en: 'Token Dashboard', tone: 'green' as const, stars: 2 },
-  { icon: '🧠', zh: '思考深度', en: 'Thinking Depth', tone: 'purple' as const, stars: 2 },
-  { icon: '🤖', zh: 'Agent 管理', en: 'Agent Manager', tone: 'cyan' as const, stars: 1 },
-  { icon: '@', zh: '跨任务引用', en: '@ Mentions', tone: 'cyan' as const, stars: 1 },
-  { icon: '⌘', zh: '斜杠命令', en: 'Slash Commands', tone: 'green' as const, stars: 1 },
-  { icon: '📂', zh: '本地文件监听', en: 'File Watching', tone: 'yellow' as const, stars: 1 },
-  { icon: '🔀', zh: '模型切换', en: 'Model Switch', tone: 'cyan' as const, stars: 1 },
-  { icon: '📋', zh: '工具执行记录', en: 'Tool Logs', tone: 'yellow' as const, stars: 1 },
-  { icon: '🎙', zh: '语音输入', en: 'Voice Input', tone: 'purple' as const, stars: 1 },
-  { icon: '📤', zh: '会话导出', en: 'Session Export', tone: 'purple' as const, stars: 0 },
-  { icon: '🔄', zh: '自动更新', en: 'Auto-Update', tone: 'green' as const, stars: 0 },
-  { icon: '🔍', zh: '全文搜索', en: 'Full-Text Search', tone: 'purple' as const, stars: 0 },
-  { icon: '🔔', zh: '桌面通知', en: 'Notifications', tone: 'purple' as const, stars: 0 },
-  { icon: '🏷', zh: '设备标识', en: 'Device Identity', tone: 'yellow' as const, stars: 0 },
-  { icon: '🌐', zh: '8 种语言', en: '8 Languages', tone: 'green' as const, stars: 0 },
-  { icon: '🎨', zh: '主题切换', en: 'Dark / Light', tone: 'cyan' as const, stars: 0 },
-  { icon: '🖼', zh: '图片上传', en: 'Image Upload', tone: 'cyan' as const, stars: 0 },
+  { icon: '🛡', zh: '工具审批', en: 'Tool Approval', tone: 'red' as const, stars: 2, ver: 'v0.0.6' },
+  { icon: '🔗', zh: '多网关', en: 'Multi-Gateway', tone: 'green' as const, stars: 2, ver: 'v0.0.3' },
+  { icon: '⏰', zh: '定时任务', en: 'Cron Jobs', tone: 'yellow' as const, stars: 2, ver: 'v0.0.11' },
+  { icon: '📊', zh: '用量面板', en: 'Token Dashboard', tone: 'green' as const, stars: 2, ver: 'v0.0.7' },
+  { icon: '🧠', zh: '思考深度', en: 'Thinking Depth', tone: 'purple' as const, stars: 2, ver: 'v0.0.3' },
+  { icon: '🤖', zh: 'Agent 管理', en: 'Agent Manager', tone: 'cyan' as const, stars: 1, ver: 'v0.0.10' },
+  { icon: '@', zh: '跨任务引用', en: '@ Mentions', tone: 'cyan' as const, stars: 1, ver: 'v0.0.7' },
+  { icon: '⌘', zh: '斜杠命令', en: 'Slash Commands', tone: 'green' as const, stars: 1, ver: 'v0.0.4' },
+  { icon: '📂', zh: '本地文件监听', en: 'File Watching', tone: 'yellow' as const, stars: 1, ver: 'v0.0.11' },
+  { icon: '🔀', zh: '模型切换', en: 'Model Switch', tone: 'cyan' as const, stars: 1, ver: 'v0.0.3' },
+  { icon: '📋', zh: '工具执行记录', en: 'Tool Logs', tone: 'yellow' as const, stars: 1, ver: 'v0.0.2' },
+  { icon: '🎙', zh: '语音输入', en: 'Voice Input', tone: 'purple' as const, stars: 1, ver: 'v0.0.4' },
+  { icon: '📤', zh: '会话导出', en: 'Session Export', tone: 'purple' as const, stars: 0, ver: 'v0.0.10' },
+  { icon: '🔄', zh: '自动更新', en: 'Auto-Update', tone: 'green' as const, stars: 0, ver: 'v0.0.10' },
+  { icon: '🔍', zh: '全文搜索', en: 'Full-Text Search', tone: 'purple' as const, stars: 0, ver: 'v0.0.8' },
+  { icon: '🔔', zh: '桌面通知', en: 'Notifications', tone: 'purple' as const, stars: 0, ver: 'v0.0.11' },
+  { icon: '🏷', zh: '设备标识', en: 'Device Identity', tone: 'yellow' as const, stars: 0, ver: 'v0.0.9' },
+  { icon: '🌐', zh: '8 种语言', en: '8 Languages', tone: 'green' as const, stars: 0, ver: 'v0.0.12' },
+  { icon: '🎨', zh: '主题切换', en: 'Dark / Light', tone: 'cyan' as const, stars: 0, ver: 'v0.0.1' },
+  { icon: '🖼', zh: '图片上传', en: 'Image Upload', tone: 'cyan' as const, stars: 0, ver: 'v0.0.2' },
 ];
 
 const next = [
@@ -35,10 +35,13 @@ function starLabel(n: number) {
 <template>
   <div class="cw-feature-matrix">
     <div v-for="f in features" :key="f.en" class="cw-feature-cell" :data-tone="f.tone">
-      <span class="cw-feature-cell-icon">{{ f.icon }}</span>
-      <span class="en cw-feature-cell-label">{{ f.en }}</span>
-      <span class="zh cw-feature-cell-label">{{ f.zh }}</span>
-      <span v-if="f.stars" class="cw-feature-cell-stars">{{ starLabel(f.stars) }}</span>
+      <div class="cw-feature-cell-main">
+        <span class="cw-feature-cell-icon">{{ f.icon }}</span>
+        <span class="en cw-feature-cell-label">{{ f.en }}</span>
+        <span class="zh cw-feature-cell-label">{{ f.zh }}</span>
+        <span v-if="f.stars" class="cw-feature-cell-stars">{{ starLabel(f.stars) }}</span>
+      </div>
+      <span class="cw-feature-cell-ver">{{ f.ver }}</span>
     </div>
   </div>
   <div class="cw-feature-next-row">

--- a/keynote/components/DeckQualityGatesSlide.vue
+++ b/keynote/components/DeckQualityGatesSlide.vue
@@ -1,6 +1,18 @@
 <script setup lang="ts">
 const guards = [
   {
+    cmd: 'knip',
+    zh: '死代码/无引用导出扫描接入 check 与 CI',
+    en: 'Dead-code + unused-export scan wired into check and CI',
+    tone: 'red' as const,
+  },
+  {
+    cmd: 'test:coverage',
+    zh: 'Vitest 覆盖率纳入 CI 测试环节',
+    en: 'Vitest coverage included in CI test stage',
+    tone: 'purple' as const,
+  },
+  {
     cmd: 'check:architecture',
     zh: '会话 Key 必须走 buildSessionKey()',
     en: 'Session key via buildSessionKey() only',
@@ -45,7 +57,12 @@ const pipeline = [
     en: 'Husky: lint-staged + arch check',
     tone: 'green' as const,
   },
-  { stage: 'PR Check', zh: '8 项质量门 + 3 平台构建', en: '8 quality gates + 3-platform build', tone: 'cyan' as const },
+  {
+    stage: 'PR Check',
+    zh: '8 项质量门 + coverage 测试 + 3 平台构建',
+    en: '8 quality gates + coverage tests + 3-platform build',
+    tone: 'cyan' as const,
+  },
   {
     stage: 'E2E',
     zh: 'Playwright: Smoke + Gateway (Docker)',
@@ -63,7 +80,7 @@ const pipeline = [
 
 <template>
   <div class="cw-split cw-split--media cw-mt-16" style="align-items: stretch">
-    <div class="cw-stack-md">
+    <div class="cw-stack-sm">
       <div v-for="g in guards" :key="g.cmd" class="cw-guard-row" :data-tone="g.tone">
         <span class="cw-guard-cmd">{{ g.cmd }}</span>
         <span class="en cw-guard-desc">{{ g.en }}</span>

--- a/keynote/components/DeckVibeCodingSlide.vue
+++ b/keynote/components/DeckVibeCodingSlide.vue
@@ -1,23 +1,29 @@
 <script setup lang="ts">
 const days = [
-  { en: 'Fri 3/13', zh: '周五 3/13', prs: 7, enPhase: 'Kickoff', zhPhase: '起步', tone: 'green' as const },
-  { en: 'Sat 3/14', zh: '周六 3/14', prs: 6, enPhase: 'Accelerate', zhPhase: '加速', tone: 'cyan' as const },
-  { en: 'Sun 3/15', zh: '周日 3/15', prs: 10, enPhase: 'Accelerate', zhPhase: '加速', tone: 'cyan' as const },
-  { en: 'Mon 3/16', zh: '周一 3/16', prs: 23, enPhase: 'Explosion', zhPhase: '爆发', tone: 'purple' as const },
-  { en: 'Tue 3/17', zh: '周二 3/17', prs: 13, enPhase: 'Infra', zhPhase: '基建', tone: 'yellow' as const },
-  { en: 'Wed 3/18', zh: '周三 3/18', prs: 10, enPhase: 'Polish', zhPhase: '打磨', tone: 'cyan' as const },
-  { en: 'Thu 3/19', zh: '周四 3/19', prs: 13, enPhase: 'Security', zhPhase: '安全', tone: 'red' as const },
+  { en: 'Fri 3/13', zh: '周五 3/13', prs: 11, enPhase: 'Kickoff', zhPhase: '起步', tone: 'green' as const },
+  { en: 'Sat 3/14', zh: '周六 3/14', prs: 11, enPhase: 'Accelerate', zhPhase: '加速', tone: 'cyan' as const },
+  { en: 'Sun 3/15', zh: '周日 3/15', prs: 4, enPhase: 'Accelerate', zhPhase: '加速', tone: 'cyan' as const },
+  { en: 'Mon 3/16', zh: '周一 3/16', prs: 25, enPhase: 'Explosion', zhPhase: '爆发', tone: 'purple' as const },
+  { en: 'Tue 3/17', zh: '周二 3/17', prs: 14, enPhase: 'Infra', zhPhase: '基建', tone: 'yellow' as const },
+  { en: 'Wed 3/18', zh: '周三 3/18', prs: 14, enPhase: 'Polish', zhPhase: '打磨', tone: 'cyan' as const },
+  { en: 'Thu 3/19', zh: '周四 3/19', prs: 18, enPhase: 'Security', zhPhase: '安全', tone: 'red' as const },
+  { en: 'Sun 3/22', zh: '周日 3/22', prs: 4, enPhase: 'Stabilize', zhPhase: '稳定', tone: 'yellow' as const },
+  { en: 'Mon 3/23', zh: '周一 3/23', prs: 17, enPhase: 'Ship v10', zhPhase: '发版', tone: 'green' as const },
+  { en: 'Tue 3/24', zh: '周二 3/24', prs: 8, enPhase: 'Expand', zhPhase: '扩展', tone: 'cyan' as const },
+  { en: 'Wed 3/25', zh: '周三 3/25', prs: 9, enPhase: 'i18n + DX', zhPhase: '国际化', tone: 'purple' as const },
+  { en: 'Thu 3/26', zh: '周四 3/26', prs: 4, enPhase: 'Toolchain', zhPhase: '工具链', tone: 'red' as const },
 ];
 
 const maxPrs = Math.max(...days.map((d) => d.prs));
 
 const stats = [
-  { value: '28', label: 'feat', tone: 'green' as const },
-  { value: '30', label: 'fix', tone: 'red' as const },
+  { value: '53', label: 'fix', tone: 'red' as const },
+  { value: '44', label: 'feat', tone: 'green' as const },
+  { value: '11', label: 'docs', tone: 'purple' as const },
+  { value: '9', label: 'build', tone: 'yellow' as const },
+  { value: '8', label: 'refactor', tone: 'cyan' as const },
+  { value: '8', label: 'chore', tone: 'green' as const },
   { value: '6', label: 'UI', tone: 'cyan' as const },
-  { value: '5', label: 'build', tone: 'yellow' as const },
-  { value: '5', label: 'docs', tone: 'purple' as const },
-  { value: '4', label: 'chore', tone: 'green' as const },
 ];
 
 const tools = [
@@ -46,7 +52,7 @@ const tools = [
       <div class="cw-stat-card" data-tone="green">
         <div class="en cw-stat-label">Total PRs Merged</div>
         <div class="zh cw-stat-label">PR 合并总数</div>
-        <div class="cw-stat-value">82</div>
+        <div class="cw-stat-value">139</div>
       </div>
 
       <div class="cw-sprint-breakdown">

--- a/keynote/slides.md
+++ b/keynote/slides.md
@@ -20,13 +20,13 @@ favicon: ''
 
 ---
 
-# <span class="en">About Me</span><span class="zh">关于我</span>
+# 👋 <span class="en">About Me</span><span class="zh">关于我</span>
 
 <DeckAboutMeSlide />
 
 ---
 
-# <span class="en">Pain Points of Using OpenClaw</span><span class="zh">养虾的痛点</span>
+# 😤 <span class="en">Pain Points of Using OpenClaw</span><span class="zh">养虾的痛点</span>
 
 <div class="en cw-kicker">"One window, one task, one context."</div>
 <div class="zh cw-kicker">"一个窗口，一个任务，一个上下文。"</div>
@@ -72,7 +72,7 @@ favicon: ''
 
 ---
 
-# <span class="en">What is ClawWork</span><span class="zh">ClawWork 是什么</span>
+# 🦐 <span class="en">What is ClawWork</span><span class="zh">ClawWork 是什么</span>
 
 <div class="en cw-kicker">A desktop client for OpenClaw, <strong>built for parallel work</strong>.</div>
 <div class="zh cw-kicker">一个 OpenClaw 桌面客户端，<strong>为并行工作而生</strong>。</div>
@@ -97,8 +97,8 @@ favicon: ''
   <DeckFeatureCard
     tone="purple"
     icon="📦"
-    en-title="Artifact Aggregation"
-    zh-title="产物聚合"
+    en-title="File Management"
+    zh-title="文件管理"
     en-body="Every Agent output is automatically collected, browsable, and searchable."
     zh-body="所有 Agent 产出自动收集，可浏览，可搜索。"
   />
@@ -112,7 +112,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Launch Sprint</span><span class="zh">启动冲刺</span>
+# 🚀 <span class="en">Launch Sprint</span><span class="zh">启动冲刺</span>
 
 <div class="en cw-kicker">10 Releases in 12 Days</div>
 <div class="zh cw-kicker">12 天发布 10 个版本</div>
@@ -172,7 +172,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Architecture at a Glance</span><span class="zh">架构概览</span>
+# 🏗 <span class="en">Architecture at a Glance</span><span class="zh">架构概览</span>
 
 <div class="en cw-kicker">Single WebSocket, <strong>Multiple Gateways, Parallel Sessions</strong></div>
 <div class="zh cw-kicker">单 WebSocket，<strong>多 Gateway，并行会话</strong></div>
@@ -188,7 +188,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Three-Panel Layout</span><span class="zh">三栏布局</span>
+# 🖥 <span class="en">Three-Panel Layout</span><span class="zh">三栏布局</span>
 
 <div class="en cw-kicker">Left, Center, Right. Everything visible at once.</div>
 <div class="zh cw-kicker">左、中、右。一目了然。</div>
@@ -204,7 +204,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Multi-Session in Action</span><span class="zh">多会话实战</span>
+# ⚡ <span class="en">Multi-Session in Action</span><span class="zh">多会话实战</span>
 
 <div class="en cw-kicker">Three tasks running in parallel. Each with isolated context.</div>
 <div class="zh cw-kicker">三个任务并行运行。各自独立上下文。</div>
@@ -220,7 +220,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Artifact Aggregation</span><span class="zh">产物聚合</span>
+# 📂 <span class="en">File Management</span><span class="zh">文件管理</span>
 
 <div class="en cw-kicker">Every file the Agent produces, automatically collected.</div>
 <div class="zh cw-kicker">Agent 产出的每一个文件，自动收集。</div>
@@ -258,13 +258,13 @@ favicon: ''
 
 ---
 
-# <span class="en">Task Progress Tracking</span><span class="zh">任务进度追踪</span>
+# 📊 <span class="en">Task Progress Tracking</span><span class="zh">任务进度追踪</span>
 
 <DeckTaskProgressSlide />
 
 ---
 
-# <span class="en">Token & Context Awareness</span><span class="zh">Token 与上下文感知</span>
+# 🧠 <span class="en">Token & Context Awareness</span><span class="zh">Token 与上下文感知</span>
 
 <div class="en cw-kicker">You always know how much runway you have.</div>
 <div class="zh cw-kicker">你始终知道还剩多少空间。</div>
@@ -273,7 +273,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Feature Matrix</span><span class="zh">功能大全</span>
+# 🧩 <span class="en">Feature Matrix</span><span class="zh">功能大全</span>
 
 <div class="en cw-kicker">20 capabilities beyond chat. All shipped.</div>
 <div class="zh cw-kicker">20 项超越聊天的能力，全部已发布。</div>
@@ -282,13 +282,13 @@ favicon: ''
 
 ---
 
-# <span class="en">Tech Stack</span><span class="zh">技术栈</span>
+# 🔧 <span class="en">Tech Stack</span><span class="zh">技术栈</span>
 
 <DeckTechStackSlide />
 
 ---
 
-# <span class="en">Lessons from Gateway Integration</span><span class="zh">Gateway 集成踩坑记</span>
+# ⚠️ <span class="en">Lessons from Gateway Integration</span><span class="zh">Gateway 集成踩坑记</span>
 
 <div class="en cw-kicker">Things we learned the hard way, so you do not have to.</div>
 <div class="zh cw-kicker">我们踩过的坑，帮你提前避开。</div>
@@ -331,7 +331,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Dev Workflow</span><span class="zh">开发工作流</span>
+# 🔄 <span class="en">Dev Workflow</span><span class="zh">开发工作流</span>
 
 <div class="en cw-kicker">Vibe Coding: requirement → parallel worktrees → auto review → ship.</div>
 <div class="zh cw-kicker">Vibe Coding：需求 → 并行 worktree → 自动 review → 发版。</div>
@@ -340,7 +340,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Engineering Quality</span><span class="zh">工程质量体系</span>
+# 🛡 <span class="en">Engineering Quality</span><span class="zh">工程质量体系</span>
 
 <div class="en cw-kicker">Solo developer, <strong>production-grade guardrails</strong>.</div>
 <div class="zh cw-kicker">一个人开发，<strong>生产级护栏</strong>。</div>
@@ -349,7 +349,7 @@ favicon: ''
 
 ---
 
-# <span class="en">Open Source Collaboration</span><span class="zh">开源协作</span>
+# 🤝 <span class="en">Open Source Collaboration</span><span class="zh">开源协作</span>
 
 <div class="en cw-kicker">From first clone to merged PR.</div>
 <div class="zh cw-kicker">从 clone 到 PR 合并。</div>
@@ -358,16 +358,16 @@ favicon: ''
 
 ---
 
-# <span class="en">Sprint Breakdown</span><span class="zh">冲刺全景</span>
+# 📈 <span class="en">Sprint Breakdown</span><span class="zh">冲刺全景</span>
 
-<div class="en cw-kicker">7 Days · 82 PRs · 1.2B Tokens</div>
-<div class="zh cw-kicker">7 天 · 82 个 PR · 1.2B Token</div>
+<div class="en cw-kicker">14 Days · 139 PRs · 1.2B Tokens</div>
+<div class="zh cw-kicker">14 天 · 139 个 PR · 1.2B Token</div>
 
 <DeckVibeCodingSlide />
 
 ---
 
-# <span class="en">Community Signal</span><span class="zh">社区信号</span>
+# ⭐ <span class="en">Community Signal</span><span class="zh">社区信号</span>
 
 <div class="cw-grid-2">
   <DeckSignalCard

--- a/keynote/style.css
+++ b/keynote/style.css
@@ -1294,6 +1294,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
+  height: 100%;
 }
 
 .cw-thanks-copy {
@@ -1399,7 +1400,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 14px;
+  padding: 6px 12px;
   border-radius: var(--cw-radius-sm);
   background: var(--cw-tone-soft);
   border: 1px solid var(--cw-tone-border);
@@ -1422,9 +1423,9 @@
 .cw-pipeline {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: space-evenly;
   height: 100%;
-  gap: 12px;
+  gap: 0;
 }
 
 .cw-pipeline-step {
@@ -1592,9 +1593,9 @@
 
 .cw-feature-cell {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
   border-radius: var(--cw-radius-sm);
   background: var(--cw-tone-soft);
   border: 1px solid var(--cw-tone-border);
@@ -1603,12 +1604,21 @@
     box-shadow 0.25s ease;
 }
 
+.cw-feature-cell-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .cw-feature-cell:hover {
   transform: translateY(-2px);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
 }
 
 .cw-feature-cell--next {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
   border-style: dashed;
   opacity: 0.75;
 }
@@ -1626,11 +1636,19 @@
 }
 
 .cw-feature-cell-stars {
-  margin-left: auto;
   font-size: 0.6rem;
   color: var(--cw-yellow);
   flex-shrink: 0;
   letter-spacing: 1px;
+}
+
+.cw-feature-cell-ver {
+  margin-left: calc(1.05rem + 8px);
+  font-family: var(--cw-font-mono);
+  font-size: 0.5rem;
+  line-height: 1;
+  color: var(--cw-text-muted);
+  opacity: 0.5;
 }
 
 .cw-feature-next-row {
@@ -1667,22 +1685,22 @@
 .cw-sprint-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
   font-size: 0.8rem;
 }
 
 .cw-sprint-day {
-  width: 80px;
+  width: 68px;
   flex-shrink: 0;
   font-family: var(--cw-font-mono);
-  font-size: 0.88rem;
+  font-size: 0.82rem;
   color: var(--cw-text-muted);
 }
 
 .cw-sprint-bar-track {
   flex: 1;
-  height: 24px;
-  border-radius: 6px;
+  height: 18px;
+  border-radius: 5px;
   background: var(--cw-bg-panel);
   overflow: hidden;
 }
@@ -1705,11 +1723,13 @@
 }
 
 .cw-sprint-phase {
-  width: 40px;
-  font-size: 0.88rem;
+  width: 72px;
+  flex-shrink: 0;
+  font-size: 0.78rem;
   font-weight: 600;
   color: var(--cw-tone);
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
+  text-align: right;
 }
 
 .cw-sprint-breakdown {


### PR DESCRIPTION
## Summary

- Remove `VSCode workspace` from quality gates (editor config, not a CI gate); fix gate count 9→8
- Add version tags (v0.0.1–v0.0.12) to each Feature Matrix entry, sourced from git history
- Rename "Artifact Aggregation" → "File Management" across slides
- Add emoji prefix to all 18 slide titles
- Update Sprint Breakdown with latest GitHub data: 7→14 days, 82→139 PRs, 7→12 timeline rows
- Fix layout overflow on quality gates (p16) and sprint timeline (p18)
- Center Thanks page (p20) vertically
- Add `Updated 2026-03-26` date to cover slide

## Test plan

- [ ] `pnpm dev:slides` — verify all 20 pages render without overflow
- [ ] Check p12 (Feature Matrix) version badges display correctly
- [ ] Check p16 (Engineering Quality) right-side pipeline not clipped
- [ ] Check p18 (Sprint Breakdown) left/right columns do not overlap
- [ ] Check p20 (Thanks) content is vertically centered
- [ ] Toggle EN/ZH to verify both languages