### PR TITLE
[Fix] Production-grade SSRF guard with numeric IP parsing and DNS pre-resolution

### DIFF
--- a/packages/desktop/src/main/artifact/auto-extract.ts
+++ b/packages/desktop/src/main/artifact/auto-extract.ts
@@ -1,4 +1,4 @@
-import { net, BrowserWindow } from 'electron';
+import { BrowserWindow } from 'electron';
 import { readFileSync } from 'fs';
 import { resolve, sep } from 'path';
 import { extractImagesFromMarkdown, extractCodeBlocksFromMarkdown } from './extract.js';
@@ -6,6 +6,7 @@ import { saveArtifactFromBuffer } from './save.js';
 import { getDb } from '../db/index.js';
 import { artifacts } from '../db/schema.js';
 import { eq } from 'drizzle-orm';
+import { safeFetch } from '../net/safe-fetch.js';
 import type { Artifact } from '@clawwork/shared';
 
 interface AutoExtractParams {
@@ -13,43 +14,6 @@ interface AutoExtractParams {
   taskId: string;
   messageId: string;
   content: string;
-}
-
-const MAX_REMOTE_SIZE = 10 * 1024 * 1024;
-const FETCH_TIMEOUT_MS = 10_000;
-
-function isPrivateHost(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
-}
-
-async function fetchToBuffer(url: string): Promise<Buffer> {
-  const parsed = new URL(url);
-  if (parsed.protocol !== 'https:') {
-    throw new Error('remote fetch disabled for non-https scheme');
-  }
-  if (isPrivateHost(parsed.hostname)) {
-    throw new Error('remote fetch disabled for private hosts');
-  }
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    const res = await net.fetch(url, { signal: controller.signal });
-    if (!res.ok) throw new Error(`fetch ${url} failed: ${res.status}`);
-
-    const contentLength = Number(res.headers.get('content-length') ?? '0');
-    if (contentLength > MAX_REMOTE_SIZE) {
-      throw new Error('remote artifact too large');
-    }
-
-    const ab = await res.arrayBuffer();
-    if (ab.byteLength > MAX_REMOTE_SIZE) {
-      throw new Error('remote artifact too large');
-    }
-    return Buffer.from(ab);
-  } finally {
-    clearTimeout(timeout);
-  }
 }
 
 export async function autoExtractArtifacts(params: AutoExtractParams): Promise<void> {
@@ -68,7 +32,7 @@ export async function autoExtractArtifacts(params: AutoExtractParams): Promise<v
     try {
       let buffer: Buffer;
       if (img.isRemote) {
-        buffer = await fetchToBuffer(img.src);
+        buffer = await safeFetch(img.src);
       } else if (img.src.startsWith('clawwork-media://')) {
         const filePath = resolve(img.src.replace('clawwork-media://', ''));
         if (!filePath.startsWith(resolve(workspacePath) + sep)) continue;

--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow, dialog, net, shell } from 'electron';
+import { ipcMain, BrowserWindow, dialog, shell } from 'electron';
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve, sep } from 'path';
 import { eq } from 'drizzle-orm';
@@ -7,6 +7,7 @@ import { artifacts, tasks, messages } from '../db/schema.js';
 import { saveArtifact, saveArtifactFromBuffer } from '../artifact/save.js';
 import { getWorkspacePath } from '../workspace/config.js';
 import { searchArtifacts } from '../db/search.js';
+import { safeFetch } from '../net/safe-fetch.js';
 
 interface SaveParams {
   taskId: string;
@@ -149,9 +150,7 @@ export function registerArtifactHandlers(): void {
         let buffer: Buffer;
         const url = params.url;
         if (/^https?:\/\//.test(url)) {
-          const res = await net.fetch(url);
-          if (!res.ok) return { ok: false, error: `fetch failed: ${res.status}` };
-          buffer = Buffer.from(await res.arrayBuffer());
+          buffer = await safeFetch(url);
         } else if (url.startsWith('file://')) {
           const filePath = resolve(url.replace('file://', ''));
           if (!filePath.startsWith(resolve(workspacePath) + sep)) {

--- a/packages/desktop/src/main/net/safe-fetch.ts
+++ b/packages/desktop/src/main/net/safe-fetch.ts
@@ -1,0 +1,31 @@
+import { net } from 'electron';
+import { assertNotPrivateHost } from './ssrf-guard.js';
+
+const DEFAULT_MAX_SIZE = 10 * 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface SafeFetchOptions {
+  maxSize?: number;
+  timeoutMs?: number;
+}
+
+export async function safeFetch(url: string, opts: SafeFetchOptions = {}): Promise<Buffer> {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:') throw new Error('HTTPS required');
+  await assertNotPrivateHost(parsed.hostname);
+
+  const maxSize = opts.maxSize ?? DEFAULT_MAX_SIZE;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await net.fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`fetch ${url}: ${res.status}`);
+    const cl = Number(res.headers.get('content-length') ?? '0');
+    if (cl > maxSize) throw new Error('response too large');
+    const ab = await res.arrayBuffer();
+    if (ab.byteLength > maxSize) throw new Error('response too large');
+    return Buffer.from(ab);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/desktop/src/main/net/ssrf-guard.ts
+++ b/packages/desktop/src/main/net/ssrf-guard.ts
@@ -1,0 +1,59 @@
+import { isIP } from 'node:net';
+import { resolve4, resolve6 } from 'node:dns/promises';
+
+function isPrivateIPv4(ip: string): boolean {
+  const p = ip.split('.').map(Number);
+  if (p.length !== 4 || p.some((n) => n < 0 || n > 255 || !Number.isInteger(n))) return false;
+  const [a, b] = p;
+  return (
+    a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    a === 0 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 240
+  );
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  if (lower === '::' || lower === '::1') return true;
+  const first = parseInt(lower.split(':')[0], 16);
+  if ((first & 0xfe00) === 0xfc00) return true;
+  if ((first & 0xffc0) === 0xfe80) return true;
+  const v4Match = lower.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4Match) return isPrivateIPv4(v4Match[1]);
+  const hexMatch = lower.match(/::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hexMatch) {
+    const hi = parseInt(hexMatch[1], 16);
+    const lo = parseInt(hexMatch[2], 16);
+    return isPrivateIPv4(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`);
+  }
+  return false;
+}
+
+export function isPrivateIP(ip: string): boolean {
+  const v = isIP(ip);
+  if (v === 4) return isPrivateIPv4(ip);
+  if (v === 6) return isPrivateIPv6(ip);
+  return false;
+}
+
+export function isPrivateHost(hostname: string): boolean {
+  return hostname === 'localhost' || isPrivateIP(hostname);
+}
+
+export async function assertNotPrivateHost(hostname: string): Promise<void> {
+  if (isPrivateHost(hostname)) throw new Error('SSRF blocked: private host');
+  if (isIP(hostname)) return;
+  const results = await Promise.allSettled([resolve4(hostname), resolve6(hostname)]);
+  for (const r of results) {
+    if (r.status !== 'fulfilled') continue;
+    for (const ip of r.value) {
+      if (isPrivateIP(ip)) throw new Error('SSRF blocked: resolves to private IP');
+    }
+  }
+}

--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { assertNotPrivateHostMock, netFetchMock } = vi.hoisted(() => ({
+  assertNotPrivateHostMock: vi.fn(),
+  netFetchMock: vi.fn(),
+}));
+
+vi.mock('../src/main/net/ssrf-guard.js', () => ({
+  assertNotPrivateHost: assertNotPrivateHostMock,
+}));
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock },
+}));
+
+import { safeFetch } from '../src/main/net/safe-fetch.js';
+
+beforeEach(() => {
+  assertNotPrivateHostMock.mockReset();
+  netFetchMock.mockReset();
+});
+
+function mockResponse(body: ArrayBuffer, status = 200, headers: Record<string, string> = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    arrayBuffer: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('safeFetch', () => {
+  it('rejects non-HTTPS URLs before any network call', async () => {
+    await expect(safeFetch('http://example.com/img.png')).rejects.toThrow('HTTPS required');
+    expect(assertNotPrivateHostMock).not.toHaveBeenCalled();
+    expect(netFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calls assertNotPrivateHost with parsed hostname', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(undefined);
+    const body = new ArrayBuffer(4);
+    netFetchMock.mockResolvedValue(mockResponse(body));
+
+    await safeFetch('https://cdn.example.com/img.png');
+    expect(assertNotPrivateHostMock).toHaveBeenCalledWith('cdn.example.com');
+  });
+
+  it('rejects when assertNotPrivateHost throws', async () => {
+    assertNotPrivateHostMock.mockRejectedValue(new Error('SSRF blocked: private host'));
+    await expect(safeFetch('https://10.0.0.1/secret')).rejects.toThrow('SSRF blocked');
+    expect(netFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns buffer on success', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(undefined);
+    const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    netFetchMock.mockResolvedValue(mockResponse(data.buffer));
+
+    const buf = await safeFetch('https://cdn.example.com/img.png');
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.length).toBe(4);
+  });
+
+  it('rejects when content-length exceeds maxSize', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(undefined);
+    netFetchMock.mockResolvedValue(mockResponse(new ArrayBuffer(0), 200, { 'content-length': '999999999' }));
+
+    await expect(safeFetch('https://cdn.example.com/huge.bin', { maxSize: 1024 })).rejects.toThrow('too large');
+  });
+
+  it('rejects when actual body exceeds maxSize', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(undefined);
+    const big = new ArrayBuffer(2048);
+    netFetchMock.mockResolvedValue(mockResponse(big));
+
+    await expect(safeFetch('https://cdn.example.com/big.bin', { maxSize: 1024 })).rejects.toThrow('too large');
+  });
+
+  it('rejects on non-ok HTTP status', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(undefined);
+    netFetchMock.mockResolvedValue(mockResponse(new ArrayBuffer(0), 404));
+
+    await expect(safeFetch('https://cdn.example.com/missing.png')).rejects.toThrow('404');
+  });
+});

--- a/packages/desktop/test/ssrf-guard.test.ts
+++ b/packages/desktop/test/ssrf-guard.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:dns/promises', () => ({
+  resolve4: vi.fn(),
+  resolve6: vi.fn(),
+}));
+
+import { isPrivateIP, isPrivateHost, assertNotPrivateHost } from '../src/main/net/ssrf-guard.js';
+import { resolve4, resolve6 } from 'node:dns/promises';
+
+const mockResolve4 = vi.mocked(resolve4);
+const mockResolve6 = vi.mocked(resolve6);
+
+beforeEach(() => {
+  mockResolve4.mockReset();
+  mockResolve6.mockReset();
+});
+
+describe('isPrivateIP', () => {
+  const privateCases: [string, string][] = [
+    ['127.0.0.1', 'loopback'],
+    ['127.255.255.255', 'loopback high'],
+    ['10.0.0.1', '10/8'],
+    ['10.255.255.255', '10/8 high'],
+    ['172.16.0.1', '172.16/12 low'],
+    ['172.31.255.255', '172.16/12 high'],
+    ['192.168.0.1', '192.168/16'],
+    ['192.168.255.255', '192.168/16 high'],
+    ['169.254.1.1', 'link-local'],
+    ['0.0.0.0', 'unspecified'],
+    ['0.1.2.3', '0/8'],
+    ['100.64.0.1', 'CGNAT low'],
+    ['100.127.255.255', 'CGNAT high'],
+    ['198.18.0.1', 'benchmark low'],
+    ['198.19.255.255', 'benchmark high'],
+    ['240.0.0.1', 'reserved class E'],
+    ['255.255.255.255', 'broadcast'],
+  ];
+
+  for (const [ip, label] of privateCases) {
+    it(`blocks ${ip} (${label})`, () => {
+      expect(isPrivateIP(ip)).toBe(true);
+    });
+  }
+
+  const publicCases: [string, string][] = [
+    ['8.8.8.8', 'Google DNS'],
+    ['1.1.1.1', 'Cloudflare DNS'],
+    ['172.15.255.255', 'just below 172.16/12'],
+    ['172.32.0.0', 'just above 172.16/12'],
+    ['100.63.255.255', 'just below CGNAT'],
+    ['100.128.0.0', 'just above CGNAT'],
+    ['198.17.255.255', 'just below benchmark'],
+    ['198.20.0.0', 'just above benchmark'],
+    ['239.255.255.255', 'just below class E'],
+    ['11.0.0.1', 'public 11.x'],
+  ];
+
+  for (const [ip, label] of publicCases) {
+    it(`allows ${ip} (${label})`, () => {
+      expect(isPrivateIP(ip)).toBe(false);
+    });
+  }
+
+  it('blocks IPv6 loopback ::1', () => {
+    expect(isPrivateIP('::1')).toBe(true);
+  });
+
+  it('blocks IPv6 unspecified ::', () => {
+    expect(isPrivateIP('::')).toBe(true);
+  });
+
+  it('blocks IPv6 ULA fd12:3456::1', () => {
+    expect(isPrivateIP('fd12:3456::1')).toBe(true);
+  });
+
+  it('blocks IPv6 ULA fc00::1', () => {
+    expect(isPrivateIP('fc00::1')).toBe(true);
+  });
+
+  it('blocks IPv6 link-local fe80::1', () => {
+    expect(isPrivateIP('fe80::1')).toBe(true);
+  });
+
+  it('allows public IPv6 2001:4860:4860::8888', () => {
+    expect(isPrivateIP('2001:4860:4860::8888')).toBe(false);
+  });
+
+  it('blocks IPv4-mapped IPv6 ::ffff:10.0.0.1', () => {
+    expect(isPrivateIP('::ffff:10.0.0.1')).toBe(true);
+  });
+
+  it('blocks IPv4-mapped IPv6 hex form ::ffff:a00:1', () => {
+    expect(isPrivateIP('::ffff:a00:1')).toBe(true);
+  });
+
+  it('allows IPv4-mapped IPv6 public ::ffff:8.8.8.8', () => {
+    expect(isPrivateIP('::ffff:8.8.8.8')).toBe(false);
+  });
+
+  it('returns false for non-IP strings', () => {
+    expect(isPrivateIP('example.com')).toBe(false);
+    expect(isPrivateIP('10.cdn.example.com')).toBe(false);
+    expect(isPrivateIP('fc-assets.cloudfront.net')).toBe(false);
+  });
+});
+
+describe('isPrivateHost', () => {
+  it('blocks localhost', () => {
+    expect(isPrivateHost('localhost')).toBe(true);
+  });
+
+  it('blocks private IPs', () => {
+    expect(isPrivateHost('10.0.0.1')).toBe(true);
+  });
+
+  it('allows public domains', () => {
+    expect(isPrivateHost('example.com')).toBe(false);
+  });
+
+  it('does NOT false-positive on domains starting with private-looking prefixes', () => {
+    expect(isPrivateHost('10.cdn.example.com')).toBe(false);
+    expect(isPrivateHost('192.168.example.com')).toBe(false);
+    expect(isPrivateHost('fc-assets.cloudfront.net')).toBe(false);
+  });
+});
+
+describe('assertNotPrivateHost', () => {
+  it('rejects private IP immediately without DNS', async () => {
+    await expect(assertNotPrivateHost('10.0.0.1')).rejects.toThrow('SSRF blocked');
+    expect(mockResolve4).not.toHaveBeenCalled();
+  });
+
+  it('rejects localhost immediately without DNS', async () => {
+    await expect(assertNotPrivateHost('localhost')).rejects.toThrow('SSRF blocked');
+  });
+
+  it('allows public IP without DNS', async () => {
+    await expect(assertNotPrivateHost('8.8.8.8')).resolves.toBeUndefined();
+    expect(mockResolve4).not.toHaveBeenCalled();
+  });
+
+  it('resolves domain and blocks if DNS points to private IP', async () => {
+    mockResolve4.mockResolvedValue(['10.0.0.1']);
+    mockResolve6.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertNotPrivateHost('evil.example.com')).rejects.toThrow('SSRF blocked');
+  });
+
+  it('allows domain that resolves to public IP', async () => {
+    mockResolve4.mockResolvedValue(['93.184.216.34']);
+    mockResolve6.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertNotPrivateHost('example.com')).resolves.toBeUndefined();
+  });
+
+  it('blocks if any resolved address is private', async () => {
+    mockResolve4.mockResolvedValue(['93.184.216.34', '10.0.0.1']);
+    mockResolve6.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertNotPrivateHost('mixed.example.com')).rejects.toThrow('SSRF blocked');
+  });
+
+  it('blocks if IPv6 resolution returns private address', async () => {
+    mockResolve4.mockRejectedValue(new Error('ENOTFOUND'));
+    mockResolve6.mockResolvedValue(['fd12::1']);
+    await expect(assertNotPrivateHost('v6only.example.com')).rejects.toThrow('SSRF blocked');
+  });
+
+  it('allows domain when DNS fails entirely', async () => {
+    mockResolve4.mockRejectedValue(new Error('ENOTFOUND'));
+    mockResolve6.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertNotPrivateHost('broken-dns.example.com')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Replace the string-prefix SSRF check in `auto-extract.ts` with a proper numeric IP parsing module and DNS pre-resolution guard, extracted into a shared `net/` layer used by all outbound fetch paths.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The previous `isPrivateHost` only matched three literal strings (`localhost`, `127.0.0.1`, `::1`). This missed all RFC 1918 ranges, link-local, CGNAT, reserved, and IPv6 private addresses. The todo.md suggested a string-prefix approach which introduced false positives (blocking `10.cdn.example.com`) and still missed IPv6-mapped IPv4 and DNS rebinding vectors. Additionally, `artifact-handlers.ts` had a bare `net.fetch` with zero SSRF protection.

## What changed?

- **New `src/main/net/ssrf-guard.ts`**: Numeric IPv4/IPv6 range checks via `node:net` `isIP()` covering 10/8, 172.16/12, 192.168/16, 127/8, 169.254/16, 0/8, 100.64/10 (CGNAT), 198.18/15 (benchmark), 240/4 (reserved), IPv6 loopback/ULA/link-local, and IPv4-mapped IPv6 (both dotted and hex forms). DNS pre-resolution via `node:dns/promises` blocks rebinding attacks.
- **New `src/main/net/safe-fetch.ts`**: Unified HTTPS-only fetch wrapper with SSRF guard, configurable size limit (default 10MB), and timeout (default 10s).
- **`auto-extract.ts`**: Removed inline `isPrivateHost`, `fetchToBuffer`, and related constants. Now uses `safeFetch`.
- **`artifact-handlers.ts`**: Replaced unprotected `net.fetch` in `artifact:save-image-url` with `safeFetch`.

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: changes are confined to main-process network utilities; no renderer, preload, or shared contract changes

## Linked issues

Closes the SSRF private host check gap identified in the worktree todo.

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate: lint + architecture + ui-contract + renderer-copy + i18n + dead-code + format + typecheck + test)
- [ ] `pnpm build`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm check -> all green
148 tests passed (49 ssrf-guard + 7 safe-fetch + 92 existing)
```

## Screenshots or recordings

No UI changes.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate