### PR TITLE
[Feat] Add @All mention and deduplicate agent list in mention picker

### DIFF
--- a/packages/core/src/stores/room-store.ts
+++ b/packages/core/src/stores/room-store.ts
@@ -163,8 +163,8 @@ export function createRoomStore(deps: RoomStoreDeps) {
       const room = get().rooms[taskId];
       if (!room) return;
 
-      const already = room.performers.some((p) => p.sessionKey === subagentKey);
-      if (already) return;
+      const bySession = room.performers.some((p) => p.sessionKey === subagentKey);
+      if (bySession) return;
 
       const performer: RoomPerformer = {
         sessionKey: subagentKey,
@@ -174,10 +174,10 @@ export function createRoomStore(deps: RoomStoreDeps) {
       };
 
       set((s) => {
-        const existing = s.rooms[taskId];
-        if (!existing) return s;
+        const current = s.rooms[taskId];
+        if (!current) return s;
         return {
-          rooms: { ...s.rooms, [taskId]: { ...existing, performers: [...existing.performers, performer] } },
+          rooms: { ...s.rooms, [taskId]: { ...current, performers: [...current.performers, performer] } },
           subagentKeyMap: { ...s.subagentKeyMap, [subagentKey]: taskId },
         };
       });

--- a/packages/desktop/src/renderer/components/ChatInput/constants.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/constants.ts
@@ -6,6 +6,8 @@ export const ACCEPTED_TYPES = 'image/png,image/jpeg,image/gif,image/webp';
 export const GATEWAY_INJECTED_MODEL = 'gateway-injected';
 export const EMPTY_MODELS_CATALOG: ModelCatalogEntry[] = [];
 
+export const MENTION_ALL_AGENT_ID = '__all__';
+
 export const THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'adaptive'] as const;
 export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
 

--- a/packages/desktop/src/renderer/components/ChatInput/index.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput/index.tsx
@@ -15,6 +15,7 @@ import {
   FolderOpen,
   ListTodo,
   Plus,
+  Users,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
@@ -42,7 +43,7 @@ import SlashArgPicker from '../SlashArgPicker';
 import VoiceIntroDialog from '../VoiceIntroDialog';
 import MentionPicker, { type MentionTab, type AgentMentionEntry } from '../MentionPicker';
 import { useRoomStore } from '@/stores/roomStore';
-import { ACCEPTED_TYPES, THINKING_LEVELS, THINKING_LABEL_KEYS } from './constants';
+import { ACCEPTED_TYPES, THINKING_LEVELS, THINKING_LABEL_KEYS, MENTION_ALL_AGENT_ID } from './constants';
 import { formatContextWindow } from './utils';
 import { useImageAttachments } from './useImageAttachments';
 import { useContextFolders } from './useContextFolders';
@@ -70,12 +71,16 @@ export default function ChatInput() {
   const performers = useRoomStore((s) => (activeTaskId ? s.rooms[activeTaskId]?.performers : undefined));
   const mentionAgents = useMemo<AgentMentionEntry[]>(() => {
     if (!performers) return [];
-    return performers.map((p) => ({
-      agentId: p.agentId,
-      agentName: p.agentName,
-      emoji: p.emoji,
-      sessionKey: p.sessionKey,
-    }));
+    const byAgent = new Map<string, AgentMentionEntry>();
+    for (const p of performers) {
+      byAgent.set(p.agentId, {
+        agentId: p.agentId,
+        agentName: p.agentName,
+        emoji: p.emoji,
+        sessionKey: p.sessionKey,
+      });
+    }
+    return [...byAgent.values()];
   }, [performers]);
 
   const {
@@ -523,7 +528,9 @@ export default function ChatInput() {
                           'bg-[var(--accent)]/10 text-[var(--accent)]',
                         )}
                       >
-                        {a.emoji ? (
+                        {a.agentId === MENTION_ALL_AGENT_ID ? (
+                          <Users size={14} className="flex-shrink-0" />
+                        ) : a.emoji ? (
                           <span className="emoji-sm">{a.emoji}</span>
                         ) : (
                           <Bot size={14} className="flex-shrink-0" />

--- a/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
@@ -27,7 +27,7 @@ import { useRoomStore } from '../../stores/roomStore';
 import { composer } from '../../platform';
 import type { PendingImage } from './types';
 import type { ThinkingLevel } from './constants';
-import { GATEWAY_INJECTED_MODEL, EMPTY_MODELS_CATALOG, MAX_TEXT_TOTAL } from './constants';
+import { GATEWAY_INJECTED_MODEL, EMPTY_MODELS_CATALOG, MAX_TEXT_TOTAL, MENTION_ALL_AGENT_ID } from './constants';
 import { getModelLabel, readAsBase64 } from './utils';
 
 interface UseChatSendOpts {
@@ -342,6 +342,7 @@ export function useChatSend(opts: UseChatSendOpts) {
         (artifactMentions.length ? `[@${artifactMentions[0].name}]` : '') ||
         (images.length ? `[${t('chatInput.image')}]` : '');
 
+      const isMentionAll = agentMentions.some((a) => a.agentId === MENTION_ALL_AGENT_ID);
       await composer.send(task.id, {
         content: finalContent,
         attachments: allAttachments.length > 0 ? allAttachments : undefined,
@@ -349,7 +350,8 @@ export function useChatSend(opts: UseChatSendOpts) {
         presetModel: pendingPresetModel,
         presetThinking: pendingPresetThinking,
         titleHint: task.title ? undefined : titleHint,
-        mentions: agentMentions.length > 0 ? agentMentions.map((a) => a.agentId) : undefined,
+        mentionAll: isMentionAll || undefined,
+        mentions: agentMentions.length > 0 && !isMentionAll ? agentMentions.map((a) => a.agentId) : undefined,
       });
     } catch (err) {
       setProcessing(task.id, false);

--- a/packages/desktop/src/renderer/components/ChatInput/useMentionPicker.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useMentionPicker.ts
@@ -3,6 +3,7 @@ import type { Task, Artifact, FileIndexEntry } from '@clawwork/shared';
 import type { MentionItem, MentionTab, AgentMentionEntry } from '../MentionPicker';
 import { useFileStore } from '../../stores/fileStore';
 import { useTaskStore } from '../../stores/taskStore';
+import { MENTION_ALL_AGENT_ID } from './constants';
 
 interface UseMentionPickerOpts {
   textareaRef: RefObject<HTMLTextAreaElement | null>;
@@ -97,7 +98,11 @@ export function useMentionPicker(opts: UseMentionPickerOpts) {
           return;
         }
         stripAtQuery();
-        setSelectedAgents((prev) => [...prev, item.agent]);
+        if (item.agent.agentId === MENTION_ALL_AGENT_ID) {
+          setSelectedAgents([item.agent]);
+        } else {
+          setSelectedAgents((prev) => prev.filter((a) => a.agentId !== MENTION_ALL_AGENT_ID).concat(item.agent));
+        }
         closeMentionPicker();
         return;
       }

--- a/packages/desktop/src/renderer/components/MentionPicker.tsx
+++ b/packages/desktop/src/renderer/components/MentionPicker.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useMemo } from 'react';
-import { Bot, File, FileCode, FolderOpen, Image as ImageIcon, ListTodo } from 'lucide-react';
+import { Bot, File, FileCode, FolderOpen, Image as ImageIcon, ListTodo, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Task, Artifact, FileIndexEntry } from '@clawwork/shared';
 import { useFileStore } from '@/stores/fileStore';
 import { cn, formatFileSize } from '@/lib/utils';
+import { MENTION_ALL_AGENT_ID } from './ChatInput/constants';
 
 export type MentionTab = 'local' | 'tasks' | 'files' | 'agents';
 
@@ -94,10 +95,19 @@ export default function MentionPicker({
   const items = useMemo<MentionItem[]>(() => {
     const q = query.toLowerCase();
     if (activeTab === 'agents') {
+      const allEntry: AgentMentionEntry = {
+        agentId: MENTION_ALL_AGENT_ID,
+        agentName: t('mentionPicker.allAgents'),
+        sessionKey: '',
+      };
       const filtered = q
         ? agents.filter((a) => a.agentName.toLowerCase().includes(q) || a.agentId.toLowerCase().includes(q))
         : agents;
-      return filtered.map((a) => ({ kind: 'agent' as const, agent: a }));
+      const allMatches = !q || allEntry.agentName.toLowerCase().includes(q);
+      return [
+        ...(allMatches ? [{ kind: 'agent' as const, agent: allEntry }] : []),
+        ...filtered.map((a) => ({ kind: 'agent' as const, agent: a })),
+      ];
     }
     if (activeTab === 'local') {
       const filtered = q
@@ -111,7 +121,7 @@ export default function MentionPicker({
     }
     const filtered = q ? artifacts.filter((a) => a.name.toLowerCase().includes(q)) : artifacts;
     return filtered.map((a) => ({ kind: 'file' as const, artifact: a }));
-  }, [activeTab, query, tasks, artifacts, localFiles, agents]);
+  }, [activeTab, query, tasks, artifacts, localFiles, agents, t]);
 
   useEffect(() => {
     onItemsChange?.(items);
@@ -185,7 +195,9 @@ export default function MentionPicker({
                 onClick={() => onSelectAgent(a)}
                 onMouseEnter={() => onHoverIndex(i)}
               >
-                {a.emoji ? (
+                {a.agentId === MENTION_ALL_AGENT_ID ? (
+                  <Users size={14} className="text-[var(--accent)] flex-shrink-0" />
+                ) : a.emoji ? (
                   <span className="emoji-sm flex-shrink-0">{a.emoji}</span>
                 ) : (
                   <Bot size={14} className="text-[var(--accent)] flex-shrink-0" />

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -332,7 +332,8 @@
     "noLocalFiles": "Keine passenden lokalen Dateien",
     "noTasks": "Keine passenden Aufgaben",
     "noFiles": "Keine passenden Dateien",
-    "noAgents": "No performers discovered yet"
+    "noAgents": "No performers discovered yet",
+    "allAgents": "Alle Agents"
   },
   "slash": {
     "argOptions": "Optionen fuer /{{command}}"

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -332,7 +332,8 @@
     "noLocalFiles": "No matching local files",
     "noTasks": "No matching tasks",
     "noFiles": "No matching files",
-    "noAgents": "No performers discovered yet"
+    "noAgents": "No performers discovered yet",
+    "allAgents": "All Agents"
   },
   "slash": {
     "argOptions": "Options for /{{command}}"

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -332,7 +332,8 @@
     "noLocalFiles": "No se encontraron archivos locales",
     "noTasks": "No se encontraron tareas",
     "noFiles": "No se encontraron archivos",
-    "noAgents": "No performers discovered yet"
+    "noAgents": "No performers discovered yet",
+    "allAgents": "Todos los agentes"
   },
   "slash": {
     "argOptions": "Opciones de /{{command}}"

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -332,7 +332,8 @@
     "noLocalFiles": "一致するローカルファイルがありません",
     "noTasks": "一致するタスクがありません",
     "noFiles": "一致するファイルがありません",
-    "noAgents": "No performers discovered yet"
+    "noAgents": "No performers discovered yet",
+    "allAgents": "全エージェント"
   },
   "slash": {
     "argOptions": "/{{command}} のオプション"

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -332,7 +332,8 @@
     "noLocalFiles": "일치하는 로컬 파일이 없습니다",
     "noTasks": "일치하는 작업이 없습니다",
     "noFiles": "일치하는 파일이 없습니다",
-    "noAgents": "No performers discovered yet"
+    "noAgents": "No performers discovered yet",
+    "allAgents": "모든 에이전트"
   },
   "slash": {
     "argOptions": "/{{command}} 옵션"

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -332,7 +332,8 @@
     "noLocalFiles": "Nenhum arquivo local correspondente",
     "noTasks": "Nenhuma tarefa correspondente",
     "noFiles": "Nenhum arquivo correspondente",
-    "noAgents": "No performers discovered yet"
+    "noAgents": "No performers discovered yet",
+    "allAgents": "Todos os agentes"
   },
   "slash": {
     "argOptions": "Opções para /{{command}}"

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -332,7 +332,8 @@
     "noLocalFiles": "找不到符合的本機檔案",
     "noTasks": "找不到符合的任務",
     "noFiles": "找不到符合的檔案",
-    "noAgents": "No performers discovered yet"
+    "noAgents": "No performers discovered yet",
+    "allAgents": "所有代理"
   },
   "slash": {
     "argOptions": "/{{command}} 的選項"

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -332,7 +332,8 @@
     "noLocalFiles": "没有匹配的本地文件",
     "noTasks": "没有匹配的任务",
     "noFiles": "没有匹配的文件",
-    "noAgents": "No performers discovered yet"
+    "noAgents": "No performers discovered yet",
+    "allAgents": "所有智能体"
   },
   "slash": {
     "argOptions": "/{{command}} 的可选项"


### PR DESCRIPTION
## Summary

Add an "All Agents" option to the @ mention picker in multi-agent conversations and fix duplicate agents appearing in the list when the same agent has multiple sessions.

## Type of change

- [x] `[Feat]` new feature
- [x] `[Fix]` bug fix

## Why is this needed?

1. **Duplicate agents in mention list**: When the same agent type has multiple sessions (e.g., reconnect, re-spawn), `registerPerformerKey` deduplicates by `sessionKey` but not `agentId`, causing the same agent to appear multiple times in the @ mention picker.

2. **No way to mention all agents at once**: Users had to individually @ each agent. The existing `mentionAll` flag in `chat-composer.ts` was already implemented but had no UI surface.

## What changed?

- **Mention picker dedup (UI layer)**: `ChatInput/index.tsx` now deduplicates `mentionAgents` by `agentId` using a Map (last-write-wins keeps the latest session). The underlying `room-store.ts` performers array and `subagentKeyMap` remain untouched to preserve complete session routing.
- **"All Agents" entry**: `MentionPicker.tsx` prepends a hardcoded "All Agents" item (with `Users` icon) at the top of the agents tab. Uses sentinel `MENTION_ALL_AGENT_ID = "__all__"` defined in `ChatInput/constants.ts`.
- **Mutual exclusion**: Selecting "All" clears individual selections; selecting an individual agent removes "All". Implemented in `useMentionPicker.ts`.
- **Send path**: `useChatSend.ts` detects the sentinel and sets `mentionAll: true` on `composer.send()`, which broadcasts to conductor + all performers.
- **i18n**: Added `mentionPicker.allAgents` key across all 8 locales.

## Architecture impact

- Owning layer: renderer (mention picker UI), core (room-store unchanged)
- Cross-layer impact: none — the sentinel is entirely within the renderer; `mentionAll` was already supported by the core `chat-composer.ts`
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: `room-store.ts` performers array and `subagentKeyMap` are unchanged; all sessionKey→taskId mappings are preserved for event routing. Dedup is strictly at the UI display layer.

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate)
- [ ] Manual smoke test

```text
pnpm check — all passed (lint, architecture, ui-contract, renderer-copy, i18n, dead-code, format, typecheck, 214 tests)
```

## Screenshots or recordings

N/A — dropdown picker UI change, no layout or token changes.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Added "All Agents" option in the @ mention picker for multi-agent conversations. Fixed duplicate agents appearing in the mention list.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate