### PR TITLE
[Fix] Remove private key leak and raw IPC backdoor from preload bridge

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -56,7 +56,6 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
-    "@electron-toolkit/preload": "^3.0.0",
     "@electron-toolkit/utils": "^4.0.0",
     "@tailwindcss/vite": "^4.0.0",
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/desktop/src/main/ipc/settings-handlers.ts
+++ b/packages/desktop/src/main/ipc/settings-handlers.ts
@@ -3,7 +3,6 @@ import { readConfig, updateConfig, writeConfig, buildGatewayAuth } from '../work
 import type { AppConfig, GatewayServerConfig } from '../workspace/config.js';
 import { getGatewayClient, addGateway, removeGateway } from '../ws/index.js';
 import { GatewayClient } from '../ws/gateway-client.js';
-import { loadOrCreateDeviceIdentity } from '../ws/device-identity.js';
 import { SUPPORTED_LANGUAGE_CODES } from '@clawwork/shared';
 import type { GatewayAuth } from '@clawwork/shared';
 
@@ -13,7 +12,6 @@ function getMainWindow(): BrowserWindow | null {
 }
 
 export function registerSettingsHandlers(): void {
-  ipcMain.handle('pairing:get-device-identity', () => loadOrCreateDeviceIdentity());
   ipcMain.handle('settings:get', (): AppConfig | null => {
     return readConfig();
   });

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -409,7 +409,6 @@ export interface ClawWorkAPI {
   setWindowButtonVisibility: (visible: boolean) => void;
 
   getDeviceId: () => Promise<string>;
-  getDeviceIdentity: () => Promise<{ deviceId: string; publicKeyPem: string; privateKeyPem: string }>;
 
   selectContextFolder: () => Promise<IpcResult>;
   listContextFiles: (folders: string[], query?: string) => Promise<IpcResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,5 +1,4 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { electronAPI } from '@electron-toolkit/preload';
 import type {
   ApprovalDecision,
   CronJobCreate,
@@ -285,12 +284,6 @@ function buildApi(): ClawWorkAPI {
     setWindowButtonVisibility: (visible: boolean) => ipcRenderer.send('ui:set-window-button-visibility', visible),
 
     getDeviceId: () => ipcRenderer.invoke('workspace:get-device-id') as Promise<string>,
-    getDeviceIdentity: () =>
-      ipcRenderer.invoke('pairing:get-device-identity') as Promise<{
-        deviceId: string;
-        publicKeyPem: string;
-        privateKeyPem: string;
-      }>,
 
     selectContextFolder: () => ipcRenderer.invoke('context:select-folder'),
     listContextFiles: (folders: string[], query?: string) =>
@@ -336,7 +329,6 @@ function buildApi(): ClawWorkAPI {
 
 if (process.contextIsolated) {
   try {
-    contextBridge.exposeInMainWorld('electron', electronAPI);
     contextBridge.exposeInMainWorld('clawwork', buildApi());
   } catch (error) {
     throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,6 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
-      '@electron-toolkit/preload':
-        specifier: ^3.0.0
-        version: 3.0.2(electron@34.5.8)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@34.5.8)
@@ -1007,11 +1004,6 @@ packages:
 
   '@drauu/core@1.0.0':
     resolution: {integrity: sha512-r1fPyuKaGuNHc8vxRFUT8LxqWjJ3nx+U+zsHcEOurmJoB7uN+zpFw5kTLInfdfvQZ+qF/ebQjw1AwbGcc1XKsQ==}
-
-  '@electron-toolkit/preload@3.0.2':
-    resolution: {integrity: sha512-TWWPToXd8qPRfSXwzf5KVhpXMfONaUuRAZJHsKthKgZR/+LqX1dZVSSClQ8OTAEduvLGdecljCsoT2jSshfoUg==}
-    peerDependencies:
-      electron: '>=13.0.0'
 
   '@electron-toolkit/utils@4.0.0':
     resolution: {integrity: sha512-qXSntwEzluSzKl4z5yFNBknmPGjPa3zFhE4mp9+h0cgokY5ornAeP+CJQDBhKsL1S58aOQfcwkD3NwLZCl+64g==}
@@ -8662,10 +8654,6 @@ snapshots:
       ajv-keywords: 3.5.2(ajv@6.14.0)
 
   '@drauu/core@1.0.0': {}
-
-  '@electron-toolkit/preload@3.0.2(electron@34.5.8)':
-    dependencies:
-      electron: 34.5.8
 
   '@electron-toolkit/utils@4.0.0(electron@34.5.8)':
     dependencies:


### PR DESCRIPTION
## Summary

Remove two unnecessary security surface expansions in the preload bridge: a private key leak via `getDeviceIdentity` and a raw IPC backdoor via `window.electron`.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The renderer process renders AI-generated markdown content — the most likely XSS attack surface. Two preload exposures violated Electron security best practice:

1. **`getDeviceIdentity`** returned the Ed25519 private key (the device authentication credential) to the renderer via `contextBridge`. Any XSS could exfiltrate it. Zero renderer code calls this method — `gateway-client.ts` consumes it directly in the main process.
2. **`window.electron`** exposed raw `ipcRenderer.send/invoke/on` from `@electron-toolkit/preload`, giving any compromised renderer an untyped IPC backdoor that bypasses the typed `ClawWorkAPI` boundary. Zero renderer code references it.

## What changed?

- Removed `getDeviceIdentity` property from `buildApi()` in `preload/index.ts`
- Removed `getDeviceIdentity` type declaration from `clawwork.d.ts`
- Removed `contextBridge.exposeInMainWorld('electron', electronAPI)` and its import
- Removed `pairing:get-device-identity` IPC handler and unused `loadOrCreateDeviceIdentity` import from `settings-handlers.ts`
- Removed unused `@electron-toolkit/preload` devDependency

## Architecture impact

- Owning layer: preload / main
- Cross-layer impact: none — zero renderer consumers exist for either removed surface
- Invariants touched from `docs/architecture-invariants.md`: preload bridge is the sole renderer↔main boundary; only typed `window.clawwork` is exposed
- Why those invariants remain protected: the typed `ClawWorkAPI` contract is unchanged; only dead, security-negative surfaces were removed

## Linked issues

N/A — proactive security hardening

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate: lint + architecture + ui-contract + renderer-copy + i18n + dead-code + format + typecheck + test)
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check — all green, 92 desktop tests + 59 pwa tests + 6 shared tests passed
grep -r getDeviceIdentity packages/desktop/src/renderer/ — no matches
grep -r window.electron packages/desktop/src/renderer/ — no matches
knip — @electron-toolkit/preload no longer flagged as unused (removed from package.json)
```

## Screenshots or recordings

No UI change.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Removed private key exposure and raw IPC backdoor from the renderer preload bridge. No functional change — neither surface had any renderer consumers.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate