### PR TITLE
[Fix] Inject client version from package.json at build time

### DIFF
--- a/packages/pwa/src/gateway/client.ts
+++ b/packages/pwa/src/gateway/client.ts
@@ -380,7 +380,7 @@ export class BrowserGatewayClient {
           client: {
             id: 'gateway-client',
             displayName: 'ClawWork PWA',
-            version: '0.1.0',
+            version: __APP_VERSION__,
             platform: 'pwa',
             mode: 'backend',
             deviceFamily: 'mobile',

--- a/packages/pwa/src/vite-env.d.ts
+++ b/packages/pwa/src/vite-env.d.ts
@@ -1,2 +1,4 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+
+declare const __APP_VERSION__: string;

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -1,10 +1,16 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'));
+
 export default defineConfig(({ command }) => ({
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary

Replace the hardcoded `'0.1.0'` client version in the Gateway connect payload with a build-time constant derived from `package.json`, so the server always sees the correct client version after any version bump.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The `version` field in the Gateway handshake payload (`client.ts:383`) was a hardcoded string `'0.1.0'`. After any version bump in `package.json`, the server-side diagnostics and version-aware feature gating would see a stale client version.

## What changed?

- `packages/pwa/vite.config.ts` — read `version` from `package.json` and inject it as `__APP_VERSION__` via Vite `define`
- `packages/pwa/src/vite-env.d.ts` — add type declaration for the global constant
- `packages/pwa/src/gateway/client.ts` — replace `'0.1.0'` with `__APP_VERSION__`

## Architecture impact

- Owning layer: renderer (PWA)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is limited to build-time constant injection and its single consumer

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [ ] `pnpm build`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passed
pnpm test — 157/157 passed
```

## Screenshots or recordings

N/A — no UI change.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate