### PR TITLE
[Fix] PWA polish: remove type lies, dead config, and edge-swipe dead zone

### DIFF
--- a/packages/pwa/public/_headers
+++ b/packages/pwa/public/_headers
@@ -6,3 +6,6 @@
 
 /manifest.webmanifest
   Cache-Control: public, max-age=0, must-revalidate
+
+/sw.js
+  Cache-Control: public, max-age=0, must-revalidate

--- a/packages/pwa/src/persistence/db.ts
+++ b/packages/pwa/src/persistence/db.ts
@@ -83,19 +83,21 @@ let dbPromise: Promise<IDBPDatabase<ClawWorkDBSchema>> | null = null;
 function getDb(): Promise<IDBPDatabase<ClawWorkDBSchema>> {
   if (!dbPromise) {
     dbPromise = openDB<ClawWorkDBSchema>('clawwork-pwa', 1, {
-      upgrade(db) {
-        db.createObjectStore('identity', { keyPath: 'id' });
-        db.createObjectStore('gateways', { keyPath: 'id' });
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1) {
+          db.createObjectStore('identity', { keyPath: 'id' });
+          db.createObjectStore('gateways', { keyPath: 'id' });
 
-        const taskStore = db.createObjectStore('tasks', { keyPath: 'id' });
-        taskStore.createIndex('by-gateway', 'gatewayId');
-        taskStore.createIndex('by-updated', 'updatedAt');
+          const taskStore = db.createObjectStore('tasks', { keyPath: 'id' });
+          taskStore.createIndex('by-gateway', 'gatewayId');
+          taskStore.createIndex('by-updated', 'updatedAt');
 
-        const messageStore = db.createObjectStore('messages', { keyPath: 'id' });
-        messageStore.createIndex('by-task', 'taskId');
-        messageStore.createIndex('by-task-timestamp', ['taskId', 'timestamp']);
+          const messageStore = db.createObjectStore('messages', { keyPath: 'id' });
+          messageStore.createIndex('by-task', 'taskId');
+          messageStore.createIndex('by-task-timestamp', ['taskId', 'timestamp']);
 
-        db.createObjectStore('preferences', { keyPath: 'key' });
+          db.createObjectStore('preferences', { keyPath: 'key' });
+        }
       },
     });
   }

--- a/packages/pwa/src/platform/index.ts
+++ b/packages/pwa/src/platform/index.ts
@@ -39,8 +39,10 @@ export const ports = new Proxy({} as PlatformPorts, {
 
 export function getGatewayBroadcasters() {
   ensurePorts();
+  const result = _gwResult;
+  if (!result) throw new Error('Gateway transport not initialized');
   return {
-    broadcastEvent: _gwResult!.broadcastEvent,
-    broadcastStatus: _gwResult!.broadcastStatus,
+    broadcastEvent: result.broadcastEvent,
+    broadcastStatus: result.broadcastStatus,
   };
 }

--- a/packages/pwa/src/stores/hooks.ts
+++ b/packages/pwa/src/stores/hooks.ts
@@ -5,7 +5,7 @@ import { messageStoreApi, taskStoreApi, uiStoreApi } from './index.js';
 export function useMessageStore(): MessageState;
 export function useMessageStore<T>(selector: (state: MessageState) => T): T;
 export function useMessageStore<T>(selector?: (state: MessageState) => T) {
-  return useStore(messageStoreApi, selector!);
+  return selector ? useStore(messageStoreApi, selector) : useStore(messageStoreApi);
 }
 useMessageStore.getState = messageStoreApi.getState;
 useMessageStore.setState = messageStoreApi.setState;
@@ -14,7 +14,7 @@ useMessageStore.subscribe = messageStoreApi.subscribe;
 export function useTaskStore(): TaskState;
 export function useTaskStore<T>(selector: (state: TaskState) => T): T;
 export function useTaskStore<T>(selector?: (state: TaskState) => T) {
-  return useStore(taskStoreApi, selector!);
+  return selector ? useStore(taskStoreApi, selector) : useStore(taskStoreApi);
 }
 useTaskStore.getState = taskStoreApi.getState;
 useTaskStore.setState = taskStoreApi.setState;
@@ -23,7 +23,7 @@ useTaskStore.subscribe = taskStoreApi.subscribe;
 export function useUiStore(): UiState;
 export function useUiStore<T>(selector: (state: UiState) => T): T;
 export function useUiStore<T>(selector?: (state: UiState) => T) {
-  return useStore(uiStoreApi, selector!);
+  return selector ? useStore(uiStoreApi, selector) : useStore(uiStoreApi);
 }
 useUiStore.getState = uiStoreApi.getState;
 useUiStore.setState = uiStoreApi.setState;

--- a/packages/pwa/src/views/DrawerLayout.tsx
+++ b/packages/pwa/src/views/DrawerLayout.tsx
@@ -142,7 +142,7 @@ export function DrawerLayout({ onSignedOut }: DrawerLayoutProps) {
         {!drawerOpen && (
           <div
             className="fixed inset-y-0 left-0 z-30"
-            style={{ width: 20 }}
+            style={{ width: 12 }}
             onTouchStart={(e) => {
               edgeTouchRef.current = e.touches[0]!.clientX;
             }}

--- a/packages/pwa/tsconfig.json
+++ b/packages/pwa/tsconfig.json
@@ -2,10 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "noEmit": true
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary

Bundle six independent P3 polish items for the PWA package: eliminate non-null assertion type lies, remove dead tsconfig configuration, add missing service worker cache header, establish IndexedDB migration path, and reduce edge-swipe dead zone width.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Each item individually is small but collectively they address: (1) two `!` non-null assertions that lie to the type checker and mask potential runtime errors, (2) a dead `@/*` path alias that misleads contributors, (3) a missing `sw.js` cache header that relies on implicit browser behavior instead of explicit spec-compliant policy, (4) an IndexedDB upgrade callback with no version guard that will break on the first schema change, and (5) a 20px edge-swipe detector that creates an unnecessarily large tap dead zone.

## What changed?

- `stores/hooks.ts`: Replace `selector!` with conditional overload dispatch (`selector ? useStore(api, selector) : useStore(api)`) in all three store hooks
- `tsconfig.json`: Remove unused `baseUrl` and `paths` entries
- `public/_headers`: Add `/sw.js` with `Cache-Control: public, max-age=0, must-revalidate`
- `persistence/db.ts`: Add `oldVersion` parameter to upgrade callback and wrap store creation in `if (oldVersion < 1)`
- `platform/index.ts`: Replace `_gwResult!` with local variable extraction and runtime invariant check
- `views/DrawerLayout.tsx`: Reduce edge-swipe detector width from 20px to 12px

## Architecture impact

- Owning layer: renderer (PWA package)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: all changes are internal to the PWA package with no cross-layer or cross-package effects

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passed
pnpm test — 157 tests passed (shared 6, pwa 59, desktop 92)
pnpm lint — passed
pnpm check:architecture — passed
pnpm check:ui-contract — passed
```

## Screenshots or recordings

No UI changes beyond the edge-swipe detector width reduction (20px → 12px), which is invisible — it only affects the touch target area.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate