### PR TITLE
[Fix] Centralize theme ownership and sync meta[theme-color] on switch

### DIFF
--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
-    <meta name="theme-color" content="#1c1c1c" />
+    <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="icon" type="image/png" href="/icons/icon-192.png" />

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -7,56 +7,17 @@ import { useUiStore } from './stores/hooks';
 import { reconnectAllClients } from './gateway/client';
 import { DrawerLayout } from './views/DrawerLayout';
 import { Toaster } from 'sonner';
+import { useThemeInit } from './hooks/useThemeInit';
 
 const PairingViewLazy = lazy(() => import('./views/PairingView').then((m) => ({ default: m.PairingView })));
-
-const THEME_STORAGE_KEY = 'clawwork-theme';
-
-type ThemeValue = 'dark' | 'light';
-
-function resolveTheme(): ThemeValue {
-  try {
-    const stored = localStorage.getItem(THEME_STORAGE_KEY);
-    if (stored === 'dark' || stored === 'light') return stored;
-  } catch (err) {
-    reportDebugEvent({
-      level: 'warn',
-      domain: 'app',
-      event: 'theme.storage.read.failed',
-      error: { message: err instanceof Error ? err.message : 'theme storage read failed' },
-    });
-  }
-  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
-}
-
-function applyTheme(theme: ThemeValue): void {
-  document.documentElement.setAttribute('data-theme', theme);
-}
 
 export default function App() {
   const { t } = useTranslation();
   const [ready, setReady] = useState(false);
   const [paired, setPaired] = useState(false);
-  const [theme, setThemeState] = useState<ThemeValue>(resolveTheme);
+  const storeTheme = useUiStore((s) => s.theme);
 
-  useEffect(() => {
-    applyTheme(theme);
-  }, [theme]);
-
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: light)');
-    const onChange = () => {
-      try {
-        if (!localStorage.getItem(THEME_STORAGE_KEY)) {
-          setThemeState(mq.matches ? 'light' : 'dark');
-        }
-      } catch {
-        setThemeState(mq.matches ? 'light' : 'dark');
-      }
-    };
-    mq.addEventListener('change', onChange);
-    return () => mq.removeEventListener('change', onChange);
-  }, []);
+  useThemeInit();
 
   useEffect(() => {
     isPaired()
@@ -86,7 +47,7 @@ export default function App() {
           <PairingViewLazy onPaired={() => setPaired(true)} />
         )}
       </Suspense>
-      <Toaster theme={theme} richColors position="top-center" />
+      <Toaster theme={storeTheme === 'auto' ? 'system' : storeTheme} richColors position="top-center" />
     </ErrorBoundary>
   );
 }

--- a/packages/pwa/src/components/SettingsSheet.tsx
+++ b/packages/pwa/src/components/SettingsSheet.tsx
@@ -5,8 +5,6 @@ import { Moon, Sun, Globe, LogOut } from 'lucide-react';
 import { useUiStore } from '../stores/hooks';
 import { SUPPORTED_LANGUAGE_CODES } from '@clawwork/shared';
 
-const THEME_STORAGE_KEY = 'clawwork-theme';
-
 const LANGUAGE_LABELS: Record<string, string> = {
   en: 'English',
   zh: '简体中文',
@@ -33,14 +31,7 @@ export function SettingsSheet({ open, onClose, onSignOut }: SettingsSheetProps) 
   const isDark = theme === 'dark' || (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
 
   const toggleTheme = useCallback(() => {
-    const next = isDark ? 'light' : 'dark';
-    setTheme(next);
-    document.documentElement.setAttribute('data-theme', next);
-    try {
-      localStorage.setItem(THEME_STORAGE_KEY, next);
-    } catch {
-      /* storage unavailable */
-    }
+    setTheme(isDark ? 'light' : 'dark');
   }, [isDark, setTheme]);
 
   const changeLanguage = useCallback(

--- a/packages/pwa/src/hooks/useThemeInit.ts
+++ b/packages/pwa/src/hooks/useThemeInit.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useUiStore } from '../stores/hooks';
+import { THEME_STORAGE_KEY } from '../lib/constants';
+
+type ResolvedTheme = 'dark' | 'light';
+
+function resolve(theme: string): ResolvedTheme {
+  if (theme === 'dark' || theme === 'light') return theme;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyToDOM(resolved: ResolvedTheme): void {
+  const root = document.documentElement;
+  root.setAttribute('data-theme', resolved);
+  root.style.colorScheme = resolved;
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (meta) {
+    const bg = getComputedStyle(root).getPropertyValue('--bg-primary').trim();
+    if (bg) meta.setAttribute('content', bg);
+  }
+}
+
+export function useThemeInit(): void {
+  const theme = useUiStore((s) => s.theme);
+
+  useEffect(() => {
+    applyToDOM(resolve(theme));
+    if (theme === 'dark' || theme === 'light') {
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, theme);
+      } catch {}
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => {
+      const current = useUiStore.getState().theme;
+      if (current !== 'dark' && current !== 'light') {
+        applyToDOM(mq.matches ? 'dark' : 'light');
+      }
+    };
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+}

--- a/packages/pwa/src/lib/constants.ts
+++ b/packages/pwa/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const THEME_STORAGE_KEY = 'clawwork-theme';

--- a/packages/pwa/src/stores/index.ts
+++ b/packages/pwa/src/stores/index.ts
@@ -12,6 +12,7 @@ import { ports } from '../platform/index.js';
 import { getIdentity } from '../persistence/db.js';
 import { getClient } from '../gateway/client.js';
 import { reportDebugEvent } from '../lib/debug.js';
+import { THEME_STORAGE_KEY } from '../lib/constants.js';
 import i18next from 'i18next';
 import { toast } from 'sonner';
 
@@ -58,6 +59,11 @@ const uiStoreApi = createUiStore({
   storage: localStorageAdapter,
   getViewportWidth: () => (typeof window !== 'undefined' ? window.innerWidth : 0),
 });
+
+const storedTheme = localStorageAdapter.get(THEME_STORAGE_KEY);
+if (storedTheme === 'dark' || storedTheme === 'light') {
+  uiStoreApi.setState({ theme: storedTheme });
+}
 
 const messageStoreApi = createMessageStore({
   persistMessage: (...args) => getPorts().persistence.persistMessage(...args),


### PR DESCRIPTION
## Summary

Consolidate scattered theme state management (App.tsx local state + SettingsSheet DOM manipulation + duplicated constants) into a single `useThemeInit` hook that owns all theme side effects. Fixes stale `<meta name="theme-color">` that never updated on theme switch.

## Type of change

- [x] `[Fix]` bug fix
- [x] `[Refactor]` internal cleanup

## Why is this needed?

1. `<meta name="theme-color">` was hardcoded to `#1c1c1c` (wrong value — `--bg-tertiary`, not `--bg-primary`) and never updated when the user switched themes. On mobile PWA, the status bar stayed dark regardless of theme.
2. Theme state was split between React `useState` in App.tsx and Zustand store in SettingsSheet — completely disconnected. `<Toaster>` received stale theme.
3. `THEME_STORAGE_KEY` was independently declared in two files.
4. DOM manipulation (`data-theme`, `localStorage`) was scattered across App.tsx and SettingsSheet with no single owner.

## What changed?

- **New `useThemeInit` hook** — single owner for all theme side effects: applies `data-theme`, `colorScheme`, syncs `meta[theme-color]` by reading `--bg-primary` from computed CSS (no hardcoded color mapping), persists to localStorage, and listens for system preference changes
- **New `lib/constants.ts`** — single definition of `THEME_STORAGE_KEY`
- **`stores/index.ts`** — synchronous theme hydration from localStorage at store creation (eliminates FOUC)
- **`App.tsx`** — removed ~30 lines of local theme state, `resolveTheme()`, `applyTheme()`, system preference listener; replaced with `useThemeInit()` call
- **`SettingsSheet.tsx`** — `toggleTheme` reduced to `setTheme(isDark ? 'light' : 'dark')` — no DOM/localStorage manipulation
- **`index.html`** — meta tag corrected from `#1c1c1c` to `#000000`

## Architecture impact

- Owning layer: renderer (PWA)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: changes are entirely within the PWA renderer layer; no shared/core/main process changes

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate: lint + architecture + ui-contract + renderer-copy + i18n + dead-code + format + typecheck + test)
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm check — all passed (92 desktop tests, 59 pwa tests, 6 shared tests)
```

## Screenshots or recordings

No visual change. The meta tag update is only observable via DOM inspector or on mobile PWA status bar.

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Fixed PWA status bar color not updating when switching between dark and light themes.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate