### PR TITLE
[Fix] Validate sourcePath in artifact:save IPC handler

### DIFF
--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,5 +1,6 @@
 import { ipcMain, BrowserWindow, dialog, shell } from 'electron';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, realpathSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import { fileURLToPath } from 'node:url';
 import { resolve, sep } from 'path';
 import { eq } from 'drizzle-orm';
@@ -25,10 +26,16 @@ export function registerArtifactHandlers(): void {
       return { ok: false, error: 'workspace not configured' };
     }
     try {
+      const realSource = realpathSync(params.sourcePath);
+      const allowedPrefixes = [resolve(workspacePath) + sep, tmpdir() + sep];
+      if (!allowedPrefixes.some((p) => realSource.startsWith(p))) {
+        return { ok: false, error: 'source path outside allowed locations' };
+      }
+
       const artifact = await saveArtifact({
         workspacePath,
         taskId: params.taskId,
-        sourcePath: params.sourcePath,
+        sourcePath: realSource,
         messageId: params.messageId,
         fileName: params.fileName,
         mediaType: params.mediaType,


### PR DESCRIPTION
## Summary

Validate `sourcePath` in the `artifact:save` IPC handler to prevent arbitrary file exfiltration. Previously, `sourcePath` from the renderer was passed directly to `copyFileSync()` without any validation, allowing any file readable by the process owner to be copied into the workspace.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The `artifact:save` IPC handler accepted an unvalidated `sourcePath` from the renderer process. A compromised renderer (e.g. via XSS) could read arbitrary files from the local filesystem — SSH keys, cloud credentials, env files — by copying them into the workspace artifact directory. This is a critical security vulnerability (see #130).

Other handlers in the same file (`artifact:read-file`, `artifact:open-file`, `artifact:save-image-url`) already validate paths correctly; `artifact:save` was the only one missing validation.

## What changed?

- Added `realpathSync()` call to resolve symlinks before validation
- Added allowlist check: `sourcePath` must resolve to within the workspace directory or the OS temp directory
- Pass the resolved physical path (not the raw input) to `saveArtifact()` to minimize TOCTOU window

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: IPC security boundary — renderer input must be validated in main process
- Why those invariants remain protected: validation happens at the IPC boundary before any filesystem operation

## Linked issues

Closes #130

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] Not run — `pnpm build` (no build-time impact, code-only change in main process)

Commands, screenshots, or notes:

```text
pnpm check — all 213 tests pass, lint clean, typecheck clean
```

## Screenshots or recordings

No UI change.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fixed a security vulnerability where the artifact:save IPC handler accepted unvalidated file paths from the renderer, potentially allowing arbitrary file reads. Source paths are now restricted to the workspace and OS temp directory.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate