### PR TITLE
[Fix] PWA i18n structural integrity — complete key coverage, stable debug log keys, CI guard

### DIFF
--- a/packages/core/src/services/error-classify.ts
+++ b/packages/core/src/services/error-classify.ts
@@ -31,13 +31,13 @@ export function formatErrorForUser(err: AppError, t: TranslateFn): string {
   const stageLabel = t(`errors.stage.${err.stage}`, { defaultValue: err.stage });
   if (err.rawMessage) return `${stageLabel}: ${err.rawMessage}`;
   if (err.code) return `${stageLabel}: [${err.code}]`;
-  return `${stageLabel}: ${t('errors.unknown', { defaultValue: 'Unknown error' })}`;
+  return `${stageLabel}: ${t('errors.unknown')}`;
 }
 
 export function formatErrorForToast(err: AppError, t: TranslateFn): { title: string; description: string } {
   const stageKey = `errors.stage.${err.stage}`;
   const stageLabel = t(stageKey, { defaultValue: err.stage });
-  const title = `${stageLabel} ${t('errors.failed', { defaultValue: 'failed' })}`;
-  const description = err.rawMessage || err.code || t('errors.unknown', { defaultValue: 'Unknown error' });
+  const title = `${stageLabel} ${t('errors.failed')}`;
+  const description = err.rawMessage || err.code || t('errors.unknown');
   return { title, description };
 }

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -87,7 +87,7 @@ function AppShell({ onSignedOut }: { onSignedOut: () => void }) {
             minHeight: 44,
           }}
         >
-          {t('shell.reconnect', { defaultValue: 'Reconnect' })}
+          {t('shell.reconnect')}
         </button>
       </div>
     );

--- a/packages/pwa/src/components/ChatMessage.tsx
+++ b/packages/pwa/src/components/ChatMessage.tsx
@@ -25,7 +25,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
     return (
       <div
         role="article"
-        aria-label={t('chat.systemMessage', { defaultValue: 'System message' })}
+        aria-label={t('chat.systemMessage')}
         className="mb-3 flex items-start gap-2 rounded-lg px-3 py-2"
         style={{ backgroundColor: 'var(--bg-tertiary)', opacity: 0.7 }}
       >
@@ -41,11 +41,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
 
   if (isUser) {
     return (
-      <div
-        role="article"
-        aria-label={t('chat.userMessage', { defaultValue: 'Your message' })}
-        className="mb-4 flex justify-end"
-      >
+      <div role="article" aria-label={t('chat.userMessage')} className="mb-4 flex justify-end">
         <div className="rounded-2xl px-4 py-2.5" style={{ backgroundColor: 'var(--user-bubble-bg)', maxWidth: '85%' }}>
           <p className="whitespace-pre-wrap type-body" style={{ color: 'var(--text-primary)' }}>
             {message.content}
@@ -56,7 +52,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
   }
 
   return (
-    <div role="article" aria-label={t('chat.assistantMessage', { defaultValue: 'Assistant message' })} className="mb-4">
+    <div role="article" aria-label={t('chat.assistantMessage')} className="mb-4">
       {message.content && (
         <div className="prose-chat type-body">
           <Suspense fallback={<MarkdownFallback content={message.content} />}>

--- a/packages/pwa/src/components/GatewayDebugLog.tsx
+++ b/packages/pwa/src/components/GatewayDebugLog.tsx
@@ -1,4 +1,5 @@
 import { useSyncExternalStore, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { X, Trash2, Copy, RefreshCw } from 'lucide-react';
 import { getDebugLog, subscribeDebugLog, clearDebugLog } from '../lib/debug';
 import { reconnectAllClients } from '../gateway/client-registry';
@@ -47,6 +48,7 @@ function compactData(entry: DebugLogEntry): string | null {
 }
 
 export function GatewayDebugLog({ open, onClose }: GatewayDebugLogProps) {
+  const { t } = useTranslation();
   const log = useSyncExternalStore(subscribeDebugLog, getDebugLog);
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -65,17 +67,17 @@ export function GatewayDebugLog({ open, onClose }: GatewayDebugLogProps) {
   };
 
   return (
-    <BottomSheet open={open} onClose={onClose} maxHeight="80vh" ariaLabel="Gateway Log">
+    <BottomSheet open={open} onClose={onClose} maxHeight="80vh" ariaLabel={t('debugLog.title')}>
       <div className="flex shrink-0 items-center justify-between px-4 py-2" style={{ touchAction: 'manipulation' }}>
         <span className="type-label" style={{ color: 'var(--text-primary)' }}>
-          Gateway Log ({log.length})
+          {t('debugLog.title')} ({log.length})
         </span>
         <div className="flex items-center gap-2">
           <button
             onClick={reconnectAllClients}
             className="rounded-lg p-1.5 transition-colors"
             style={{ color: 'var(--accent)', minHeight: 36, minWidth: 36 }}
-            aria-label="Reconnect"
+            aria-label={t('debugLog.reconnect')}
           >
             <RefreshCw size={16} />
           </button>
@@ -83,7 +85,7 @@ export function GatewayDebugLog({ open, onClose }: GatewayDebugLogProps) {
             onClick={handleCopy}
             className="rounded-lg p-1.5 transition-colors"
             style={{ color: 'var(--text-secondary)', minHeight: 36, minWidth: 36 }}
-            aria-label="Copy log"
+            aria-label={t('debugLog.copyLog')}
           >
             <Copy size={16} />
           </button>
@@ -91,7 +93,7 @@ export function GatewayDebugLog({ open, onClose }: GatewayDebugLogProps) {
             onClick={clearDebugLog}
             className="rounded-lg p-1.5 transition-colors"
             style={{ color: 'var(--text-secondary)', minHeight: 36, minWidth: 36 }}
-            aria-label="Clear log"
+            aria-label={t('debugLog.clearLog')}
           >
             <Trash2 size={16} />
           </button>
@@ -99,7 +101,7 @@ export function GatewayDebugLog({ open, onClose }: GatewayDebugLogProps) {
             onClick={onClose}
             className="rounded-lg p-1.5 transition-colors"
             style={{ color: 'var(--text-secondary)', minHeight: 36, minWidth: 36 }}
-            aria-label="Close"
+            aria-label={t('debugLog.close')}
           >
             <X size={16} />
           </button>
@@ -112,13 +114,13 @@ export function GatewayDebugLog({ open, onClose }: GatewayDebugLogProps) {
       >
         {log.length === 0 && (
           <div className="py-8 text-center" style={{ color: 'var(--text-muted)' }}>
-            No events yet
+            {t('debugLog.empty')}
           </div>
         )}
-        {log.map((entry, i) => {
+        {log.map((entry) => {
           const data = compactData(entry);
           return (
-            <div key={i} className="flex gap-2 py-0.5" style={{ wordBreak: 'break-all' }}>
+            <div key={entry.id} className="flex gap-2 py-0.5" style={{ wordBreak: 'break-all' }}>
               <span className="shrink-0 tabular-nums" style={{ color: 'var(--text-muted)' }}>
                 {formatTime(entry.ts)}
               </span>

--- a/packages/pwa/src/components/GatewayStatus.tsx
+++ b/packages/pwa/src/components/GatewayStatus.tsx
@@ -10,11 +10,7 @@ export function GatewayStatus() {
   if (entries.length === 0) return null;
 
   return (
-    <div
-      className="flex flex-wrap gap-1.5"
-      role="status"
-      aria-label={t('gateway.statusLabel', { defaultValue: 'Gateway connection status' })}
-    >
+    <div className="flex flex-wrap gap-1.5" role="status" aria-label={t('gateway.statusLabel')}>
       {entries.map(([gwId, status]) => {
         const info = infoMap[gwId];
         const color =

--- a/packages/pwa/src/components/SettingsSheet.tsx
+++ b/packages/pwa/src/components/SettingsSheet.tsx
@@ -59,9 +59,7 @@ export function SettingsSheet({ open, onClose, onSignOut }: SettingsSheetProps) 
         >
           {isDark ? <Moon size={18} /> : <Sun size={18} />}
           <span className="flex-1 text-left type-body">
-            {isDark
-              ? t('settings.darkMode', { defaultValue: 'Dark Mode' })
-              : t('settings.lightMode', { defaultValue: 'Light Mode' })}
+            {isDark ? t('settings.darkMode') : t('settings.lightMode')}
           </span>
           <span className="type-support" style={{ color: 'var(--text-muted)' }}>
             {isDark ? '🌙' : '☀️'}
@@ -72,7 +70,7 @@ export function SettingsSheet({ open, onClose, onSignOut }: SettingsSheetProps) 
           <div className="flex items-center gap-3 px-3 py-3">
             <Globe size={18} style={{ color: 'var(--text-primary)' }} />
             <span className="type-body" style={{ color: 'var(--text-primary)' }}>
-              {t('settings.language', { defaultValue: 'Language' })}
+              {t('settings.language')}
             </span>
           </div>
           <div className="grid grid-cols-2 gap-1 px-1">

--- a/packages/pwa/src/components/StreamingMessage.tsx
+++ b/packages/pwa/src/components/StreamingMessage.tsx
@@ -14,7 +14,7 @@ export function StreamingMessage({ turn }: StreamingMessageProps) {
   const text = turn.streamingText || turn.content;
 
   return (
-    <div className="mb-4" role="article" aria-label={t('chat.assistantMessage', { defaultValue: 'Assistant message' })}>
+    <div className="mb-4" role="article" aria-label={t('chat.assistantMessage')}>
       {!text && !turn.finalized && (
         <div className="flex items-center gap-1.5 py-3" aria-label={t('chat.thinking')}>
           <div className="h-2 w-2 animate-pulse rounded-full" style={{ backgroundColor: 'var(--text-muted)' }} />

--- a/packages/pwa/src/components/TaskList.tsx
+++ b/packages/pwa/src/components/TaskList.tsx
@@ -55,7 +55,7 @@ export function TaskList({ onSelect }: TaskListProps) {
   });
 
   return (
-    <nav className="py-2" role="navigation" aria-label={t('tasks.navigationLabel', { defaultValue: 'Task list' })}>
+    <nav className="py-2" role="navigation" aria-label={t('tasks.navigationLabel')}>
       {groupedTasks.map((group) => (
         <div key={group.label}>
           <div className="px-4 py-1.5">

--- a/packages/pwa/src/components/ToolCallCard.tsx
+++ b/packages/pwa/src/components/ToolCallCard.tsx
@@ -79,7 +79,7 @@ export function ToolCallCard({ toolCall }: ToolCallCardProps) {
           )}
           {!toolCall.args && !toolCall.result && (
             <span className="type-support" style={{ color: 'var(--text-muted)' }}>
-              {t('tools.emptyDetails', { defaultValue: 'No details available' })}
+              {t('tools.emptyDetails')}
             </span>
           )}
         </div>

--- a/packages/pwa/src/i18n/locales/de.json
+++ b/packages/pwa/src/i18n/locales/de.json
@@ -1,21 +1,18 @@
 {
   "app": {
+    "name": "ClawWork",
     "loading": "Laden...",
     "error": "Ein Fehler ist aufgetreten",
     "reload": "Neu laden",
     "paired": "Mobilgerät gekoppelt"
   },
   "pairing": {
-    "title": "Mit PC koppeln",
     "subtitle": "Scannen Sie den QR-Code auf Ihrer Desktop-App",
     "instruction": "Nach dem Scannen genehmigen Sie dieses Gerät auf dem Desktop.",
-    "scanning": "Scannen...",
     "loadingCamera": "Kamera wird gestartet...",
     "scanButton": "QR-Code scannen",
     "cancelButton": "Abbrechen",
-    "error": "Kopplung fehlgeschlagen",
     "invalidQr": "Ungültiger QR-Code",
-    "retryButton": "Erneut versuchen",
     "cameraError": "Kamerazugriff verweigert",
     "videoError": "Kamera konnte nicht gestartet werden",
     "scannerUnsupported": "QR-Scanner wird in diesem Browser nicht unterstützt"
@@ -30,7 +27,6 @@
     "systemMessage": "Systemnachricht",
     "userMessage": "Ihre Nachricht",
     "assistantMessage": "Assistenznachricht",
-    "you": "Sie",
     "assistant": "Assistent",
     "mainArea": "Chat",
     "virtualizedList": "Chatverlauf"
@@ -48,21 +44,20 @@
     "connected": "Verbunden",
     "connecting": "Verbinde...",
     "disconnected": "Getrennt",
-    "notFound": "Gateway nicht gefunden",
     "statusLabel": "Gateway-Verbindungsstatus"
   },
   "agents": { "selectTitle": "Agent auswählen", "empty": "Keine Agenten verfügbar" },
   "drawer": {
+    "title": "Navigationsmenü",
     "settings": "Einstellungen",
     "signOut": "Abmelden",
     "menuButton": "Menü öffnen",
     "closeButton": "Menü schließen",
-    "newTaskButton": "Neue Aufgabe"
+    "newTaskButton": "Neue Aufgabe",
+    "search": "Suchen"
   },
-  "tools": { "expandButton": "Details anzeigen", "collapseButton": "Details ausblenden" },
+  "tools": { "emptyDetails": "Keine Details verfügbar" },
   "shell": {
-    "connected": "Gateway verbunden",
-    "bootstrapping": "Verbinde mit Gateway...",
     "reconnect": "Neu verbinden"
   },
   "errors": {
@@ -82,5 +77,13 @@
     }
   },
   "qrScanner": { "videoLabel": "Kamerasucher für QR-Code-Scan", "scanFrameLabel": "QR-Code-Scanbereich" },
-  "settings": { "darkMode": "Dunkelmodus", "lightMode": "Hellmodus", "language": "Sprache" }
+  "settings": { "darkMode": "Dunkelmodus", "lightMode": "Hellmodus", "language": "Sprache" },
+  "debugLog": {
+    "title": "Gateway-Protokoll",
+    "reconnect": "Neu verbinden",
+    "copyLog": "Protokoll kopieren",
+    "clearLog": "Protokoll löschen",
+    "close": "Schließen",
+    "empty": "Noch keine Ereignisse"
+  }
 }

--- a/packages/pwa/src/i18n/locales/en.json
+++ b/packages/pwa/src/i18n/locales/en.json
@@ -1,21 +1,18 @@
 {
   "app": {
+    "name": "ClawWork",
     "loading": "Loading...",
     "error": "Something went wrong",
     "reload": "Reload",
     "paired": "Mobile device paired"
   },
   "pairing": {
-    "title": "Pair with your PC",
     "subtitle": "Scan the QR code shown on your desktop app to get started",
     "instruction": "After scanning, approve this device on your desktop before the mobile app can connect.",
-    "scanning": "Scanning...",
     "loadingCamera": "Loading camera...",
     "scanButton": "Scan QR Code",
     "cancelButton": "Cancel",
-    "error": "Pairing failed",
     "invalidQr": "Invalid QR code",
-    "retryButton": "Try Again",
     "cameraError": "Camera access denied",
     "videoError": "Failed to start camera",
     "scannerUnsupported": "QR scanner not supported on this browser"
@@ -30,7 +27,6 @@
     "systemMessage": "System message",
     "userMessage": "Your message",
     "assistantMessage": "Assistant message",
-    "you": "You",
     "assistant": "Assistant",
     "mainArea": "Chat",
     "virtualizedList": "Chat transcript"
@@ -48,7 +44,6 @@
     "connected": "Connected",
     "connecting": "Connecting...",
     "disconnected": "Disconnected",
-    "notFound": "Gateway not found",
     "statusLabel": "Gateway connection status"
   },
   "agents": {
@@ -56,19 +51,19 @@
     "empty": "No agents available"
   },
   "drawer": {
+    "title": "Navigation drawer",
     "settings": "Settings",
     "signOut": "Sign out",
     "menuButton": "Open menu",
     "closeButton": "Close menu",
-    "newTaskButton": "New task"
+    "newTaskButton": "New task",
+    "search": "Search"
   },
   "tools": {
-    "expandButton": "Show details",
-    "collapseButton": "Hide details"
+    "emptyDetails": "No details available"
   },
   "shell": {
-    "connected": "Gateway connected",
-    "bootstrapping": "Connecting to gateway..."
+    "reconnect": "Reconnect"
   },
   "errors": {
     "requestFailed": "Request failed",
@@ -89,5 +84,18 @@
   "qrScanner": {
     "videoLabel": "Camera viewfinder for QR code scanning",
     "scanFrameLabel": "QR code scan area"
+  },
+  "settings": {
+    "darkMode": "Dark Mode",
+    "lightMode": "Light Mode",
+    "language": "Language"
+  },
+  "debugLog": {
+    "title": "Gateway Log",
+    "reconnect": "Reconnect",
+    "copyLog": "Copy log",
+    "clearLog": "Clear log",
+    "close": "Close",
+    "empty": "No events yet"
   }
 }

--- a/packages/pwa/src/i18n/locales/es.json
+++ b/packages/pwa/src/i18n/locales/es.json
@@ -1,21 +1,18 @@
 {
   "app": {
+    "name": "ClawWork",
     "loading": "Cargando...",
     "error": "Algo salió mal",
     "reload": "Recargar",
     "paired": "Dispositivo móvil emparejado"
   },
   "pairing": {
-    "title": "Emparejar con PC",
     "subtitle": "Escanea el código QR que aparece en tu app de escritorio",
     "instruction": "Después de escanear, aprueba este dispositivo en el escritorio.",
-    "scanning": "Escaneando...",
     "loadingCamera": "Iniciando cámara...",
     "scanButton": "Escanear código QR",
     "cancelButton": "Cancelar",
-    "error": "Error de emparejamiento",
     "invalidQr": "Código QR no válido",
-    "retryButton": "Reintentar",
     "cameraError": "Acceso a la cámara denegado",
     "videoError": "No se pudo iniciar la cámara",
     "scannerUnsupported": "Escáner QR no soportado en este navegador"
@@ -30,7 +27,6 @@
     "systemMessage": "Mensaje del sistema",
     "userMessage": "Tu mensaje",
     "assistantMessage": "Mensaje del asistente",
-    "you": "Tú",
     "assistant": "Asistente",
     "mainArea": "Chat",
     "virtualizedList": "Historial de chat"
@@ -48,19 +44,20 @@
     "connected": "Conectado",
     "connecting": "Conectando...",
     "disconnected": "Desconectado",
-    "notFound": "Gateway no encontrado",
     "statusLabel": "Estado de conexión del gateway"
   },
   "agents": { "selectTitle": "Seleccionar agente", "empty": "No hay agentes disponibles" },
   "drawer": {
+    "title": "Panel de navegación",
     "settings": "Configuración",
     "signOut": "Cerrar sesión",
     "menuButton": "Abrir menú",
     "closeButton": "Cerrar menú",
-    "newTaskButton": "Nueva tarea"
+    "newTaskButton": "Nueva tarea",
+    "search": "Buscar"
   },
-  "tools": { "expandButton": "Mostrar detalles", "collapseButton": "Ocultar detalles" },
-  "shell": { "connected": "Gateway conectado", "bootstrapping": "Conectando al gateway...", "reconnect": "Reconectar" },
+  "tools": { "emptyDetails": "Sin detalles disponibles" },
+  "shell": { "reconnect": "Reconectar" },
   "errors": {
     "requestFailed": "Solicitud fallida",
     "sendFailed": "Envío fallido",
@@ -78,5 +75,13 @@
     }
   },
   "qrScanner": { "videoLabel": "Visor de cámara para escaneo QR", "scanFrameLabel": "Área de escaneo QR" },
-  "settings": { "darkMode": "Modo oscuro", "lightMode": "Modo claro", "language": "Idioma" }
+  "settings": { "darkMode": "Modo oscuro", "lightMode": "Modo claro", "language": "Idioma" },
+  "debugLog": {
+    "title": "Registro del gateway",
+    "reconnect": "Reconectar",
+    "copyLog": "Copiar registro",
+    "clearLog": "Borrar registro",
+    "close": "Cerrar",
+    "empty": "Sin eventos aún"
+  }
 }

--- a/packages/pwa/src/i18n/locales/ja.json
+++ b/packages/pwa/src/i18n/locales/ja.json
@@ -1,21 +1,18 @@
 {
   "app": {
+    "name": "ClawWork",
     "loading": "読み込み中...",
     "error": "エラーが発生しました",
     "reload": "再読み込み",
     "paired": "モバイルデバイスがペアリングされました"
   },
   "pairing": {
-    "title": "PCとペアリング",
     "subtitle": "デスクトップアプリに表示されたQRコードをスキャンしてください",
     "instruction": "スキャン後、デスクトップでこのデバイスを承認してください。",
-    "scanning": "スキャン中...",
     "loadingCamera": "カメラを起動中...",
     "scanButton": "QRコードをスキャン",
     "cancelButton": "キャンセル",
-    "error": "ペアリング失敗",
     "invalidQr": "無効なQRコード",
-    "retryButton": "再試行",
     "cameraError": "カメラの権限が拒否されました",
     "videoError": "カメラを起動できません",
     "scannerUnsupported": "このブラウザではQRスキャンがサポートされていません"
@@ -30,7 +27,6 @@
     "systemMessage": "システムメッセージ",
     "userMessage": "あなたのメッセージ",
     "assistantMessage": "アシスタントメッセージ",
-    "you": "あなた",
     "assistant": "アシスタント",
     "mainArea": "チャット",
     "virtualizedList": "チャット履歴"
@@ -48,7 +44,6 @@
     "connected": "接続済み",
     "connecting": "接続中...",
     "disconnected": "切断",
-    "notFound": "ゲートウェイが見つかりません",
     "statusLabel": "ゲートウェイ接続状態"
   },
   "agents": {
@@ -56,19 +51,18 @@
     "empty": "利用可能なエージェントがありません"
   },
   "drawer": {
+    "title": "ナビゲーションメニュー",
     "settings": "設定",
     "signOut": "サインアウト",
     "menuButton": "メニューを開く",
     "closeButton": "メニューを閉じる",
-    "newTaskButton": "新しいタスク"
+    "newTaskButton": "新しいタスク",
+    "search": "検索"
   },
   "tools": {
-    "expandButton": "詳細を表示",
-    "collapseButton": "詳細を非表示"
+    "emptyDetails": "詳細情報なし"
   },
   "shell": {
-    "connected": "ゲートウェイ接続済み",
-    "bootstrapping": "ゲートウェイに接続中...",
     "reconnect": "再接続"
   },
   "errors": {
@@ -95,5 +89,13 @@
     "darkMode": "ダークモード",
     "lightMode": "ライトモード",
     "language": "言語"
+  },
+  "debugLog": {
+    "title": "ゲートウェイログ",
+    "reconnect": "再接続",
+    "copyLog": "ログをコピー",
+    "clearLog": "ログをクリア",
+    "close": "閉じる",
+    "empty": "イベントはまだありません"
   }
 }

--- a/packages/pwa/src/i18n/locales/ko.json
+++ b/packages/pwa/src/i18n/locales/ko.json
@@ -1,21 +1,18 @@
 {
   "app": {
+    "name": "ClawWork",
     "loading": "로딩 중...",
     "error": "오류가 발생했습니다",
     "reload": "새로고침",
     "paired": "모바일 기기가 페어링되었습니다"
   },
   "pairing": {
-    "title": "PC와 페어링",
     "subtitle": "데스크톱 앱에 표시된 QR 코드를 스캔하세요",
     "instruction": "스캔 후 데스크톱에서 이 기기를 승인해 주세요.",
-    "scanning": "스캔 중...",
     "loadingCamera": "카메라 시작 중...",
     "scanButton": "QR 코드 스캔",
     "cancelButton": "취소",
-    "error": "페어링 실패",
     "invalidQr": "유효하지 않은 QR 코드",
-    "retryButton": "다시 시도",
     "cameraError": "카메라 권한이 거부되었습니다",
     "videoError": "카메라를 시작할 수 없습니다",
     "scannerUnsupported": "이 브라우저에서는 QR 스캔이 지원되지 않습니다"
@@ -30,7 +27,6 @@
     "systemMessage": "시스템 메시지",
     "userMessage": "내 메시지",
     "assistantMessage": "어시스턴트 메시지",
-    "you": "나",
     "assistant": "어시스턴트",
     "mainArea": "채팅",
     "virtualizedList": "채팅 기록"
@@ -48,19 +44,20 @@
     "connected": "연결됨",
     "connecting": "연결 중...",
     "disconnected": "연결 끊김",
-    "notFound": "게이트웨이를 찾을 수 없음",
     "statusLabel": "게이트웨이 연결 상태"
   },
   "agents": { "selectTitle": "에이전트 선택", "empty": "사용 가능한 에이전트 없음" },
   "drawer": {
+    "title": "탐색 메뉴",
     "settings": "설정",
     "signOut": "로그아웃",
     "menuButton": "메뉴 열기",
     "closeButton": "메뉴 닫기",
-    "newTaskButton": "새 작업"
+    "newTaskButton": "새 작업",
+    "search": "검색"
   },
-  "tools": { "expandButton": "상세 보기", "collapseButton": "상세 숨기기" },
-  "shell": { "connected": "게이트웨이 연결됨", "bootstrapping": "게이트웨이 연결 중...", "reconnect": "재연결" },
+  "tools": { "emptyDetails": "상세 정보 없음" },
+  "shell": { "reconnect": "재연결" },
   "errors": {
     "requestFailed": "요청 실패",
     "sendFailed": "전송 실패",
@@ -78,5 +75,13 @@
     }
   },
   "qrScanner": { "videoLabel": "QR 코드 스캔 뷰파인더", "scanFrameLabel": "QR 코드 스캔 영역" },
-  "settings": { "darkMode": "다크 모드", "lightMode": "라이트 모드", "language": "언어" }
+  "settings": { "darkMode": "다크 모드", "lightMode": "라이트 모드", "language": "언어" },
+  "debugLog": {
+    "title": "게이트웨이 로그",
+    "reconnect": "재연결",
+    "copyLog": "로그 복사",
+    "clearLog": "로그 지우기",
+    "close": "닫기",
+    "empty": "아직 이벤트가 없습니다"
+  }
 }

--- a/packages/pwa/src/i18n/locales/pt.json
+++ b/packages/pwa/src/i18n/locales/pt.json
@@ -1,21 +1,18 @@
 {
   "app": {
+    "name": "ClawWork",
     "loading": "Carregando...",
     "error": "Algo deu errado",
     "reload": "Recarregar",
     "paired": "Dispositivo móvel emparelhado"
   },
   "pairing": {
-    "title": "Emparelhar com PC",
     "subtitle": "Escaneie o código QR exibido no seu app desktop",
     "instruction": "Após escanear, aprove este dispositivo no desktop.",
-    "scanning": "Escaneando...",
     "loadingCamera": "Iniciando câmera...",
     "scanButton": "Escanear código QR",
     "cancelButton": "Cancelar",
-    "error": "Falha no emparelhamento",
     "invalidQr": "Código QR inválido",
-    "retryButton": "Tentar novamente",
     "cameraError": "Acesso à câmera negado",
     "videoError": "Não foi possível iniciar a câmera",
     "scannerUnsupported": "Scanner QR não suportado neste navegador"
@@ -30,7 +27,6 @@
     "systemMessage": "Mensagem do sistema",
     "userMessage": "Sua mensagem",
     "assistantMessage": "Mensagem do assistente",
-    "you": "Você",
     "assistant": "Assistente",
     "mainArea": "Chat",
     "virtualizedList": "Histórico do chat"
@@ -48,19 +44,20 @@
     "connected": "Conectado",
     "connecting": "Conectando...",
     "disconnected": "Desconectado",
-    "notFound": "Gateway não encontrado",
     "statusLabel": "Status da conexão do gateway"
   },
   "agents": { "selectTitle": "Selecionar agente", "empty": "Nenhum agente disponível" },
   "drawer": {
+    "title": "Painel de navegação",
     "settings": "Configurações",
     "signOut": "Sair",
     "menuButton": "Abrir menu",
     "closeButton": "Fechar menu",
-    "newTaskButton": "Nova tarefa"
+    "newTaskButton": "Nova tarefa",
+    "search": "Pesquisar"
   },
-  "tools": { "expandButton": "Mostrar detalhes", "collapseButton": "Ocultar detalhes" },
-  "shell": { "connected": "Gateway conectado", "bootstrapping": "Conectando ao gateway...", "reconnect": "Reconectar" },
+  "tools": { "emptyDetails": "Nenhum detalhe disponível" },
+  "shell": { "reconnect": "Reconectar" },
   "errors": {
     "requestFailed": "Falha na solicitação",
     "sendFailed": "Falha no envio",
@@ -78,5 +75,13 @@
     }
   },
   "qrScanner": { "videoLabel": "Visor da câmera para escaneamento QR", "scanFrameLabel": "Área de escaneamento QR" },
-  "settings": { "darkMode": "Modo escuro", "lightMode": "Modo claro", "language": "Idioma" }
+  "settings": { "darkMode": "Modo escuro", "lightMode": "Modo claro", "language": "Idioma" },
+  "debugLog": {
+    "title": "Registro do gateway",
+    "reconnect": "Reconectar",
+    "copyLog": "Copiar registro",
+    "clearLog": "Limpar registro",
+    "close": "Fechar",
+    "empty": "Nenhum evento ainda"
+  }
 }

--- a/packages/pwa/src/i18n/locales/zh-TW.json
+++ b/packages/pwa/src/i18n/locales/zh-TW.json
@@ -1,21 +1,18 @@
 {
   "app": {
+    "name": "ClawWork",
     "loading": "載入中...",
     "error": "發生錯誤",
     "reload": "重新載入",
     "paired": "行動裝置已配對"
   },
   "pairing": {
-    "title": "與電腦配對",
     "subtitle": "掃描桌面應用程式上顯示的 QR Code 以開始",
     "instruction": "掃碼後，請在桌面端批准此裝置，然後手機端即可連線。",
-    "scanning": "掃描中...",
     "loadingCamera": "正在啟動相機...",
     "scanButton": "掃描 QR Code",
     "cancelButton": "取消",
-    "error": "配對失敗",
     "invalidQr": "無效的 QR Code",
-    "retryButton": "重試",
     "cameraError": "相機權限被拒絕",
     "videoError": "無法啟動相機",
     "scannerUnsupported": "此瀏覽器不支援 QR Code 掃描"
@@ -30,7 +27,6 @@
     "systemMessage": "系統訊息",
     "userMessage": "你的訊息",
     "assistantMessage": "助手訊息",
-    "you": "你",
     "assistant": "助手",
     "mainArea": "聊天",
     "virtualizedList": "聊天記錄"
@@ -48,7 +44,6 @@
     "connected": "已連線",
     "connecting": "連線中...",
     "disconnected": "未連線",
-    "notFound": "未找到閘道",
     "statusLabel": "閘道連線狀態"
   },
   "agents": {
@@ -56,19 +51,18 @@
     "empty": "暫無可用智能體"
   },
   "drawer": {
+    "title": "導航選單",
     "settings": "設定",
     "signOut": "登出",
     "menuButton": "開啟選單",
     "closeButton": "關閉選單",
-    "newTaskButton": "新建任務"
+    "newTaskButton": "新建任務",
+    "search": "搜尋"
   },
   "tools": {
-    "expandButton": "顯示詳情",
-    "collapseButton": "隱藏詳情"
+    "emptyDetails": "暫無詳情"
   },
   "shell": {
-    "connected": "閘道已連線",
-    "bootstrapping": "正在連接閘道...",
     "reconnect": "重新連線"
   },
   "errors": {
@@ -95,5 +89,13 @@
     "darkMode": "深色模式",
     "lightMode": "淺色模式",
     "language": "語言"
+  },
+  "debugLog": {
+    "title": "閘道日誌",
+    "reconnect": "重新連線",
+    "copyLog": "複製日誌",
+    "clearLog": "清除日誌",
+    "close": "關閉",
+    "empty": "尚無事件"
   }
 }

--- a/packages/pwa/src/i18n/locales/zh.json
+++ b/packages/pwa/src/i18n/locales/zh.json
@@ -1,21 +1,18 @@
 {
   "app": {
+    "name": "ClawWork",
     "loading": "加载中...",
     "error": "出现错误",
     "reload": "重新加载",
     "paired": "移动设备已配对"
   },
   "pairing": {
-    "title": "与电脑配对",
     "subtitle": "扫描桌面应用上显示的二维码以开始",
     "instruction": "扫码后，请在桌面端批准此设备，然后手机端即可连接。",
-    "scanning": "扫描中...",
     "loadingCamera": "正在启动相机...",
     "scanButton": "扫描二维码",
     "cancelButton": "取消",
-    "error": "配对失败",
     "invalidQr": "无效的二维码",
-    "retryButton": "重试",
     "cameraError": "相机权限被拒绝",
     "videoError": "无法启动相机",
     "scannerUnsupported": "此浏览器不支持二维码扫描"
@@ -30,7 +27,6 @@
     "systemMessage": "系统消息",
     "userMessage": "你的消息",
     "assistantMessage": "助手消息",
-    "you": "你",
     "assistant": "助手",
     "mainArea": "聊天",
     "virtualizedList": "聊天记录"
@@ -48,7 +44,6 @@
     "connected": "已连接",
     "connecting": "连接中...",
     "disconnected": "未连接",
-    "notFound": "未找到网关",
     "statusLabel": "网关连接状态"
   },
   "agents": {
@@ -56,19 +51,18 @@
     "empty": "暂无可用智能体"
   },
   "drawer": {
+    "title": "导航菜单",
     "settings": "设置",
     "signOut": "退出登录",
     "menuButton": "打开菜单",
     "closeButton": "关闭菜单",
-    "newTaskButton": "新建任务"
+    "newTaskButton": "新建任务",
+    "search": "搜索"
   },
   "tools": {
-    "expandButton": "显示详情",
-    "collapseButton": "隐藏详情"
+    "emptyDetails": "暂无详情"
   },
   "shell": {
-    "connected": "网关已连接",
-    "bootstrapping": "正在连接网关...",
     "reconnect": "重新连接"
   },
   "errors": {
@@ -95,5 +89,13 @@
     "darkMode": "深色模式",
     "lightMode": "浅色模式",
     "language": "语言"
+  },
+  "debugLog": {
+    "title": "网关日志",
+    "reconnect": "重新连接",
+    "copyLog": "复制日志",
+    "clearLog": "清除日志",
+    "close": "关闭",
+    "empty": "暂无事件"
   }
 }

--- a/packages/pwa/src/lib/debug.ts
+++ b/packages/pwa/src/lib/debug.ts
@@ -5,6 +5,7 @@ const IS_DEV = import.meta.env.DEV;
 const MAX_LOG_ENTRIES = 200;
 
 export interface DebugLogEntry {
+  id: number;
   ts: string;
   level: string;
   domain: string;
@@ -13,6 +14,7 @@ export interface DebugLogEntry {
   error?: { message: string };
 }
 
+let nextId = 0;
 const logBuffer: DebugLogEntry[] = [];
 const listeners = new Set<() => void>();
 
@@ -70,6 +72,7 @@ export function reportDebugEvent(event: Partial<DebugEvent>): void {
   }
 
   const entry: DebugLogEntry = {
+    id: nextId++,
     ts: full.ts,
     level: full.level,
     domain: full.domain,

--- a/packages/pwa/src/views/ChatView.tsx
+++ b/packages/pwa/src/views/ChatView.tsx
@@ -101,7 +101,7 @@ export function ChatView() {
       <div
         className="flex h-full flex-col items-center justify-center px-8"
         role="main"
-        aria-label={t('chat.mainArea', { defaultValue: 'Chat' })}
+        aria-label={t('chat.mainArea')}
       >
         <p className="text-center type-body" style={{ color: 'var(--text-muted)' }}>
           {t('chat.emptyState')}
@@ -112,7 +112,7 @@ export function ChatView() {
 
   if (!activeTaskId && pendingNewTask) {
     return (
-      <div className="flex h-full flex-col" role="main" aria-label={t('chat.mainArea', { defaultValue: 'Chat' })}>
+      <div className="flex h-full flex-col" role="main" aria-label={t('chat.mainArea')}>
         <div className="flex-1" />
         <ChatInput taskId="__pending__" />
       </div>
@@ -120,7 +120,7 @@ export function ChatView() {
   }
 
   return (
-    <div className="flex h-full flex-col" role="main" aria-label={t('chat.mainArea', { defaultValue: 'Chat' })}>
+    <div className="flex h-full flex-col" role="main" aria-label={t('chat.mainArea')}>
       <div
         ref={useVirtualization ? undefined : scrollRef}
         className={`flex-1 px-4 py-4 ${useVirtualization ? 'overflow-hidden' : 'overflow-y-auto'}`}

--- a/packages/pwa/src/views/DrawerLayout.tsx
+++ b/packages/pwa/src/views/DrawerLayout.tsx
@@ -82,7 +82,7 @@ export function DrawerLayout({ onSignedOut }: DrawerLayoutProps) {
             aria-label={t('agents.selectTitle')}
           >
             <span className="type-label truncate" style={{ color: 'var(--text-primary)' }}>
-              {activeTask?.title || (pendingNewTask ? t('tasks.newTask') : t('app.name', { defaultValue: 'ClawWork' }))}
+              {activeTask?.title || (pendingNewTask ? t('tasks.newTask') : t('app.name'))}
             </span>
             <ChevronDown size={16} style={{ color: 'var(--text-muted)' }} aria-hidden="true" />
           </button>
@@ -131,7 +131,7 @@ export function DrawerLayout({ onSignedOut }: DrawerLayoutProps) {
                 ref={containerRef}
                 role="dialog"
                 aria-modal="true"
-                aria-label={t('drawer.title', { defaultValue: 'Navigation drawer' })}
+                aria-label={t('drawer.title')}
                 tabIndex={-1}
                 onKeyDown={handleKeyDown}
                 initial={{ x: '-100%' }}
@@ -155,7 +155,7 @@ export function DrawerLayout({ onSignedOut }: DrawerLayoutProps) {
                   >
                     <Search size={16} style={{ color: 'var(--text-muted)' }} aria-hidden="true" />
                     <span className="type-body" style={{ color: 'var(--text-muted)' }}>
-                      {t('drawer.search', { defaultValue: 'Search' })}
+                      {t('drawer.search')}
                     </span>
                   </div>
                   <button

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -1,14 +1,26 @@
 #!/usr/bin/env node
-import { readFileSync, readdirSync } from 'fs';
+import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join, extname, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
-const LOCALE_DIR = join(ROOT, 'packages/desktop/src/renderer/i18n/locales');
-const RENDERER_DIR = join(ROOT, 'packages/desktop/src/renderer');
-const QUICK_LAUNCH = join(RENDERER_DIR, 'quick-launch.html');
+
+const PACKAGES = [
+  {
+    name: 'desktop',
+    localeDir: join(ROOT, 'packages/desktop/src/renderer/i18n/locales'),
+    sourceDirs: [join(ROOT, 'packages/desktop/src/renderer'), join(ROOT, 'packages/core/src')],
+  },
+  {
+    name: 'pwa',
+    localeDir: join(ROOT, 'packages/pwa/src/i18n/locales'),
+    sourceDirs: [join(ROOT, 'packages/pwa/src'), join(ROOT, 'packages/core/src')],
+  },
+];
+
 const SHARED_CONSTANTS = join(ROOT, 'packages/shared/src/constants.ts');
+const QUICK_LAUNCH = join(ROOT, 'packages/desktop/src/renderer/quick-launch.html');
 
 let exitCode = 0;
 
@@ -30,6 +42,7 @@ function readJson(path) {
 }
 
 function collectFiles(dir, exts) {
+  if (!existsSync(dir)) return [];
   const results = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
@@ -42,109 +55,142 @@ function collectFiles(dir, exts) {
   return results;
 }
 
-// ── 10a: Key parity check ──────────────────────────────────────────
-console.log('── i18n key parity check ──');
+for (const pkg of PACKAGES) {
+  if (!existsSync(pkg.localeDir)) continue;
 
-const localeFiles = readdirSync(LOCALE_DIR).filter((f) => f.endsWith('.json'));
-const enKeys = flatten(readJson(join(LOCALE_DIR, 'en.json')));
-const enSet = new Set(enKeys);
+  console.log(`\n══ ${pkg.name} ══`);
 
-for (const file of localeFiles) {
-  if (file === 'en.json') continue;
-  const lang = file.replace('.json', '');
-  const langKeys = flatten(readJson(join(LOCALE_DIR, file)));
-  const langSet = new Set(langKeys);
+  // ── Key parity check ──────────────────────────────────────────────
+  console.log('── i18n key parity check ──');
 
-  const missing = enKeys.filter((k) => !langSet.has(k));
-  const extra = langKeys.filter((k) => !enSet.has(k));
+  const localeFiles = readdirSync(pkg.localeDir).filter((f) => f.endsWith('.json'));
+  const enKeys = flatten(readJson(join(pkg.localeDir, 'en.json')));
+  const enSet = new Set(enKeys);
 
-  if (missing.length > 0) {
+  for (const file of localeFiles) {
+    if (file === 'en.json') continue;
+    const lang = file.replace('.json', '');
+    const langKeys = flatten(readJson(join(pkg.localeDir, file)));
+    const langSet = new Set(langKeys);
+
+    const missing = enKeys.filter((k) => !langSet.has(k));
+    const extra = langKeys.filter((k) => !enSet.has(k));
+
+    if (missing.length > 0) {
+      console.error(
+        `  ERROR [${lang}] missing ${missing.length} keys: ${missing.slice(0, 5).join(', ')}${missing.length > 5 ? '...' : ''}`,
+      );
+      exitCode = 1;
+    }
+    if (extra.length > 0) {
+      console.error(
+        `  ERROR [${lang}] extra ${extra.length} keys: ${extra.slice(0, 5).join(', ')}${extra.length > 5 ? '...' : ''}`,
+      );
+      exitCode = 1;
+    }
+    if (missing.length === 0 && extra.length === 0) {
+      console.log(`  OK [${lang}]`);
+    }
+  }
+
+  // ── Unused key check ──────────────────────────────────────────────
+  console.log('\n── i18n unused key check ──');
+
+  const sourceFiles = pkg.sourceDirs.flatMap((d) => collectFiles(d, ['.ts', '.tsx']));
+  const sourceText = sourceFiles.map((f) => readFileSync(f, 'utf-8')).join('\n');
+
+  const dynamicPrefixRe = /t\(\s*`([^$`]+)\$\{/g;
+  const dynamicPrefixes = [];
+  let dm;
+  while ((dm = dynamicPrefixRe.exec(sourceText)) !== null) {
+    dynamicPrefixes.push(dm[1]);
+  }
+
+  const unreferenced = [];
+  for (const key of enKeys) {
+    if (sourceText.includes(key)) continue;
+    if (dynamicPrefixes.some((p) => key.startsWith(p))) continue;
+    unreferenced.push(key);
+  }
+
+  if (unreferenced.length > 0) {
     console.error(
-      `  ERROR [${lang}] missing ${missing.length} keys: ${missing.slice(0, 5).join(', ')}${missing.length > 5 ? '...' : ''}`,
+      `  ERROR ${unreferenced.length} unused keys (remove from all locale files, or use a scanner-visible pattern like t(\`prefix.\${var}\`)):`,
     );
-    exitCode = 1;
-  }
-  if (extra.length > 0) {
-    console.error(
-      `  ERROR [${lang}] extra ${extra.length} keys: ${extra.slice(0, 5).join(', ')}${extra.length > 5 ? '...' : ''}`,
-    );
-    exitCode = 1;
-  }
-  if (missing.length === 0 && extra.length === 0) {
-    console.log(`  OK [${lang}]`);
-  }
-}
-
-// ── 10b: Unused key check ───────────────────────────────────────────
-console.log('\n── i18n unused key check ──');
-
-const CORE_DIR = join(ROOT, 'packages/core/src');
-const sourceFiles = [...collectFiles(RENDERER_DIR, ['.ts', '.tsx']), ...collectFiles(CORE_DIR, ['.ts', '.tsx'])];
-const sourceText = sourceFiles.map((f) => readFileSync(f, 'utf-8')).join('\n');
-
-const dynamicPrefixRe = /t\(\s*`([^$`]+)\$\{/g;
-const dynamicPrefixes = [];
-let dm;
-while ((dm = dynamicPrefixRe.exec(sourceText)) !== null) {
-  dynamicPrefixes.push(dm[1]);
-}
-
-const unreferenced = [];
-for (const key of enKeys) {
-  if (sourceText.includes(key)) continue;
-  if (dynamicPrefixes.some((p) => key.startsWith(p))) continue;
-  unreferenced.push(key);
-}
-
-if (unreferenced.length > 0) {
-  console.error(
-    `  ERROR ${unreferenced.length} unused keys (remove from all locale files, or use a scanner-visible pattern like t(\`prefix.\${var}\`)):`,
-  );
-  for (const k of unreferenced) {
-    console.error(`    - ${k}`);
-  }
-  exitCode = 1;
-} else {
-  console.log('  OK — no unused keys detected');
-}
-
-// ── 10c: quick-launch.html drift check ─────────────────────────────
-console.log('\n── quick-launch.html locale drift check ──');
-
-const sharedSrc = readFileSync(SHARED_CONSTANTS, 'utf-8');
-const codesMatch = sharedSrc.match(/SUPPORTED_LANGUAGE_CODES\s*=\s*\[([^\]]+)\]/);
-if (!codesMatch) {
-  console.error('  ERROR could not parse SUPPORTED_LANGUAGE_CODES from shared/constants.ts');
-  exitCode = 1;
-} else {
-  const sharedCodes = new Set(
-    codesMatch[1]
-      .split(',')
-      .map((s) => s.trim().replace(/['"]/g, ''))
-      .filter(Boolean),
-  );
-
-  const qlHtml = readFileSync(QUICK_LAUNCH, 'utf-8');
-  const messagesMatch = qlHtml.match(/var\s+messages\s*=\s*\{([\s\S]*?)\};/);
-  if (!messagesMatch) {
-    console.error('  ERROR could not parse messages object from quick-launch.html');
+    for (const k of unreferenced) {
+      console.error(`    - ${k}`);
+    }
     exitCode = 1;
   } else {
-    const qlCodes = new Set([...messagesMatch[1].matchAll(/['"]?([a-zA-Z-]+)['"]?\s*:\s*\{/g)].map((m) => m[1]));
+    console.log('  OK — no unused keys detected');
+  }
 
-    const missingInQl = [...sharedCodes].filter((c) => !qlCodes.has(c));
-    const extraInQl = [...qlCodes].filter((c) => !sharedCodes.has(c));
+  // ── defaultValue anti-pattern check ───────────────────────────────
+  console.log('\n── i18n defaultValue check ──');
 
-    if (missingInQl.length > 0) {
-      console.error(`  ERROR quick-launch.html missing locales: ${missingInQl.join(', ')}`);
-      exitCode = 1;
+  const defaultValueRe = /\bt\(\s*['"][^'"]+['"]\s*,\s*\{[^}]*defaultValue/g;
+  const violations = [];
+  for (const file of sourceFiles) {
+    const content = readFileSync(file, 'utf-8');
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (defaultValueRe.test(lines[i])) {
+        violations.push(`${file.replace(ROOT + '/', '')}:${i + 1}`);
+      }
+      defaultValueRe.lastIndex = 0;
     }
-    if (extraInQl.length > 0) {
-      console.error(`  ERROR quick-launch.html has extra locales: ${extraInQl.join(', ')}`);
-      exitCode = 1;
+  }
+
+  if (violations.length > 0) {
+    console.error(`  ERROR ${violations.length} t() calls use defaultValue — add the key to en.json instead:`);
+    for (const v of violations) {
+      console.error(`    - ${v}`);
     }
-    if (missingInQl.length === 0 && extraInQl.length === 0) {
-      console.log('  OK — locale keys match SUPPORTED_LANGUAGE_CODES');
+    exitCode = 1;
+  } else {
+    console.log('  OK — no defaultValue usage detected');
+  }
+}
+
+// ── quick-launch.html drift check (desktop only) ───────────────────
+if (existsSync(QUICK_LAUNCH) && existsSync(SHARED_CONSTANTS)) {
+  console.log('\n── quick-launch.html locale drift check ──');
+
+  const sharedSrc = readFileSync(SHARED_CONSTANTS, 'utf-8');
+  const codesMatch = sharedSrc.match(/SUPPORTED_LANGUAGE_CODES\s*=\s*\[([^\]]+)\]/);
+  if (!codesMatch) {
+    console.error('  ERROR could not parse SUPPORTED_LANGUAGE_CODES from shared/constants.ts');
+    exitCode = 1;
+  } else {
+    const sharedCodes = new Set(
+      codesMatch[1]
+        .split(',')
+        .map((s) => s.trim().replace(/['"]/g, ''))
+        .filter(Boolean),
+    );
+
+    const qlHtml = readFileSync(QUICK_LAUNCH, 'utf-8');
+    const messagesMatch = qlHtml.match(/var\s+messages\s*=\s*\{([\s\S]*?)\};/);
+    if (!messagesMatch) {
+      console.error('  ERROR could not parse messages object from quick-launch.html');
+      exitCode = 1;
+    } else {
+      const qlCodes = new Set([...messagesMatch[1].matchAll(/['"]?([a-zA-Z-]+)['"]?\s*:\s*\{/g)].map((m) => m[1]));
+
+      const missingInQl = [...sharedCodes].filter((c) => !qlCodes.has(c));
+      const extraInQl = [...qlCodes].filter((c) => !sharedCodes.has(c));
+
+      if (missingInQl.length > 0) {
+        console.error(`  ERROR quick-launch.html missing locales: ${missingInQl.join(', ')}`);
+        exitCode = 1;
+      }
+      if (extraInQl.length > 0) {
+        console.error(`  ERROR quick-launch.html has extra locales: ${extraInQl.join(', ')}`);
+        exitCode = 1;
+      }
+      if (missingInQl.length === 0 && extraInQl.length === 0) {
+        console.log('  OK — locale keys match SUPPORTED_LANGUAGE_CODES');
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix i18n structural integrity across the PWA package: en.json becomes the authoritative superset, all `defaultValue` anti-patterns are eliminated, `GatewayDebugLog` gains full i18n support with stable React keys, and the CI check script is extended to guard both desktop and PWA.

## Type of change

- [x] `[Fix]` bug fix
- [x] `[Build]` CI, packaging, or tooling change

## Why is this needed?

`GatewayDebugLog` was the only PWA component with hardcoded English strings while every other component uses `useTranslation()`. Deeper investigation revealed systemic i18n issues: `en.json` (the fallback locale) was missing 8 keys that existed in other locales, 12 `t()` calls used `defaultValue` as a crutch (scattering English text between locale files and component code), `DebugLogEntry` lacked stable IDs causing React key misuse (`key={i}`), 10 dead locale keys existed from desktop copy-paste, and the CI check script only covered the desktop package.

## What changed?

- **en.json authoritative superset**: Added 8 missing keys (`app.name`, `shell.reconnect`, `settings.*`, `drawer.title/search`, `tools.emptyDetails`)
- **Key parity across all 8 locales**: Added `app.name`, `drawer.title`, `drawer.search`, `tools.emptyDetails` to all non-English locales
- **Eliminated all `defaultValue` usage**: Removed 12 occurrences across 7 component files + `error-classify.ts` (kept dynamic-key fallback in `formatErrorForToast`)
- **Stable debug log IDs**: Added monotonic `id` field to `DebugLogEntry` in `debug.ts`; `GatewayDebugLog` uses `key={entry.id}` instead of `key={i}`
- **`debugLog` i18n namespace**: 6 new keys across all 8 locales; `GatewayDebugLog` now uses `useTranslation()` for all user-visible strings
- **Dead key cleanup**: Removed 10 unused PWA locale keys (`chat.you`, `gateway.notFound`, `pairing.{error,retryButton,scanning,title}`, `shell.{bootstrapping,connected}`, `tools.{expandButton,collapseButton}`)
- **CI guard extended**: `check-i18n.mjs` now covers both desktop and PWA packages, and detects `defaultValue` anti-pattern on static keys

## Architecture impact

- Owning layer: renderer (PWA), core (error-classify), build (scripts)
- Cross-layer impact: yes — `DebugLogEntry` interface in `packages/pwa/src/lib/debug.ts` gains an `id: number` field; `error-classify.ts` in core removes redundant `defaultValue` on static keys
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: changes are additive (new interface field, new locale keys) or subtractive (removed dead keys and anti-patterns); no message persistence or gateway protocol changes

## Linked issues

Closes the GatewayDebugLog i18n gap identified during PWA development.

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm check:i18n`
- [ ] `pnpm build`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm typecheck — passed
pnpm test — 157/157 tests passed (shared: 6, pwa: 59, desktop: 92)
node scripts/check-i18n.mjs — all checks passed (key parity, unused keys, defaultValue, quick-launch drift)
```

## Screenshots or recordings

No UI layout changes. All modifications are string substitutions (hardcoded → i18n) and locale file updates.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Gateway debug log panel now supports all 8 languages. Fixed missing translations for settings, navigation drawer, and shell reconnect across all locales.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate