### PR TITLE
[Refactor] Extract client registry and eliminate composerBridge hack

### DIFF
--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -4,7 +4,7 @@ import { isPaired } from './persistence/db';
 import { reportDebugEvent } from './lib/debug';
 import { useGatewayBootstrap } from './hooks/useGatewayBootstrap';
 import { useUiStore } from './stores/hooks';
-import { reconnectAllClients } from './gateway/client';
+import { reconnectAllClients } from './gateway/client-registry';
 import { DrawerLayout } from './views/DrawerLayout';
 import { Toaster } from 'sonner';
 

--- a/packages/pwa/src/components/GatewayDebugLog.tsx
+++ b/packages/pwa/src/components/GatewayDebugLog.tsx
@@ -2,7 +2,7 @@ import { useSyncExternalStore, useRef, useEffect } from 'react';
 import { AnimatePresence, m, useDragControls } from 'framer-motion';
 import { X, Trash2, Copy, RefreshCw } from 'lucide-react';
 import { getDebugLog, subscribeDebugLog, clearDebugLog } from '../lib/debug';
-import { reconnectAllClients } from '../gateway/client';
+import { reconnectAllClients } from '../gateway/client-registry';
 import type { DebugLogEntry } from '../lib/debug';
 
 interface GatewayDebugLogProps {

--- a/packages/pwa/src/gateway/client-registry.ts
+++ b/packages/pwa/src/gateway/client-registry.ts
@@ -1,0 +1,30 @@
+import type { BrowserGatewayClient } from './client.js';
+
+const clients = new Map<string, BrowserGatewayClient>();
+
+export function registerClient(client: BrowserGatewayClient): void {
+  clients.set(client.id, client);
+}
+
+export function getClient(id: string): BrowserGatewayClient | undefined {
+  return clients.get(id);
+}
+
+export function getAllClients(): BrowserGatewayClient[] {
+  return Array.from(clients.values());
+}
+
+export function reconnectAllClients(): void {
+  for (const client of clients.values()) {
+    if (!client.isConnected) {
+      client.reconnect();
+    }
+  }
+}
+
+export function destroyAllClients(): void {
+  for (const client of clients.values()) {
+    client.destroy();
+  }
+  clients.clear();
+}

--- a/packages/pwa/src/gateway/client.ts
+++ b/packages/pwa/src/gateway/client.ts
@@ -657,32 +657,3 @@ export class BrowserGatewayClient {
     return `pwa-${this.reqCounter}-${Date.now().toString(36)}`;
   }
 }
-
-const clients = new Map<string, BrowserGatewayClient>();
-
-export function registerClient(client: BrowserGatewayClient): void {
-  clients.set(client.id, client);
-}
-
-export function getClient(id: string): BrowserGatewayClient | undefined {
-  return clients.get(id);
-}
-
-export function getAllClients(): BrowserGatewayClient[] {
-  return Array.from(clients.values());
-}
-
-export function reconnectAllClients(): void {
-  for (const client of clients.values()) {
-    if (!client.isConnected) {
-      client.reconnect();
-    }
-  }
-}
-
-export function destroyAllClients(): void {
-  for (const client of clients.values()) {
-    client.destroy();
-  }
-  clients.clear();
-}

--- a/packages/pwa/src/hooks/useGatewayBootstrap.ts
+++ b/packages/pwa/src/hooks/useGatewayBootstrap.ts
@@ -2,9 +2,10 @@ import { useEffect } from 'react';
 import type { DebugEvent } from '@clawwork/shared';
 import { listGateways, getIdentity, updateGatewayToken } from '../persistence/db.js';
 import { importDeviceIdentity } from '../gateway/device-identity.js';
-import { BrowserGatewayClient, registerClient, destroyAllClients } from '../gateway/client.js';
+import { BrowserGatewayClient } from '../gateway/client.js';
+import { registerClient, destroyAllClients } from '../gateway/client-registry.js';
 import { getGatewayBroadcasters } from '../platform/index.js';
-import { dispatcher, composerBridge, uiStoreApi } from '../stores/index.js';
+import { dispatcher, uiStoreApi } from '../stores/index.js';
 import { reportDebugEvent } from '../lib/debug.js';
 import type { GatewayAuth } from '@clawwork/shared';
 import { toast } from 'sonner';
@@ -77,8 +78,6 @@ export function useGatewayBootstrap(): void {
         registerClient(client);
         client.connect();
       }
-
-      composerBridge.markAbortedByUser = (taskId) => dispatcher.markAbortedByUser(taskId);
 
       const removeEvents = dispatcher.start();
       const removeStatus = dispatcher.startGatewayStatus();

--- a/packages/pwa/src/platform/index.ts
+++ b/packages/pwa/src/platform/index.ts
@@ -4,7 +4,7 @@ import { createBrowserGatewayTransport } from './gateway-adapter.js';
 import type { BrowserGatewayTransportResult } from './gateway-adapter.js';
 import { createBrowserSettings } from './settings-adapter.js';
 import { createBrowserNotifications } from './notifications-adapter.js';
-import { getAllClients, getClient } from '../gateway/client.js';
+import { getAllClients, getClient } from '../gateway/client-registry.js';
 import { getIdentity, getScopeId } from '../persistence/db.js';
 
 let _ports: PlatformPorts | null = null;

--- a/packages/pwa/src/stores/index.ts
+++ b/packages/pwa/src/stores/index.ts
@@ -10,7 +10,7 @@ import type { PlatformPorts, ChatComposer } from '@clawwork/core';
 import type { ModelCatalogEntry, AgentInfo, DebugEvent } from '@clawwork/shared';
 import { ports } from '../platform/index.js';
 import { getIdentity } from '../persistence/db.js';
-import { getClient } from '../gateway/client.js';
+import { getClient } from '../gateway/client-registry.js';
 import { reportDebugEvent } from '../lib/debug.js';
 import i18next from 'i18next';
 import { toast } from 'sonner';
@@ -112,10 +112,6 @@ const sessionSync = createSessionSync({
   }),
 });
 
-export const composerBridge = {
-  markAbortedByUser: (_taskId: string): void => {},
-};
-
 let _dispatcher: ReturnType<typeof createGatewayDispatcher> | null = null;
 let hydrationReady: Promise<void> | null = null;
 
@@ -175,7 +171,7 @@ function getComposer(): ChatComposer {
       getTaskStore: () => taskStoreApi.getState(),
       getMessageStore: () => messageStoreApi.getState(),
       persistMessage: (...args) => getPorts().persistence.persistMessage(...args),
-      markAbortedByUser: (taskId) => composerBridge.markAbortedByUser(taskId),
+      markAbortedByUser: (taskId) => getDispatcher().markAbortedByUser(taskId),
       compactSession: (gwId, sk) => {
         const c = getClient(gwId);
         if (!c) return Promise.resolve({ ok: false, error: 'Gateway not found' });

--- a/packages/pwa/src/views/DrawerLayout.tsx
+++ b/packages/pwa/src/views/DrawerLayout.tsx
@@ -5,7 +5,7 @@ import { Menu, Settings, LogOut, ChevronDown, Search, SquarePen } from 'lucide-r
 import { useUiStore, useTaskStore } from '../stores/hooks';
 import { AgentSelector } from '../components/AgentSelector';
 import { GatewayDebugLog } from '../components/GatewayDebugLog';
-import { destroyAllClients } from '../gateway/client';
+import { destroyAllClients } from '../gateway/client-registry';
 import { clearAll } from '../persistence/db';
 import { TaskList } from '../components/TaskList';
 import { GatewayStatus } from '../components/GatewayStatus';


### PR DESCRIPTION
## Summary

Separate the module-level mutable client registry from `BrowserGatewayClient` class into its own module, and replace the `composerBridge` monkey-patching hack with a direct lazy closure call to `getDispatcher()`.

## Type of change

- [x] `[Refactor]` internal cleanup

## Why is this needed?

Two design issues in `packages/pwa/src/gateway/client.ts` and `packages/pwa/src/stores/index.ts`:

1. **Mixed concerns**: `client.ts` exports both the `BrowserGatewayClient` class (connection management) and a global mutable `Map` registry (lifecycle orchestration). These are separate responsibilities sharing a module for no reason.

2. **Runtime monkey-patching**: `composerBridge` is a mutable object with a no-op `markAbortedByUser` that gets overwritten at runtime in `useGatewayBootstrap`. This indirection exists because the composer needs the dispatcher, but both are lazily initialized. Since both already use the `getX()` lazy pattern, a direct closure `(taskId) => getDispatcher().markAbortedByUser(taskId)` resolves the dependency without mutation.

## What changed?

- Extracted `clients` Map + 5 registry functions (`registerClient`, `getClient`, `getAllClients`, `reconnectAllClients`, `destroyAllClients`) into `gateway/client-registry.ts`
- Updated 6 import sites to point at the new module
- Replaced `composerBridge.markAbortedByUser` with direct `getDispatcher().markAbortedByUser` closure in `getComposer()`
- Removed `composerBridge` export and its monkey-patch in `useGatewayBootstrap.ts`
- Net result: **-4 lines** (39 added in new file, 43 removed from existing)

## Architecture impact

- Owning layer: renderer (PWA)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: pure internal restructuring, no behavioral change

## Linked issues

N/A

## Validation

- [x] `pnpm build` (vite build passes)
- [x] TS error count unchanged (90 pre-existing errors before and after — all from unbuilt `shared/core` dist and implicit `any`)
- [ ] Not run

Commands, screenshots, or notes:

```text
# Error count comparison (stash/unstash):
Before: 90 TS errors
After:  90 TS errors (identical set)

# Vite build:
✓ built in 2.14s
PWA v0.21.2 — 30 precache entries
```

## Screenshots or recordings

No UI changes.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Refactor]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate