### PR TITLE
[Fix] Centralize window lifecycle via window-manager module

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -2,7 +2,8 @@ import { app, shell, BrowserWindow, Menu, ipcMain, globalShortcut, dialog } from
 import { join } from 'path';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
 import { nativeTheme } from 'electron';
-import { initAllGateways, destroyAllGateways, rebindAllWindows } from './ws/index.js';
+import { initAllGateways, destroyAllGateways } from './ws/index.js';
+import { getMainWindow, setMainWindow } from './window-manager.js';
 import { initDebugLogger, getDebugLogger } from './debug/index.js';
 import { registerWsHandlers } from './ipc/ws-handlers.js';
 import { registerArtifactHandlers } from './ipc/artifact-handlers.js';
@@ -19,8 +20,8 @@ import { registerContextHandlers } from './ipc/context-handlers.js';
 import { registerNotificationHandlers } from './ipc/notification-handlers.js';
 import { unwatchAll } from './context/file-watcher.js';
 import { isInstallingUpdate } from './auto-updater.js';
-import { initTray, destroyTray, updateTrayWindow } from './tray.js';
-import { initQuickLaunch, destroyQuickLaunch, updateQuickLaunchMainWindow } from './quick-launch.js';
+import { initTray, destroyTray } from './tray.js';
+import { initQuickLaunch, destroyQuickLaunch } from './quick-launch.js';
 import { getWorkspacePath, readConfig, updateConfig } from './workspace/config.js';
 import { initDatabase, closeDatabase } from './db/index.js';
 
@@ -92,11 +93,7 @@ function createWindow(): BrowserWindow {
   const devMode = readConfig()?.devMode === true;
   Menu.setApplicationMenu(buildAppMenu(devMode));
 
-  ipcMain.handle('app:rebuild-menu', () => {
-    const dm = readConfig()?.devMode === true;
-    Menu.setApplicationMenu(buildAppMenu(dm));
-  });
-  const mainWindow = new BrowserWindow({
+  const win = new BrowserWindow({
     width: 1280,
     height: 800,
     minWidth: 960,
@@ -117,50 +114,52 @@ function createWindow(): BrowserWindow {
     },
   });
 
-  ipcMain.on('ui:set-window-button-visibility', (_event, visible: boolean) => {
-    if (process.platform === 'darwin') {
-      mainWindow.setWindowButtonVisibility(visible);
+  win.on('close', (e) => {
+    if (!isQuitting && !isInstallingUpdate()) {
+      e.preventDefault();
+      win.hide();
     }
   });
 
-  mainWindow.on('ready-to-show', () => {
+  win.on('ready-to-show', () => {
     const savedZoom = readConfig()?.zoomLevel;
     if (savedZoom) {
-      mainWindow.webContents.setZoomLevel(savedZoom);
+      win.webContents.setZoomLevel(savedZoom);
     }
-    mainWindow.show();
+    win.show();
   });
 
-  mainWindow.webContents.on('before-input-event', (_event, input) => {
+  win.webContents.on('before-input-event', (_event, input) => {
     if (!(input.meta || input.control) || input.type !== 'keyDown') return;
     if (input.key === '-' || input.key === '_') {
-      const level = mainWindow.webContents.getZoomLevel() - 0.5;
-      mainWindow.webContents.setZoomLevel(level);
+      const level = win.webContents.getZoomLevel() - 0.5;
+      win.webContents.setZoomLevel(level);
       updateConfig({ zoomLevel: level });
     }
   });
 
-  mainWindow.on('blur', () => {
-    if (mainWindow.isDestroyed()) return;
-    const level = mainWindow.webContents.getZoomLevel();
+  win.on('blur', () => {
+    if (win.isDestroyed()) return;
+    const level = win.webContents.getZoomLevel();
     const saved = readConfig()?.zoomLevel ?? 0;
     if (level !== saved) {
       updateConfig({ zoomLevel: level });
     }
   });
 
-  mainWindow.webContents.setWindowOpenHandler((details) => {
+  win.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url);
     return { action: 'deny' };
   });
 
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']);
+    win.loadURL(process.env['ELECTRON_RENDERER_URL']);
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'));
+    win.loadFile(join(__dirname, '../renderer/index.html'));
   }
 
-  return mainWindow;
+  setMainWindow(win);
+  return win;
 }
 
 app.whenReady().then(() => {
@@ -187,6 +186,18 @@ app.whenReady().then(() => {
   registerContextHandlers();
   registerNotificationHandlers();
 
+  ipcMain.handle('app:rebuild-menu', () => {
+    const dm = readConfig()?.devMode === true;
+    Menu.setApplicationMenu(buildAppMenu(dm));
+  });
+
+  ipcMain.on('ui:set-window-button-visibility', (_event, visible: boolean) => {
+    if (process.platform === 'darwin') {
+      const win = getMainWindow();
+      if (win) win.setWindowButtonVisibility(visible);
+    }
+  });
+
   const wsPath = getWorkspacePath();
   if (wsPath) {
     getDebugLogger().info({ domain: 'workspace', event: 'workspace.detected', data: { workspacePath: wsPath } });
@@ -208,27 +219,18 @@ app.whenReady().then(() => {
     }
   }
 
-  const mainWindow = createWindow();
-  initAllGateways(mainWindow);
-  initTray(mainWindow);
-  initQuickLaunch(mainWindow);
-
-  mainWindow.on('close', (e) => {
-    if (!isQuitting && !isInstallingUpdate()) {
-      e.preventDefault();
-      mainWindow.hide();
-    }
-  });
+  createWindow();
+  initAllGateways();
+  initTray();
+  initQuickLaunch();
 
   app.on('activate', () => {
-    if (mainWindow && !mainWindow.isVisible()) {
-      mainWindow.show();
-      mainWindow.focus();
-    } else if (BrowserWindow.getAllWindows().length === 0) {
-      const win = createWindow();
-      rebindAllWindows(win);
-      updateTrayWindow(win);
-      updateQuickLaunchMainWindow(win);
+    const win = getMainWindow();
+    if (win) {
+      win.show();
+      win.focus();
+    } else {
+      createWindow();
     }
   });
 });

--- a/packages/desktop/src/main/ipc/settings-handlers.ts
+++ b/packages/desktop/src/main/ipc/settings-handlers.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from 'electron';
+import { ipcMain } from 'electron';
 import { readConfig, updateConfig, writeConfig, buildGatewayAuth } from '../workspace/config.js';
 import type { AppConfig, GatewayServerConfig } from '../workspace/config.js';
 import { getGatewayClient, addGateway, removeGateway } from '../ws/index.js';
@@ -6,11 +6,6 @@ import { GatewayClient } from '../ws/gateway-client.js';
 import { loadOrCreateDeviceIdentity } from '../ws/device-identity.js';
 import { SUPPORTED_LANGUAGE_CODES } from '@clawwork/shared';
 import type { GatewayAuth } from '@clawwork/shared';
-
-function getMainWindow(): BrowserWindow | null {
-  const wins = BrowserWindow.getAllWindows();
-  return wins.length > 0 ? wins[0] : null;
-}
 
 export function registerSettingsHandlers(): void {
   ipcMain.handle('pairing:get-device-identity', () => loadOrCreateDeviceIdentity());
@@ -37,10 +32,7 @@ export function registerSettingsHandlers(): void {
       config.defaultGatewayId = gateway.id;
     }
     writeConfig(config);
-    const mainWindow = getMainWindow();
-    if (mainWindow) {
-      addGateway({ id: gateway.id, name: gateway.name, url: gateway.url, auth: buildGatewayAuth(gateway) }, mainWindow);
-    }
+    addGateway({ id: gateway.id, name: gateway.name, url: gateway.url, auth: buildGatewayAuth(gateway) });
     return { ok: true };
   });
 

--- a/packages/desktop/src/main/quick-launch.ts
+++ b/packages/desktop/src/main/quick-launch.ts
@@ -4,9 +4,9 @@ import { is } from '@electron-toolkit/utils';
 import { readConfig, updateConfig } from './workspace/config.js';
 import type { QuickLaunchConfig } from './workspace/config.js';
 import { getDebugLogger } from './debug/index.js';
+import { getMainWindow } from './window-manager.js';
 
 let quickLaunchWindow: BrowserWindow | null = null;
-let mainWindowRef: BrowserWindow | null = null;
 let registeredShortcut: string | null = null;
 
 const DEFAULT_SHORTCUT = 'Alt+Space';
@@ -86,11 +86,11 @@ export function hideQuickLaunch(): void {
 
 export function handleQuickLaunchSubmit(message: string): void {
   hideQuickLaunch();
-
-  if (mainWindowRef && !mainWindowRef.isDestroyed()) {
-    mainWindowRef.webContents.send('quick-launch:submit', message);
-    mainWindowRef.show();
-    mainWindowRef.focus();
+  const win = getMainWindow();
+  if (win) {
+    win.webContents.send('quick-launch:submit', message);
+    win.show();
+    win.focus();
   }
 }
 
@@ -137,9 +137,7 @@ function unregisterShortcutKey(): void {
   }
 }
 
-export function initQuickLaunch(mainWindow: BrowserWindow): void {
-  mainWindowRef = mainWindow;
-
+export function initQuickLaunch(): void {
   const config = getConfig();
   if (config.enabled) {
     registerShortcutKey(config.shortcut);
@@ -161,10 +159,6 @@ export function updateQuickLaunchConfig(enabled: boolean, shortcut?: string): bo
   unregisterShortcutKey();
   updateConfig({ quickLaunch: { enabled: false, shortcut: newShortcut } });
   return true;
-}
-
-export function updateQuickLaunchMainWindow(win: BrowserWindow): void {
-  mainWindowRef = win;
 }
 
 export function destroyQuickLaunch(): void {

--- a/packages/desktop/src/main/tray.ts
+++ b/packages/desktop/src/main/tray.ts
@@ -1,9 +1,9 @@
 import { Tray, Menu, nativeImage, app } from 'electron';
-import type { BrowserWindow } from 'electron';
 import { join } from 'path';
 import { is } from '@electron-toolkit/utils';
 import { getDebugLogger } from './debug/index.js';
 import { readConfig, updateConfig } from './workspace/config.js';
+import { getMainWindow } from './window-manager.js';
 
 export type TrayStatus = 'idle' | 'running' | 'unread' | 'disconnected';
 
@@ -20,7 +20,6 @@ interface TrayState {
 }
 
 let tray: Tray | null = null;
-let mainWindowRef: BrowserWindow | null = null;
 let animationTimer: ReturnType<typeof setInterval> | null = null;
 let animationFrame = 0;
 
@@ -63,24 +62,23 @@ function startAnimation(): void {
 }
 
 function focusMainWindow(): void {
-  if (!mainWindowRef) return;
-  if (mainWindowRef.isMinimized()) mainWindowRef.restore();
-  if (!mainWindowRef.isVisible()) mainWindowRef.show();
-  mainWindowRef.focus();
+  const win = getMainWindow();
+  if (!win) return;
+  if (win.isMinimized()) win.restore();
+  if (!win.isVisible()) win.show();
+  win.focus();
 }
 
 function navigateToTask(taskId: string): void {
   focusMainWindow();
-  if (mainWindowRef && !mainWindowRef.isDestroyed()) {
-    mainWindowRef.webContents.send('tray:navigate-task', taskId);
-  }
+  const win = getMainWindow();
+  if (win) win.webContents.send('tray:navigate-task', taskId);
 }
 
 function openSettings(): void {
   focusMainWindow();
-  if (mainWindowRef && !mainWindowRef.isDestroyed()) {
-    mainWindowRef.webContents.send('tray:open-settings');
-  }
+  const win = getMainWindow();
+  if (win) win.webContents.send('tray:open-settings');
 }
 
 function buildMenu(state: TrayState): Menu {
@@ -117,8 +115,7 @@ function createTray(): void {
   getDebugLogger().info({ domain: 'tray', event: 'tray.init' });
 }
 
-export function initTray(win: BrowserWindow): void {
-  mainWindowRef = win;
+export function initTray(): void {
   const config = readConfig();
   if (config?.trayEnabled !== false) {
     createTray();
@@ -136,10 +133,6 @@ export function setTrayEnabled(enabled: boolean): void {
   } else {
     destroyTray();
   }
-}
-
-export function updateTrayWindow(win: BrowserWindow): void {
-  mainWindowRef = win;
 }
 
 export function updateTrayStatus(state: TrayState): void {

--- a/packages/desktop/src/main/window-manager.ts
+++ b/packages/desktop/src/main/window-manager.ts
@@ -1,0 +1,13 @@
+import { BrowserWindow } from 'electron';
+
+let mainWindow: BrowserWindow | null = null;
+
+export function getMainWindow(): BrowserWindow | null {
+  if (mainWindow && !mainWindow.isDestroyed()) return mainWindow;
+  mainWindow = null;
+  return BrowserWindow.getAllWindows()[0] ?? null;
+}
+
+export function setMainWindow(win: BrowserWindow): void {
+  mainWindow = win;
+}

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -17,8 +17,8 @@ import type {
   GatewayAuth,
   ChatAttachment,
 } from '@clawwork/shared';
-import type { BrowserWindow } from 'electron';
 import { sendToWindow } from './window-utils.js';
+import { getMainWindow } from '../window-manager.js';
 import {
   loadOrCreateDeviceIdentity,
   buildDeviceConnectPayload,
@@ -52,7 +52,6 @@ const REQ_TIMEOUT_MS = 15_000;
 
 export class GatewayClient {
   private ws: WebSocket | null = null;
-  private mainWindow: BrowserWindow | null = null;
   private authenticated = false;
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -96,10 +95,6 @@ export class GatewayClient {
     if (config.auth !== undefined) this.auth = config.auth;
     this.reconnectAttempts = 0;
     this.connect();
-  }
-
-  setMainWindow(win: BrowserWindow): void {
-    this.mainWindow = win;
   }
 
   connect(): void {
@@ -147,15 +142,13 @@ export class GatewayClient {
       this.authenticated = false;
       this.serverVersion = undefined;
       this.stopHeartbeat();
-      if (this.mainWindow) {
-        sendToWindow(this.mainWindow, 'gateway-status', {
-          gatewayId: this.gatewayId,
-          connected: false,
-          error,
-          reconnectAttempt: this.reconnectAttempts,
-          maxAttempts: MAX_RECONNECT_ATTEMPTS,
-        });
-      }
+      sendToWindow(getMainWindow(), 'gateway-status', {
+        gatewayId: this.gatewayId,
+        connected: false,
+        error,
+        reconnectAttempt: this.reconnectAttempts,
+        maxAttempts: MAX_RECONNECT_ATTEMPTS,
+      });
       // Don't retry when server explicitly rejects (pairing required, auth denied)
       if (code === WS_CLOSE_POLICY_VIOLATION) return;
       this.scheduleReconnect();
@@ -169,13 +162,11 @@ export class GatewayClient {
         gatewayId: this.gatewayId,
         error: { name: err.name, message: err.message, stack: err.stack },
       });
-      if (this.mainWindow) {
-        sendToWindow(this.mainWindow, 'gateway-status', {
-          gatewayId: this.gatewayId,
-          connected: false,
-          error: err.message,
-        });
-      }
+      sendToWindow(getMainWindow(), 'gateway-status', {
+        gatewayId: this.gatewayId,
+        connected: false,
+        error: err.message,
+      });
     });
   }
 
@@ -268,14 +259,12 @@ export class GatewayClient {
       data: { payload: summarizePayload(frame.payload) },
     });
 
-    if (this.mainWindow) {
-      sendToWindow(this.mainWindow, 'gateway-event', {
-        gatewayId: this.gatewayId,
-        event: frame.event,
-        payload: frame.payload,
-        seq: frame.seq,
-      });
-    }
+    sendToWindow(getMainWindow(), 'gateway-event', {
+      gatewayId: this.gatewayId,
+      event: frame.event,
+      payload: frame.payload,
+      seq: frame.seq,
+    });
   }
 
   private buildAuthWithDeviceToken(): GatewayAuth {
@@ -338,13 +327,11 @@ export class GatewayClient {
           this.serverVersion = typeof rawVersion === 'string' ? rawVersion : undefined;
           this.storeDeviceTokenFromPayload(payload);
           this.startHeartbeat();
-          if (this.mainWindow) {
-            sendToWindow(this.mainWindow, 'gateway-status', {
-              gatewayId: this.gatewayId,
-              connected: true,
-              serverVersion: this.serverVersion,
-            });
-          }
+          sendToWindow(getMainWindow(), 'gateway-status', {
+            gatewayId: this.gatewayId,
+            connected: true,
+            serverVersion: this.serverVersion,
+          });
         } else {
           getDebugLogger().error({
             domain: 'gateway',
@@ -729,16 +716,14 @@ export class GatewayClient {
         attempt: this.reconnectAttempts,
         error: { message: 'max reconnect attempts reached' },
       });
-      if (this.mainWindow) {
-        sendToWindow(this.mainWindow, 'gateway-status', {
-          gatewayId: this.gatewayId,
-          connected: false,
-          error: 'max reconnect attempts',
-          reconnectAttempt: this.reconnectAttempts,
-          maxAttempts: MAX_RECONNECT_ATTEMPTS,
-          gaveUp: true,
-        });
-      }
+      sendToWindow(getMainWindow(), 'gateway-status', {
+        gatewayId: this.gatewayId,
+        connected: false,
+        error: 'max reconnect attempts',
+        reconnectAttempt: this.reconnectAttempts,
+        maxAttempts: MAX_RECONNECT_ATTEMPTS,
+        gaveUp: true,
+      });
       return;
     }
 

--- a/packages/desktop/src/main/ws/index.ts
+++ b/packages/desktop/src/main/ws/index.ts
@@ -1,4 +1,3 @@
-import type { BrowserWindow } from 'electron';
 import type { GatewayClientConfig } from '@clawwork/shared';
 import { GatewayClient } from './gateway-client.js';
 import { readConfig, buildGatewayAuth, clearGatewayPairingCode } from '../workspace/config.js';
@@ -14,12 +13,11 @@ function createGatewayClient(config: GatewayClientConfig, opts?: { noReconnect?:
   });
 }
 
-export function initAllGateways(mainWindow: BrowserWindow): void {
+export function initAllGateways(): void {
   const config = readConfig();
   const gateways = config?.gateways ?? [];
   for (const gw of gateways) {
     const client = createGatewayClient({ id: gw.id, name: gw.name, url: gw.url, auth: buildGatewayAuth(gw) });
-    client.setMainWindow(mainWindow);
     client.connect();
     gatewayClients.set(gw.id, client);
   }
@@ -33,9 +31,8 @@ export function getAllGatewayClients(): Map<string, GatewayClient> {
   return gatewayClients;
 }
 
-export function addGateway(config: GatewayClientConfig, mainWindow: BrowserWindow): GatewayClient {
+export function addGateway(config: GatewayClientConfig): GatewayClient {
   const client = createGatewayClient(config);
-  client.setMainWindow(mainWindow);
   client.connect();
   gatewayClients.set(config.id, client);
   return client;
@@ -46,12 +43,6 @@ export function removeGateway(gatewayId: string): void {
   if (client) {
     client.destroy();
     gatewayClients.delete(gatewayId);
-  }
-}
-
-export function rebindAllWindows(mainWindow: BrowserWindow): void {
-  for (const client of gatewayClients.values()) {
-    client.setMainWindow(mainWindow);
   }
 }
 

--- a/packages/desktop/test/gateway-index.test.ts
+++ b/packages/desktop/test/gateway-index.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const clearPairingCodeMock = vi.fn();
 const connectMock = vi.fn();
-const setMainWindowMock = vi.fn();
 const destroyMock = vi.fn();
 
 vi.mock('../src/main/workspace/config.js', () => ({
@@ -13,7 +12,6 @@ vi.mock('../src/main/workspace/config.js', () => ({
 
 vi.mock('../src/main/ws/gateway-client.js', () => ({
   GatewayClient: vi.fn().mockImplementation((_config, opts) => ({
-    setMainWindow: setMainWindowMock,
     connect: connectMock,
     destroy: destroyMock,
     reconnect: vi.fn(),
@@ -26,22 +24,18 @@ describe('gateway index', () => {
     vi.resetModules();
     clearPairingCodeMock.mockReset();
     connectMock.mockReset();
-    setMainWindowMock.mockReset();
     destroyMock.mockReset();
   });
 
   it('clears pairing code through workspace config callback', async () => {
     const { addGateway } = await import('../src/main/ws/index.js');
 
-    addGateway(
-      {
-        id: 'gw-1',
-        name: 'Gateway',
-        url: 'wss://gateway.example.com/ws',
-        auth: { token: 'shared-token' },
-      },
-      {} as never,
-    );
+    addGateway({
+      id: 'gw-1',
+      name: 'Gateway',
+      url: 'wss://gateway.example.com/ws',
+      auth: { token: 'shared-token' },
+    });
 
     const { GatewayClient } = await import('../src/main/ws/gateway-client.js');
     const instance = vi.mocked(GatewayClient).mock.calls[0]?.[1];


### PR DESCRIPTION
## Summary

Fix IPC handler crash on macOS window re-creation by introducing a centralized `window-manager.ts` module. Replaces 5 scattered `BrowserWindow` reference caches and 3 manual rebind functions with a single `getMainWindow()` accessor.

## Type of change

- [x] `[Fix]` bug fix
- [x] `[Refactor]` internal cleanup

## Why is this needed?

On macOS, when all windows close and the user clicks the dock icon, `app.on('activate')` calls `createWindow()` again. Two IPC handlers registered inside `createWindow()` caused:

1. `ipcMain.handle('app:rebuild-menu')` throws `Error: Attempted to register a second handler` — app crashes.
2. `ipcMain.on('ui:set-window-button-visibility')` silently stacks duplicate listeners — callback fires N times after N re-creations, pointing at destroyed windows.

Additionally, the `mainWindow` variable in the `whenReady` closure was never updated after `activate` re-creation, creating a stale reference bug: the new window lacked a `close` handler for hide-on-close behavior.

## What changed?

- Add `window-manager.ts` with `getMainWindow()` / `setMainWindow()` — single source of truth (13 lines)
- Move `app:rebuild-menu` and `ui:set-window-button-visibility` IPC handlers from `createWindow()` to `app.whenReady()` block
- Move `close` handler into `createWindow()` so every window instance gets hide-on-close
- Remove `rebindAllWindows()` from `ws/index.ts`
- Remove `updateTrayWindow()` from `tray.ts`
- Remove `updateQuickLaunchMainWindow()` from `quick-launch.ts`
- Remove `mainWindow` field and `setMainWindow()` from `GatewayClient`
- Remove `mainWindowRef` module-level variables from `tray.ts` and `quick-launch.ts`
- Remove local `getMainWindow()` helper from `settings-handlers.ts`
- All modules now call `getMainWindow()` at point of use instead of caching stale references

## Architecture impact

- Owning layer: main
- Cross-layer impact: none — preload and renderer are untouched
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: changes are scoped to main-process window lifecycle; no message persistence, IPC channel, or protocol changes

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate: lint + architecture + ui-contract + renderer-copy + i18n + dead-code + format + typecheck + test)
- [ ] `pnpm build`
- [ ] Manual smoke test

```text
pnpm check — all green (157 tests passed, 0 failures)
```

## Screenshots or recordings

No UI changes.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate