### PR TITLE
[Fix] reset hydration cache after local hydration failures

### DIFF
--- a/packages/core/src/services/session-sync.ts
+++ b/packages/core/src/services/session-sync.ts
@@ -133,7 +133,10 @@ export function createSessionSync(deps: SessionSyncDeps) {
             }
           } catch {}
         }
-      })();
+      })().catch((err) => {
+        hydrationPromise = null;
+        throw err;
+      });
     }
     await hydrationPromise;
   }


### PR DESCRIPTION
## Summary

Reset the cached hydration promise when local hydration fails so future callers can retry instead of reusing a permanently rejected promise.

## Changes

- wrap the cached hydration promise in a catch handler
- clear the cache before rethrowing on failure

## Testing

- corepack pnpm install --ignore-scripts
- corepack pnpm --filter @clawwork/shared exec tsc -b
- corepack pnpm --filter @clawwork/core exec tsc -b

Fixes clawwork-ai/ClawWork#229