### PR TITLE
[Fix] Eliminate TOCTOU race in context file path validation

### DIFF
--- a/packages/desktop/src/main/context/file-reader.ts
+++ b/packages/desktop/src/main/context/file-reader.ts
@@ -1,48 +1,39 @@
-import { openSync, readSync, closeSync, readFileSync, realpathSync, statSync } from 'fs';
+import { openSync, readSync, closeSync, fstatSync, realpathSync } from 'fs';
 import { extname, sep } from 'path';
 import type { FileReadResult } from '@clawwork/shared';
 import { classifyTier, getMimeType } from './file-types.js';
 
 const MAX_TEXT_SIZE = 100 * 1024;
 
-export function validatePathSecurity(absolutePath: string, contextFolders: string[]): boolean {
-  const realPath = realpathSync(absolutePath);
-  return contextFolders.some((folder) => {
-    const realFolder = realpathSync(folder);
-    return realPath.startsWith(realFolder + sep) || realPath === realFolder;
-  });
-}
+export function readContextFile(absolutePath: string, contextFolders: string[]): FileReadResult {
+  const fd = openSync(absolutePath, 'r');
+  try {
+    const realPath = realpathSync(`/dev/fd/${fd}`);
+    const allowed = contextFolders.some((folder) => {
+      const realFolder = realpathSync(folder);
+      return realPath.startsWith(realFolder + sep) || realPath === realFolder;
+    });
+    if (!allowed) throw new Error('path outside allowed context folders');
 
-export function readContextFile(absolutePath: string): FileReadResult {
-  const ext = extname(absolutePath).toLowerCase();
-  const tier = classifyTier(ext);
-  if (tier === 'unsupported') {
-    throw new Error(`unsupported file type: ${ext}`);
-  }
-  const stat = statSync(absolutePath);
+    const ext = extname(absolutePath).toLowerCase();
+    const tier = classifyTier(ext);
+    if (tier === 'unsupported') throw new Error(`unsupported file type: ${ext}`);
 
-  if (tier === 'text') {
-    const buf = Buffer.alloc(Math.min(stat.size, MAX_TEXT_SIZE));
-    const fd = openSync(absolutePath, 'r');
-    try {
+    const { size } = fstatSync(fd);
+
+    if (tier === 'text') {
+      const buf = Buffer.alloc(Math.min(size, MAX_TEXT_SIZE));
       readSync(fd, buf, 0, buf.length, 0);
-    } finally {
-      closeSync(fd);
+      let content = buf.toString('utf-8');
+      const truncated = size > MAX_TEXT_SIZE;
+      if (truncated) content += '\n[truncated at 100KB]';
+      return { content, mimeType: getMimeType(ext), size, truncated, tier };
     }
-    let content = buf.toString('utf-8');
-    const truncated = stat.size > MAX_TEXT_SIZE;
-    if (truncated) {
-      content += '\n[truncated at 100KB]';
-    }
-    return { content, mimeType: getMimeType(ext), size: stat.size, truncated, tier };
-  }
 
-  const raw = readFileSync(absolutePath);
-  return {
-    content: raw.toString('base64'),
-    mimeType: getMimeType(ext),
-    size: stat.size,
-    truncated: false,
-    tier,
-  };
+    const buf = Buffer.alloc(size);
+    readSync(fd, buf, 0, size, 0);
+    return { content: buf.toString('base64'), mimeType: getMimeType(ext), size, truncated: false, tier };
+  } finally {
+    closeSync(fd);
+  }
 }

--- a/packages/desktop/src/main/ipc/context-handlers.ts
+++ b/packages/desktop/src/main/ipc/context-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, dialog, BrowserWindow } from 'electron';
 import { scanFolder } from '../context/file-index.js';
-import { readContextFile, validatePathSecurity } from '../context/file-reader.js';
+import { readContextFile } from '../context/file-reader.js';
 import { watchFolder, unwatchFolder } from '../context/file-watcher.js';
 
 export function registerContextHandlers(): void {
@@ -56,13 +56,7 @@ export function registerContextHandlers(): void {
 
   ipcMain.handle('context:read-file', (_event, params: { absolutePath: string; folders: string[] }) => {
     try {
-      const folders = params?.folders ?? [];
-
-      if (!validatePathSecurity(params.absolutePath, folders)) {
-        return { ok: false, error: 'path outside provided context folders' };
-      }
-
-      const result = readContextFile(params.absolutePath);
+      const result = readContextFile(params.absolutePath, params?.folders ?? []);
       return { ok: true, result };
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'unknown error';


### PR DESCRIPTION
## Summary

Eliminate TOCTOU race condition in `validatePathSecurity` / `readContextFile` by merging validation and reading into a single fd-centric operation. After `openSync`, the file descriptor is pinned to an inode — all subsequent operations (realpath resolution, stat, read) go through the fd, never touching the original path again.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The previous implementation called `validatePathSecurity(path)` then `readContextFile(path)` as two separate steps. Between validation and read, a symlink in a user-added context folder (e.g. `/tmp`) could be swapped to point outside allowed folders. Additionally, within `readContextFile` itself, `statSync(path)` and the subsequent `openSync(path)` / `readFileSync(path)` had their own TOCTOU windows.

## What changed?

- `readContextFile` now accepts `contextFolders`, opens the fd first, validates via `realpathSync("/dev/fd/${fd}")`, uses `fstatSync(fd)` for size, and reads via `readSync(fd)` for both text and binary tiers
- `validatePathSecurity` removed — its logic is inlined into the atomic fd-based flow
- `context-handlers.ts` simplified: single `readContextFile(path, folders)` call replaces the two-step validate-then-read

## Architecture impact

- Owning layer: main
- Cross-layer impact: none — the IPC contract (`context:read-file` params) is unchanged
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: the change is internal to the main process file reader; preload and renderer are unaffected

## Linked issues

Closes #115

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check:architecture`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
pnpm check — all 157 tests pass, lint clean, typecheck clean
```

## Screenshots or recordings

No UI changes.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate