### PR TITLE
[Fix] Replace per-token forced reflow with ResizeObserver and fix Virtuoso dual scroll context

### DIFF
--- a/packages/pwa/src/views/ChatView.tsx
+++ b/packages/pwa/src/views/ChatView.tsx
@@ -1,6 +1,7 @@
-import { useRef, useEffect, useCallback, useMemo } from 'react';
+import { useRef, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Message } from '@clawwork/shared';
+import type { ActiveTurn } from '@clawwork/core';
 import { EMPTY_MESSAGES } from '@clawwork/core';
 import { Virtuoso } from 'react-virtuoso';
 import { useTaskStore, useMessageStore, useUiStore } from '../stores/hooks';
@@ -9,6 +10,44 @@ import { StreamingMessage } from '../components/StreamingMessage';
 import { ChatInput } from '../components/ChatInput';
 
 const VIRTUALIZATION_THRESHOLD = 100;
+
+interface TailContext {
+  activeTurn: ActiveTurn | undefined;
+  processing: boolean;
+  gatewayStatus: string | undefined;
+  t: (key: string, options?: Record<string, string>) => string;
+}
+
+function ChatTail({ context }: { context?: TailContext }) {
+  if (!context) return null;
+  const { activeTurn, processing, gatewayStatus, t } = context;
+  return (
+    <>
+      {activeTurn && (activeTurn.streamingText || activeTurn.toolCalls.length > 0) && (
+        <StreamingMessage turn={activeTurn} />
+      )}
+      {processing && !activeTurn && (
+        <div className="flex items-center gap-2 py-3" role="status">
+          <div
+            className="h-2 w-2 animate-pulse rounded-full"
+            style={{ backgroundColor: 'var(--accent)' }}
+            aria-hidden="true"
+          />
+          <span className="type-support" style={{ color: 'var(--text-muted)' }}>
+            {t('chat.thinking')}
+          </span>
+        </div>
+      )}
+      {gatewayStatus === 'connecting' && (
+        <p className="px-3 py-3 type-support" style={{ color: 'var(--text-muted)' }}>
+          {t('chat.authorizationPending')}
+        </p>
+      )}
+    </>
+  );
+}
+
+const VIRTUOSO_COMPONENTS = { Footer: ChatTail };
 
 export function ChatView() {
   const { t } = useTranslation();
@@ -24,6 +63,7 @@ export function ChatView() {
   const activeTurn = useMessageStore((s) => (activeTaskId ? s.activeTurnByTask[activeTaskId] : undefined));
   const processing = useMessageStore((s) => activeTaskId !== null && s.processingTasks.has(activeTaskId));
   const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const useVirtualization = messages.length >= VIRTUALIZATION_THRESHOLD;
 
   const messageItems = useMemo(
@@ -31,15 +71,30 @@ export function ChatView() {
     [messages],
   );
 
-  const scrollToBottom = useCallback(() => {
-    if (!useVirtualization && scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [useVirtualization]);
+  const tailContext = useMemo<TailContext>(
+    () => ({ activeTurn, processing, gatewayStatus, t }),
+    [activeTurn, processing, gatewayStatus, t],
+  );
 
   useEffect(() => {
-    scrollToBottom();
-  }, [messages.length, activeTurn?.streamingText, scrollToBottom]);
+    const container = scrollRef.current;
+    const content = contentRef.current;
+    if (!container || !content || useVirtualization) return;
+
+    let raf = 0;
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        container.scrollTop = container.scrollHeight;
+      });
+    });
+    ro.observe(content);
+
+    return () => {
+      ro.disconnect();
+      cancelAnimationFrame(raf);
+    };
+  }, [useVirtualization]);
 
   if (!activeTaskId && !pendingNewTask) {
     return (
@@ -66,39 +121,29 @@ export function ChatView() {
 
   return (
     <div className="flex h-full flex-col" role="main" aria-label={t('chat.mainArea', { defaultValue: 'Chat' })}>
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4">
+      <div
+        ref={useVirtualization ? undefined : scrollRef}
+        className={`flex-1 px-4 py-4 ${useVirtualization ? 'overflow-hidden' : 'overflow-y-auto'}`}
+      >
         {useVirtualization ? (
           <Virtuoso
             style={{ height: '100%' }}
             data={messageItems}
             followOutput="smooth"
             alignToBottom
+            context={tailContext}
             aria-label={t('chat.virtualizedList')}
             computeItemKey={(_index, item) => item.id}
             itemContent={(_index, item) => <ChatMessage message={item.message} />}
+            components={VIRTUOSO_COMPONENTS}
           />
         ) : (
-          messages.map((msg) => <ChatMessage key={msg.id} message={msg} />)
-        )}
-        {activeTurn && (activeTurn.streamingText || activeTurn.toolCalls.length > 0) && (
-          <StreamingMessage turn={activeTurn} />
-        )}
-        {processing && !activeTurn && (
-          <div className="flex items-center gap-2 py-3" role="status">
-            <div
-              className="h-2 w-2 animate-pulse rounded-full"
-              style={{ backgroundColor: 'var(--accent)' }}
-              aria-hidden="true"
-            />
-            <span className="type-support" style={{ color: 'var(--text-muted)' }}>
-              {t('chat.thinking')}
-            </span>
+          <div ref={contentRef}>
+            {messages.map((msg) => (
+              <ChatMessage key={msg.id} message={msg} />
+            ))}
+            <ChatTail context={tailContext} />
           </div>
-        )}
-        {gatewayStatus === 'connecting' && (
-          <p className="px-3 py-3 type-support" style={{ color: 'var(--text-muted)' }}>
-            {t('chat.authorizationPending')}
-          </p>
         )}
       </div>
       <ChatInput taskId={activeTaskId ?? '__pending__'} />


### PR DESCRIPTION
## Summary

ChatView had two scroll architecture flaws: (1) `scrollToBottom` fired on every streaming token via `useEffect` on `activeTurn?.streamingText`, causing synchronous `scrollTop = scrollHeight` forced reflow ~30 times/second; (2) Virtuoso nested inside `overflow-y-auto` created competing scroll contexts, with `StreamingMessage` rendered outside Virtuoso's scroll ownership.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Per-token forced reflow causes visible jank on mobile during streaming. The dual scroll context means streaming content may be clipped or unreachable when virtualization is active (≥100 messages).

## What changed?

- Replaced `scrollToBottom` callback + `useEffect` depending on `activeTurn?.streamingText` with a single `ResizeObserver` on a content wrapper div — zero coupling to React data flow, fires at most once per frame
- Extracted tail content (StreamingMessage, thinking indicator, connecting status) into `ChatTail` component whose prop shape `{ context?: TailContext }` directly matches Virtuoso's Footer API
- Non-virtualized path: `overflow-y-auto` + `scrollRef` + `contentRef` wrapper observed by ResizeObserver
- Virtualized path: `overflow-hidden`, no scrollRef; tail content rendered via Virtuoso `components.Footer` so `followOutput` accounts for streaming height changes
- `VIRTUOSO_COMPONENTS` defined at module level for stable component identity (prevents unmount/remount per render)

## Architecture impact

- Owning layer: renderer (PWA)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is purely renderer-side scroll behavior, no DB/IPC/protocol changes

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full suite: lint + architecture + ui-contract + renderer-copy + i18n + dead-code + format + typecheck + test)
- [ ] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm check — all gates passed (92+59+6 tests, zero failures)
```

## Screenshots or recordings

No visual change. Scroll behavior is functionally identical — the fix eliminates forced reflow during streaming and resolves scroll context conflicts in virtualized mode.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate