### PR TITLE
[Fix] Agent edit form name fallback to id when name is undefined

### DIFF
--- a/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
@@ -618,7 +618,7 @@ export default function AgentsSection() {
     (agent: AgentInfo) => {
       setEditingAgentId(agent.id);
       setForm({
-        name: agent.name ?? '',
+        name: agent.name ?? agent.id,
         workspace: agentWorkspaceMap[agent.id] ?? '',
         emoji: agent.identity?.emoji ?? '',
         model: '',


### PR DESCRIPTION
## Summary

When editing an agent in Settings, the name field was left blank instead of showing the agent's current display name. This happened because `AgentInfo.name` is optional — the card component falls back to `agent.id`, but the edit form fell back to an empty string.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Clicking the edit pencil on an agent (e.g. the built-in "main" agent) opened a form with an empty name field, even though the card clearly displayed the name. This confused users into thinking the agent had no name.

## What changed?

- `openEditForm` in `AgentsSection.tsx`: changed `agent.name ?? ''` to `agent.name ?? agent.id`, matching the display fallback used by `AgentCard`.

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: single-line change in renderer presentation logic only

## Linked issues

## Validation

- [x] `pnpm lint`
- [x] `pnpm check:architecture`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check:i18n`
- [x] Manual smoke test
- [ ] Not run

```text
pnpm check passes (formatter warning on unrelated .opencode/ files only)
```

## Screenshots or recordings

N/A — the name field now shows the agent id as fallback, consistent with the card display.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate