### PR TITLE
[Fix] Use fileURLToPath for file:// URL parsing in artifact handler

### DIFF
--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,5 +1,6 @@
 import { ipcMain, BrowserWindow, dialog, net, shell } from 'electron';
 import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'node:url';
 import { resolve, sep } from 'path';
 import { eq } from 'drizzle-orm';
 import { getDb, getSqlite } from '../db/index.js';
@@ -153,7 +154,7 @@ export function registerArtifactHandlers(): void {
           if (!res.ok) return { ok: false, error: `fetch failed: ${res.status}` };
           buffer = Buffer.from(await res.arrayBuffer());
         } else if (url.startsWith('file://')) {
-          const filePath = resolve(url.replace('file://', ''));
+          const filePath = resolve(fileURLToPath(url));
           if (!filePath.startsWith(resolve(workspacePath) + sep)) {
             return { ok: false, error: 'file path outside workspace' };
           }


### PR DESCRIPTION
## Summary

Replace naive `url.replace('file://', '')` with Node.js standard `fileURLToPath()` to correctly parse `file://` URLs in the `artifact:save-image-url` IPC handler, closing a path traversal vector.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

`url.replace('file://', '')` strips the scheme but leaves the host component intact. A URL like `file://localhost/tmp/evil.png` becomes `localhost/tmp/evil.png`, which `resolve()` turns into a CWD-relative path — bypassing the workspace boundary check. This is a path traversal vulnerability.

Additionally, `new URL(url).pathname` (the obvious alternative) does not decode percent-encoded characters (`%20` stays `%20`) and produces wrong paths on Windows (`/C:/path` instead of `C:\path`). `fileURLToPath` from `node:url` handles both correctly and is the Node.js canonical API for this conversion.

## What changed?

- Added `import { fileURLToPath } from 'node:url'`
- Replaced `resolve(url.replace('file://', ''))` with `resolve(fileURLToPath(url))`

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is confined to a single IPC handler's URL parsing; no new data flows, no schema changes

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full suite: lint + architecture + ui-contract + renderer-copy + i18n + dead-code + format + typecheck + test)
- [ ] `pnpm build`
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm check — all gates passed
```

## Screenshots or recordings

No UI changes.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
