### PR TITLE
[Docs] Gateway protocol whitepaper, source guide, capability map, and sync skill

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,45 @@
+# Architecture Rules
+
+Canonical invariant list: `docs/architecture-invariants.md`.
+Use this file as the tool-oriented summary for review and enforcement.
+
+## Product Identity
+
+- ClawWork is an OpenClaw desktop operator client, not an admin console, IM client, or collaboration product.
+- Task is the primary product object. One Task = one OpenClaw session.
+- Artifact persistence is local-first: filesystem first, SQLite index second.
+- The three-panel layout is a core product affordance, not optional chrome.
+
+## Layer Ownership
+
+| Layer | Owns | Package |
+|---|---|---|
+| shared | protocol, constants, domain types, debug event types | `packages/shared/src/` |
+| core | stores, services, ports | `packages/core/src/` |
+| main | WebSocket, filesystem, database, workspace config, OS integration, IPC, tray | `packages/desktop/src/main/` |
+| preload | typed renderer bridge only | `packages/desktop/src/preload/` |
+| renderer | UI state, presentation, hooks, client-side coordination | `packages/desktop/src/renderer/` |
+
+Cross-layer changes must keep boundaries explicit and justified in the PR.
+
+## Invariants
+
+- [HIGH] Session key format: `agent:<agentId>:clawwork:task:<taskId>`
+- [HIGH] Build session keys only with `buildSessionKey()` from `@clawwork/shared` — never construct raw strings
+- [HIGH] Do not import Node builtins, `electron`, or main-process modules into renderer code
+- [HIGH] Do not fork shared protocol types inside desktop code
+- [HIGH] Dependency direction: `shared` <- `core` <- `desktop`/`pwa` — never reverse
+- [HIGH] Relative imports must not cross package boundaries (use `@clawwork/shared`, `@clawwork/core`)
+- [HIGH] API keys, tokens, or secrets must never appear in client-distributed code
+- [HIGH] Do not bypass task isolation with hidden global state
+- Do not move artifact persistence into renderer code
+- Do not patch around unclear OpenClaw behavior without checking upstream (`~/git/openclaw`) first
+
+## Escalation Triggers
+
+Stop and ask for review instead of improvising when:
+
+- a change weakens task/session isolation
+- a change crosses main/preload/renderer boundaries without a clear reason
+- a UI change cannot be expressed with existing design tokens or CSS variables
+- local behavior appears to disagree with OpenClaw protocol behavior

--- a/.claude/skills/sync-gateway-docs/SKILL.md
+++ b/.claude/skills/sync-gateway-docs/SKILL.md
@@ -1,0 +1,121 @@
+# Skill: sync-gateway-docs
+
+Sync the three ClawWork Gateway reference documents against the latest OpenClaw source code.
+
+## When to Use
+
+- Periodically (e.g., after OpenClaw releases or major Gateway changes)
+- When adding a new Gateway feature to ClawWork and the docs feel stale
+- User says: "更新 Gateway 文档", "sync gateway docs", or similar
+
+## Documents
+
+| Doc | Path | Purpose |
+|-----|------|---------|
+| Whitepaper | `docs/openclaw-gateway-whitepaper.md` | Protocol contract reference — what Gateway exposes |
+| Source Guide | `docs/openclaw-gateway-source-guide.md` | Code navigation — where to find things in openclaw |
+| Capability Map | `docs/clawwork-gateway-capability-map.md` | Usage inventory — what ClawWork actually uses |
+
+## Prerequisites
+
+- OpenClaw repo checked out at `~/git/openclaw` with latest `main`
+- ClawWork repo at `~/git/clawwork/main`
+
+## Execution
+
+Run all three phases. Each phase is independent and can be run in parallel via subagents.
+
+### Phase 1: Update Whitepaper
+
+The whitepaper is the protocol contract. It must match the current openclaw source exactly.
+
+**Step 1 — Detect changes.** Read the following openclaw files and diff against what the whitepaper currently documents:
+
+| What to check | OpenClaw source file |
+|----------------|---------------------|
+| Protocol version | `src/gateway/protocol/schema/protocol-schemas.ts` → `PROTOCOL_VERSION` |
+| Method list | `src/gateway/server-methods-list.ts` → `BASE_METHODS` (count and diff) |
+| Event list | `src/gateway/server-methods-list.ts` → `GATEWAY_EVENTS` (count and diff) |
+| Frame schemas | `src/gateway/protocol/schema/frames.ts` → ConnectParams, HelloOk, ErrorShape |
+| Client IDs/modes/caps | `src/gateway/protocol/client-info.ts` → GATEWAY_CLIENT_IDS, MODES, CAPS |
+| Chat schemas | `src/gateway/protocol/schema/logs-chat.ts` |
+| Session schemas | `src/gateway/protocol/schema/sessions.ts` |
+| Agent schemas | `src/gateway/protocol/schema/agent.ts` |
+| Agent/model/skill schemas | `src/gateway/protocol/schema/agents-models-skills.ts` |
+| Cron schemas | `src/gateway/protocol/schema/cron.ts` |
+| Error codes | `src/gateway/protocol/schema/error-codes.ts` |
+| Constants | `src/gateway/server-constants.ts`, `src/gateway/handshake-timeouts.ts` |
+| Scope mappings | `src/gateway/method-scopes.ts` |
+| Event scope guards | `src/gateway/server-broadcast.ts` → EVENT_SCOPE_GUARDS |
+| Rate limiting | `src/gateway/auth-rate-limit.ts` |
+| Snapshot/presence | `src/gateway/protocol/schema/snapshot.ts` |
+
+**Step 2 — Apply changes.** For each detected difference:
+- New methods → add to §5 method list + add schema details if it's a major domain
+- New events → add to §4 event table with scope guard + dropIfSlow info
+- Changed schemas → update the TypeScript snippets inline
+- Changed constants → update §2.4 constants table
+- New/changed client IDs → update §3.3 tables
+
+**Step 3 — Update metadata.** Bump the version line at the top of the whitepaper:
+```
+> Source of truth: reverse-engineered from `~/git/openclaw` (version YYYY.M.D)
+> Date: YYYY-MM-DD
+```
+
+**Step 4 — Verify inline sources.** Every section must have a `> Source:` annotation. If a new section was added, add one.
+
+### Phase 2: Update Source Guide
+
+The source guide maps code structure. It must reflect the current directory layout and file responsibilities.
+
+**Step 1 — Detect structural changes.** Check:
+- `ls src/gateway/protocol/schema/` — any new/removed schema files?
+- `ls src/gateway/server-methods/` — any new/removed handler files?
+- `ls src/gateway/server/` — any new/removed infrastructure files?
+- `ls src/gateway/server/ws-connection/` — any changes to auth/handshake files?
+
+**Step 2 — Apply changes.**
+- New schema files → add to §2.1 directory map
+- New handler files → add to §3.1 directory map with methods they handle
+- New infrastructure files → add to §4.2 key infrastructure table
+- Changed file responsibilities → update descriptions
+
+**Step 3 — Verify flow diagrams.** If the request/auth/broadcast flow changed, update the ASCII diagrams in §4.1, §4.3.
+
+### Phase 3: Update Capability Map
+
+The capability map tracks what ClawWork uses. It must reflect the current ClawWork code.
+
+**Step 1 — Scan ClawWork RPC calls.** Read:
+- `packages/desktop/src/main/ws/gateway-client.ts` — all `sendReq()` calls (the method string is the first argument)
+- `packages/desktop/src/main/ipc/ws-handlers.ts` — all `ipcMain.handle()` registrations
+
+**Step 2 — Scan ClawWork event handlers.** Read:
+- `packages/core/src/services/gateway-dispatcher.ts` — the dispatch switch/if-else block
+- `packages/desktop/src/main/ws/gateway-client.ts` — the `handleEvent()` method
+
+**Step 3 — Diff against existing doc.**
+- New RPC calls in ClawWork → move from §2 (unused) to §1 (used), add location + IPC channel
+- Removed RPC calls → move from §1 to §2
+- New event handlers → move from §3.2 (unhandled) to §3.1 (handled)
+- New Gateway methods (from Phase 1) not in ClawWork → add to §2 (unused)
+
+**Step 4 — Update ConnectParams (§5).** Read the current connect handshake in `gateway-client.ts` and verify client.id, client.mode, caps, scopes, device fields match.
+
+**Step 5 — Update coverage summary (§8).** Recalculate percentages.
+
+## Output
+
+After updating, report:
+1. What changed in each document (bullet list)
+2. New Gateway capabilities that ClawWork could benefit from (if any)
+3. Any discrepancies found (e.g., ClawWork calling a removed method)
+
+## Rules
+
+- Do not invent information. Every claim must trace to a source file.
+- Do not change the document structure (section numbers, headings) without reason.
+- Preserve all `> Source:` inline annotations.
+- Use the whitepaper as the intermediate reference: Phase 1 updates it from openclaw, Phase 3 references it for the full capability list.
+- If a change is ambiguous (e.g., a method was renamed vs. removed+added), check `git log --oneline -20 -- <file>` in the openclaw repo.

--- a/docs/clawwork-gateway-capability-map.md
+++ b/docs/clawwork-gateway-capability-map.md
@@ -1,0 +1,455 @@
+# ClawWork Gateway Capability Map
+
+> ClawWork 实际使用了哪些 Gateway 能力，每个接口在哪里调用，Gateway 完整能力怎么查。
+> 版本: ClawWork main @ 2026-04-02, OpenClaw Gateway 2026.4.2
+
+---
+
+## How to Use This Document
+
+```
+新功能开发:
+  1. 在 §1 "已用能力" 中查找 → 有现成调用? 直接复用
+  2. 在 §2 "未用能力" 中查找 → Gateway 已支持? 直接接入
+  3. 都没有? → 去 whitepaper §5 查完整方法列表, 或去 openclaw 源码看 schema
+
+排错:
+  1. 在 §1 找到出问题的方法 → 看 "ClawWork 调用位置" 列
+  2. 对照 "Gateway Schema" 列 → 去 openclaw 源码确认参数/返回值
+  3. 看 §3 事件表 → 确认事件是否正确处理/是否缺少处理
+```
+
+---
+
+## 1. ClawWork 已使用的 Gateway RPC 方法 (30 个)
+
+### 1.1 Chat — 核心对话
+
+| Gateway 方法   | ClawWork 调用                               | IPC Channel                           | 用途                                            |
+| -------------- | ------------------------------------------- | ------------------------------------- | ----------------------------------------------- |
+| `chat.send`    | `gateway-client.ts:535` `sendChatMessage()` | `ws:send-message`                     | 发送用户消息，触发 AI 流式响应                  |
+| `chat.history` | `gateway-client.ts:542` `getChatHistory()`  | `ws:chat-history`, `ws:sync-sessions` | 获取会话历史 (默认 limit=50, sync 时 limit=200) |
+| `chat.abort`   | `gateway-client.ts:538` `abortChat()`       | `ws:abort-chat`                       | 中止正在运行的 AI 回复                          |
+
+> Gateway Schema: `src/gateway/protocol/schema/logs-chat.ts`
+> Gateway Handler: `src/gateway/server-methods/chat.ts`
+
+**ClawWork 使用细节:**
+
+- `chat.send` 固定传 `deliver: false` (不投递到外部渠道), `idempotencyKey: randomUUID()`
+- `chat.history` 在 sync-sessions 批量拉历史时使用 limit=200
+- `chat.abort` 仅中止当前 run (不传 runId)
+
+### 1.2 Sessions — 会话管理
+
+| Gateway 方法                | ClawWork 调用                                     | IPC Channel                   | 用途                                      |
+| --------------------------- | ------------------------------------------------- | ----------------------------- | ----------------------------------------- |
+| `sessions.list`             | `gateway-client.ts:546` `listSessions()`          | `ws:list-sessions`            | 拉取全部会话列表                          |
+| `sessions.list` (spawnedBy) | `gateway-client.ts:550` `listSessionsBySpawner()` | `ws:list-sessions-by-spawner` | 按 parent 过滤会话 (子 agent)             |
+| `sessions.create`           | `gateway-client.ts:554` `createSession()`         | `ws:create-session`           | 创建新会话 (key + agentId + 可选初始消息) |
+| `sessions.patch`            | `gateway-client.ts:601` `patchSession()`          | `ws:session-patch`            | 修改会话属性 (model, thinkingLevel 等)    |
+| `sessions.reset`            | `gateway-client.ts:605` `resetSession()`          | `ws:session-reset`            | 重置会话 (reason: "new" \| "reset")       |
+| `sessions.delete`           | `gateway-client.ts:609` `deleteSession()`         | `ws:session-delete`           | 删除会话 (固定 deleteTranscript=true)     |
+| `sessions.compact`          | `gateway-client.ts:613` `compactSession()`        | `ws:session-compact`          | 压缩会话上下文                            |
+| `sessions.usage`            | `gateway-client.ts:643` `getSessionUsage()`       | `ws:session-usage`            | 单会话 token 用量分析                     |
+
+> Gateway Schema: `src/gateway/protocol/schema/sessions.ts`
+> Gateway Handler: `src/gateway/server-methods/sessions.ts`
+
+**ClawWork 未使用的 sessions 参数:**
+
+- `sessions.list`: 未使用 `activeMinutes`, `includeGlobal`, `includeUnknown`, `includeDerivedTitles`, `includeLastMessage`, `search` 过滤
+- `sessions.patch`: 传入泛型 `Record<string, unknown>`, 但 Gateway 支持 17 个可 patch 字段 (见 whitepaper §5.3)
+- `sessions.usage`: 未使用 `startDate/endDate/mode/utcOffset/includeContextWeight`
+- `sessions.delete`: 未使用 `emitLifecycleHooks` 参数
+
+### 1.3 Agents — Agent 管理
+
+| Gateway 方法        | ClawWork 调用                              | IPC Channel            | 用途                                        |
+| ------------------- | ------------------------------------------ | ---------------------- | ------------------------------------------- |
+| `agents.list`       | `gateway-client.ts:562` `listAgents()`     | `ws:agents-list`       | 列出所有 agent                              |
+| `agents.create`     | `gateway-client.ts:566` `createAgent()`    | `ws:agents-create`     | 创建 agent (name, workspace, emoji, avatar) |
+| `agents.update`     | `gateway-client.ts:575` `updateAgent()`    | `ws:agents-update`     | 更新 agent (name, workspace, model, avatar) |
+| `agents.delete`     | `gateway-client.ts:585` `deleteAgent()`    | `ws:agents-delete`     | 删除 agent                                  |
+| `agents.files.list` | `gateway-client.ts:589` `listAgentFiles()` | `ws:agents-files-list` | 列出 agent 文件                             |
+| `agents.files.get`  | `gateway-client.ts:593` `getAgentFile()`   | `ws:agents-files-get`  | 读取 agent 文件                             |
+| `agents.files.set`  | `gateway-client.ts:597` `setAgentFile()`   | `ws:agents-files-set`  | 写入 agent 文件                             |
+
+> Gateway Schema: `src/gateway/protocol/schema/agents-models-skills.ts`
+> Gateway Handler: `src/gateway/server-methods/agents.ts`
+
+### 1.4 Models & Tools — 模型和工具
+
+| Gateway 方法    | ClawWork 调用                               | IPC Channel        | 用途                                    |
+| --------------- | ------------------------------------------- | ------------------ | --------------------------------------- |
+| `models.list`   | `gateway-client.ts:558` `listModels()`      | `ws:models-list`   | 列出可用 AI 模型                        |
+| `tools.catalog` | `gateway-client.ts:619` `getToolsCatalog()` | `ws:tools-catalog` | 获取工具目录 (固定 includePlugins=true) |
+| `skills.status` | `gateway-client.ts:625` `getSkillsStatus()` | `ws:skills-status` | 获取技能状态                            |
+
+> Gateway Schema: `src/gateway/protocol/schema/agents-models-skills.ts`
+
+**ClawWork 未使用:** `tools.effective` (获取会话级实际可用工具), `skills.install`, `skills.update`, `skills.bins`
+
+### 1.5 Usage — 用量统计
+
+| Gateway 方法   | ClawWork 调用                              | IPC Channel       | 用途                    |
+| -------------- | ------------------------------------------ | ----------------- | ----------------------- |
+| `usage.status` | `gateway-client.ts:631` `getUsageStatus()` | `ws:usage-status` | 总用量概览              |
+| `usage.cost`   | `gateway-client.ts:635` `getUsageCost()`   | `ws:usage-cost`   | 费用明细 (支持日期范围) |
+
+> Gateway Schema: 见 whitepaper §5.17
+
+### 1.6 Cron — 定时任务
+
+| Gateway 方法  | ClawWork 调用                             | IPC Channel      | 用途             |
+| ------------- | ----------------------------------------- | ---------------- | ---------------- |
+| `cron.list`   | `gateway-client.ts:651` `listCronJobs()`  | `ws:cron-list`   | 列出定时任务     |
+| `cron.status` | `gateway-client.ts:655` `getCronStatus()` | `ws:cron-status` | 定时服务状态     |
+| `cron.add`    | `gateway-client.ts:659` `addCronJob()`    | `ws:cron-add`    | 创建定时任务     |
+| `cron.update` | `gateway-client.ts:663` `updateCronJob()` | `ws:cron-update` | 更新定时任务     |
+| `cron.remove` | `gateway-client.ts:667` `removeCronJob()` | `ws:cron-remove` | 删除定时任务     |
+| `cron.run`    | `gateway-client.ts:671` `runCronJob()`    | `ws:cron-run`    | 手动执行定时任务 |
+| `cron.runs`   | `gateway-client.ts:677` `listCronRuns()`  | `ws:cron-runs`   | 执行历史         |
+
+> Gateway Schema: `src/gateway/protocol/schema/cron.ts`
+
+### 1.7 Approvals — 执行审批
+
+| Gateway 方法            | ClawWork 调用                             | IPC Channel                | 用途              |
+| ----------------------- | ----------------------------------------- | -------------------------- | ----------------- |
+| `exec.approval.resolve` | `ws-handlers.ts:556` `sendReq()` 直接调用 | `ws:exec-approval-resolve` | 批准/拒绝执行请求 |
+
+> Gateway Schema: `src/gateway/protocol/schema/exec-approvals.ts`
+
+**ClawWork 未使用:** `exec.approval.request`, `exec.approval.waitDecision`, `exec.approvals.get`, `exec.approvals.set`
+
+### 1.8 System — 系统
+
+| Gateway 方法 | ClawWork 调用                            | IPC Channel | 用途               |
+| ------------ | ---------------------------------------- | ----------- | ------------------ |
+| `health`     | `gateway-client.ts:706` heartbeat 定时器 | — (内部)    | 心跳保活，定时发送 |
+
+---
+
+## 2. ClawWork 未使用的 Gateway 能力 (80+ 个方法)
+
+按功能域分组，标注潜在用途。
+
+### 2.1 可直接接入的高价值能力
+
+| Gateway 方法                    | 潜在用途                                          | Gateway Schema            |
+| ------------------------------- | ------------------------------------------------- | ------------------------- |
+| `sessions.subscribe`            | 实时监听会话列表变化，替代轮询                    | `sessions.ts`             |
+| `sessions.unsubscribe`          | 配合 subscribe 使用                               | `sessions.ts`             |
+| `sessions.messages.subscribe`   | 实时监听单会话消息，支持多窗口同步                | `sessions.ts`             |
+| `sessions.messages.unsubscribe` | 配合 subscribe 使用                               | `sessions.ts`             |
+| `sessions.preview`              | 批量获取会话预览片段 (比逐个 chat.history 更高效) | `sessions.ts`             |
+| `tools.effective`               | 获取会话级实际工具列表 (比 tools.catalog 更精确)  | `agents-models-skills.ts` |
+| `agent.identity.get`            | 获取 agent 头像/名称 (agent 切换时展示)           | `agent.ts`                |
+| `chat.inject`                   | 注入系统消息 (admin/调试用)                       | `logs-chat.ts`            |
+| `config.get` / `config.set`     | 读写 Gateway 配置 (设置面板)                      | `config.ts`               |
+| `config.schema`                 | 获取配置 JSON Schema (动态生成设置表单)           | `config.ts`               |
+| `status`                        | 系统状态概览 (Dashboard)                          | —                         |
+| `channels.status`               | 渠道连接状态 (连接管理面板)                       | `channels.ts`             |
+
+### 2.2 次优先级能力
+
+| Gateway 方法                | 潜在用途                                | Gateway Schema |
+| --------------------------- | --------------------------------------- | -------------- |
+| `agent`                     | 完整 agent 调用 (比 chat.send 更多参数) | `agent.ts`     |
+| `agent.wait`                | 等待 agent 运行完成 (同步工作流)        | `agent.ts`     |
+| `sessions.send`             | 高级会话发送 (比 chat.send 更多控制)    | `sessions.ts`  |
+| `sessions.abort`            | 会话级中止 (比 chat.abort 更高级)       | `sessions.ts`  |
+| `talk.speak`                | TTS 文本转语音                          | `channels.ts`  |
+| `talk.config` / `talk.mode` | 语音模式配置                            | `channels.ts`  |
+| `update.run`                | 触发 Gateway 软件更新                   | —              |
+| `logs.tail`                 | 流式读取 Gateway 日志 (调试面板)        | `logs-chat.ts` |
+| `doctor.memory.status`      | 内存诊断 (健康面板)                     | —              |
+| `wake`                      | 唤醒 agent                              | `agent.ts`     |
+
+### 2.3 设备/节点/插件管理 (当前不需要)
+
+| 方法组                                                                 | 方法数 | Gateway Schema            |
+| ---------------------------------------------------------------------- | ------ | ------------------------- |
+| `device.pair.*` / `device.token.*`                                     | 6      | `devices.ts`              |
+| `node.*`                                                               | 15     | `nodes.ts`                |
+| `plugin.approval.*`                                                    | 3      | `plugin-approvals.ts`     |
+| `exec.approvals.*` (settings)                                          | 4      | `exec-approvals.ts`       |
+| `wizard.*`                                                             | 4      | `wizard.ts`               |
+| `tts.*`                                                                | 6      | `channels.ts`             |
+| `voicewake.*`                                                          | 2      | —                         |
+| `secrets.*`                                                            | 2      | `secrets.ts`              |
+| `skills.install` / `skills.update` / `skills.bins`                     | 3      | `agents-models-skills.ts` |
+| `send` / `poll` / `push.test`                                          | 3      | `agent.ts`, `push.ts`     |
+| `config.apply` / `config.patch` / `config.schema.lookup`               | 3      | `config.ts`               |
+| `gateway.identity.get` / `system-presence` / `system-event`            | 3      | —                         |
+| `channels.logout` / `web.login.*`                                      | 3      | `channels.ts`             |
+| `last-heartbeat` / `set-heartbeats` / `node.canvas.capability.refresh` | 3      | —                         |
+
+---
+
+## 3. ClawWork 事件处理状态
+
+### 3.1 已处理的事件 (6 个)
+
+| Gateway 事件              | 处理位置                                           | 处理逻辑                                                                     |
+| ------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `connect.challenge`       | `gateway-client.ts:216`                            | 触发 connect 握手 (发送设备签名 + auth)                                      |
+| `tick`                    | `gateway-client.ts:239`                            | 日志记录，无操作 (心跳由 client 主动发 health RPC)                           |
+| `chat`                    | `gateway-dispatcher.ts:582` → `handleChatEvent()`  | 流式响应: delta→累加文本, final→持久化消息, error→toast, aborted→清除        |
+| `agent`                   | `gateway-dispatcher.ts:584` → `handleAgentEvent()` | 工具调用: tool stream→更新工具状态, lifecycle→处理中标记, error→去重错误提示 |
+| `exec.approval.requested` | `gateway-dispatcher.ts:586`                        | 添加到 ApprovalStore, 桌面通知, TTL 过期计时                                 |
+| `exec.approval.resolved`  | `gateway-dispatcher.ts:588`                        | 从 ApprovalStore 移除                                                        |
+
+### 3.2 未处理的事件 (18 个) — 扩展机会
+
+| Gateway 事件                | 潜在用途                                    | 接入难度                |
+| --------------------------- | ------------------------------------------- | ----------------------- |
+| `sessions.changed`          | **高价值** — 实时更新会话列表，替代手动刷新 | 低 (加 dispatcher case) |
+| `session.message`           | **高价值** — 多窗口消息同步，子 agent 进度  | 低 (需先 subscribe)     |
+| `session.tool`              | **高价值** — 多窗口工具状态同步             | 低 (需先 subscribe)     |
+| `presence`                  | 显示谁在线 (多设备场景)                     | 低                      |
+| `health`                    | 系统健康指示器 (状态栏)                     | 低                      |
+| `shutdown`                  | 优雅处理 Gateway 关闭 (提示用户)            | 低                      |
+| `update.available`          | 提示用户 Gateway 可更新                     | 低                      |
+| `plugin.approval.requested` | 插件安装审批 UI                             | 中                      |
+| `plugin.approval.resolved`  | 插件审批结果                                | 中                      |
+| `cron`                      | 定时任务执行通知                            | 中                      |
+| `device.pair.requested`     | 设备配对审批                                | 中                      |
+| `device.pair.resolved`      | 设备配对结果                                | 中                      |
+| `node.pair.requested`       | 节点配对审批                                | 中                      |
+| `node.pair.resolved`        | 节点配对结果                                | 中                      |
+| `node.invoke.request`       | 节点任务分发                                | 高 (需节点支持)         |
+| `voicewake.changed`         | 语音唤醒配置变更                            | 低                      |
+| `talk.mode`                 | 语音模式切换                                | 低                      |
+| `heartbeat`                 | Agent 心跳确认                              | 低                      |
+
+---
+
+## 4. 架构总览: 数据流
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Renderer (React)                                                │
+│                                                                 │
+│  Components                                                     │
+│    ↕ useGatewayBootstrap()  hooks/useGatewayBootstrap.ts        │
+│    ↕ platform adapter       platform/electron-adapter.ts        │
+│                                                                 │
+│  Stores (Zustand)                                               │
+│    MessageStore   → chat/agent 事件更新                          │
+│    UiStore        → 连接状态, catalog, 版本信息                   │
+│    ApprovalStore  → exec approval 事件更新                       │
+│                                                                 │
+├─── IPC Bridge ──────────────────────────────────────────────────┤
+│                                                                 │
+│  preload/index.ts                                               │
+│    gateway.invoke(channel, params)  → ipcRenderer.invoke()      │
+│    gateway.onEvent(callback)        → ipcRenderer.on()          │
+│    gateway.onStatus(callback)       → ipcRenderer.on()          │
+│                                                                 │
+├─── Main Process ────────────────────────────────────────────────┤
+│                                                                 │
+│  ipc/ws-handlers.ts (30 IPC handlers)                           │
+│    ws:send-message    → gw.sendChatMessage()                    │
+│    ws:chat-history    → gw.getChatHistory()                     │
+│    ws:abort-chat      → gw.abortChat()                          │
+│    ws:list-sessions   → gw.listSessions()                       │
+│    ws:create-session  → gw.createSession()                      │
+│    ws:session-patch   → gw.patchSession()                       │
+│    ws:session-reset   → gw.resetSession()                       │
+│    ws:session-delete  → gw.deleteSession()                      │
+│    ws:session-compact → gw.compactSession()                     │
+│    ws:session-usage   → gw.getSessionUsage()                    │
+│    ws:models-list     → gw.listModels()                         │
+│    ws:agents-*        → gw.listAgents/create/update/delete()    │
+│    ws:agents-files-*  → gw.listAgentFiles/get/set()             │
+│    ws:tools-catalog   → gw.getToolsCatalog()                    │
+│    ws:skills-status   → gw.getSkillsStatus()                    │
+│    ws:usage-*         → gw.getUsageStatus/Cost()                │
+│    ws:cron-*          → gw.listCronJobs/add/update/remove/run() │
+│    ws:exec-approval-* → gw.sendReq('exec.approval.resolve')    │
+│    ws:sync-sessions   → batch listSessions + getChatHistory     │
+│    ...                                                          │
+│                                                                 │
+│  ws/gateway-client.ts (WebSocket client)                        │
+│    sendReq(method, params) → JSON frame → WebSocket             │
+│    handleEvent(event)      → IPC → Renderer                     │
+│    heartbeat               → health RPC every N ms              │
+│    reconnect               → exponential backoff                │
+│                                                                 │
+├─── WebSocket ───────────────────────────────────────────────────┤
+│                                                                 │
+│  ws://localhost:18789                                            │
+│                                                                 │
+└───── OpenClaw Gateway ──────────────────────────────────────────┘
+```
+
+---
+
+## 5. ConnectParams — ClawWork 连接参数
+
+> Source: `packages/desktop/src/main/ws/gateway-client.ts:277-310`
+
+```typescript
+{
+  minProtocol: 3,
+  maxProtocol: 3,
+  client: {
+    id: "gateway-client",         // ⚠️ 应该用 "openclaw-macos" (见 whitepaper §3.3)
+    displayName: "ClawWork Desktop",
+    version: app.getVersion(),
+    platform: process.platform,
+    mode: "backend"               // ⚠️ 应该用 "ui" (见 whitepaper §3.3)
+  },
+  caps: ["tool-events"],
+  role: "operator",
+  scopes: [
+    "operator.admin",
+    "operator.write",
+    "operator.read",
+    "operator.approvals",
+    "operator.pairing"
+  ],
+  device: {
+    id: "<sha256-of-public-key>",
+    publicKey: "<base64url-ed25519>",
+    signature: "<base64url-signature>",
+    signedAt: Date.now(),
+    nonce: "<from-connect.challenge>"
+  },
+  auth: {
+    token?: string,
+    password?: string,
+    bootstrapToken?: string,
+    deviceToken?: string          // 首次配对后由 Gateway 签发，后续重连使用
+  }
+}
+```
+
+---
+
+## 6. 关键文件清单
+
+### ClawWork 侧
+
+| 文件                                                         | 职责                                                |
+| ------------------------------------------------------------ | --------------------------------------------------- |
+| `packages/desktop/src/main/ws/gateway-client.ts`             | WebSocket 客户端: 连接、握手、RPC、事件、心跳、重连 |
+| `packages/desktop/src/main/ws/index.ts`                      | 多 Gateway 管理: init/add/remove/reconnect          |
+| `packages/desktop/src/main/ipc/ws-handlers.ts`               | IPC Handler 注册: 30 个 `ipcMain.handle()`          |
+| `packages/desktop/src/preload/index.ts`                      | IPC Bridge: renderer ↔ main 通信                    |
+| `packages/core/src/services/gateway-dispatcher.ts`           | 事件分发: chat/agent/approval 事件处理              |
+| `packages/desktop/src/renderer/hooks/useGatewayBootstrap.ts` | Renderer 初始化: 事件订阅、catalog 拉取             |
+| `packages/core/src/stores/message-store.ts`                  | 消息状态: 流式累加、工具调用、持久化                |
+| `packages/core/src/stores/ui-store.ts`                       | UI 状态: 连接状态、catalog、版本                    |
+| `packages/desktop/src/renderer/stores/approvalStore.ts`      | 审批状态: pending approvals + TTL                   |
+| `packages/shared/src/gateway-protocol.ts`                    | 类型定义: Frame types, ConnectParams, Auth          |
+
+### OpenClaw Gateway 侧 (按查找频率排序)
+
+| 文件                                                  | 职责                                                    |
+| ----------------------------------------------------- | ------------------------------------------------------- |
+| `src/gateway/protocol/schema/logs-chat.ts`            | chat.send/history/abort schema                          |
+| `src/gateway/protocol/schema/sessions.ts`             | sessions.\* schema                                      |
+| `src/gateway/protocol/schema/agent.ts`                | agent/send/poll schema + AgentEvent                     |
+| `src/gateway/protocol/schema/agents-models-skills.ts` | agents/models/tools/skills schema                       |
+| `src/gateway/protocol/schema/cron.ts`                 | cron.\* schema                                          |
+| `src/gateway/protocol/schema/frames.ts`               | ConnectParams, HelloOk, Frame types                     |
+| `src/gateway/protocol/schema/exec-approvals.ts`       | exec.approval.\* schema                                 |
+| `src/gateway/server-methods-list.ts`                  | 完整方法列表 (BASE_METHODS) + 事件列表 (GATEWAY_EVENTS) |
+| `src/gateway/method-scopes.ts`                        | 方法→scope 权限映射                                     |
+| `src/gateway/server-broadcast.ts`                     | 事件广播 + scope guard                                  |
+| `src/gateway/server-methods/chat.ts`                  | chat handler 实现                                       |
+| `src/gateway/server-methods/sessions.ts`              | sessions handler 实现                                   |
+
+---
+
+## 7. 添加新 Gateway 能力的 Checklist
+
+当你要在 ClawWork 中接入一个新的 Gateway 方法时:
+
+```
+□ 1. 确认方法存在
+     → 查 openclaw: src/gateway/server-methods-list.ts (BASE_METHODS)
+     → 查 whitepaper §5 方法列表
+
+□ 2. 理解方法参数和返回值
+     → 查 openclaw: src/gateway/protocol/schema/<domain>.ts
+     → 查 whitepaper 对应小节的 TypeScript 定义
+
+□ 3. 确认权限要求
+     → 查 openclaw: src/gateway/method-scopes.ts
+     → ClawWork 默认请求 operator.admin, 所以几乎所有方法都能调用
+
+□ 4. 在 GatewayClient 添加方法
+     → 编辑: packages/desktop/src/main/ws/gateway-client.ts
+     → 模式: async methodName(params): Promise<Record<string, unknown>> {
+              return this.sendReq('<gateway.method>', params);
+            }
+
+□ 5. 在 IPC Handler 暴露给 Renderer
+     → 编辑: packages/desktop/src/main/ipc/ws-handlers.ts
+     → 模式: ipcMain.handle('ws:<method-name>', async (_event, payload) =>
+              gatewayRpc(payload.gatewayId, (gw) => gw.methodName(payload))
+            );
+
+□ 6. 在 Preload 声明 IPC Channel (如果需要新 channel)
+     → 编辑: packages/desktop/src/preload/index.ts
+
+□ 7. 在 Renderer 调用
+     → 通过 platform adapter 或直接 invoke('ws:<method-name>', params)
+
+□ 8. 如果方法触发新事件，在 Dispatcher 添加处理
+     → 编辑: packages/core/src/services/gateway-dispatcher.ts
+     → 添加 else if (data.event === '<event-name>') 分支
+```
+
+当你要处理一个新的 Gateway 事件时:
+
+```
+□ 1. 确认事件存在
+     → 查 openclaw: src/gateway/server-methods-list.ts (GATEWAY_EVENTS)
+     → 查 whitepaper §4 事件表
+
+□ 2. 确认事件 scope 要求
+     → 查 openclaw: src/gateway/server-broadcast.ts (EVENT_SCOPE_GUARDS)
+     → 部分事件需要 operator.read / operator.approvals / operator.pairing
+
+□ 3. 确认是否需要订阅
+     → sessions.changed 需要 sessions.subscribe
+     → session.message / session.tool 需要 sessions.messages.subscribe
+     → 其他事件自动广播
+
+□ 4. 在 Dispatcher 添加 handler
+     → 编辑: packages/core/src/services/gateway-dispatcher.ts
+     → 在 dispatch switch 中添加分支
+
+□ 5. 更新 Store
+     → 根据事件性质更新 MessageStore / UiStore / 新 Store
+```
+
+---
+
+## 8. Coverage Summary
+
+```
+Gateway 方法总计:    110+ (BASE_METHODS)
+ClawWork 已使用:     30 (27%)
+ClawWork 未使用:     80+ (73%)
+
+Gateway 事件总计:    24
+ClawWork 已处理:     6 (25%)
+ClawWork 未处理:     18 (75%)
+
+高价值未接入:
+  - sessions.subscribe/unsubscribe        → 实时会话列表
+  - sessions.messages.subscribe/unsubscribe → 多窗口消息同步
+  - sessions.preview                      → 高效批量预览
+  - tools.effective                       → 精确工具列表
+  - config.get/set/schema                 → 设置面板
+  - sessions.changed 事件                  → 替代轮询
+  - session.message/session.tool 事件      → 多窗口同步
+  - shutdown 事件                          → 优雅断开
+  - update.available 事件                  → 更新提示
+```

--- a/docs/openclaw-gateway-source-guide.md
+++ b/docs/openclaw-gateway-source-guide.md
@@ -1,0 +1,615 @@
+# OpenClaw Gateway Source Code Navigation Guide
+
+> For ClawWork developers who need to read, trace, and debug OpenClaw Gateway internals.
+> Prerequisite: read `openclaw-gateway-whitepaper.md` first for the protocol contract.
+> Repo: `~/git/openclaw` (TypeScript, ESM, pnpm)
+
+---
+
+## 0. Before You Start
+
+```bash
+cd ~/git/openclaw
+pnpm install          # install deps
+pnpm build            # verify build (also generates types)
+```
+
+Tools you'll use constantly:
+
+| Tool    | Purpose                              | Example                                                |
+| ------- | ------------------------------------ | ------------------------------------------------------ |
+| ripgrep | Search code by pattern               | `rg "chat.send" src/gateway/`                          |
+| TypeBox | Schema definitions (runtime + types) | `Type.Object({ ... })`                                 |
+| vitest  | Run tests                            | `pnpm test -- src/gateway/server-methods/chat.test.ts` |
+
+The Gateway codebase is ~440 TypeScript files under `src/gateway/`. Don't try to read everything. This guide teaches you **where to look** for what you need.
+
+---
+
+## 1. Mental Model: Four Layers
+
+```
+┌────────────────────────────────────────────────────┐
+│ Layer 4: Protocol Schema (the contract)            │
+│   src/gateway/protocol/schema/*.ts                 │
+│   What: TypeBox definitions for every frame,       │
+│         method param, response, and event payload   │
+│   When to read: "What fields does X accept/return?"│
+├────────────────────────────────────────────────────┤
+│ Layer 3: Method Handlers (the logic)               │
+│   src/gateway/server-methods/*.ts                  │
+│   What: One file per domain (chat, sessions, etc.) │
+│   When to read: "What does X actually do?"         │
+├────────────────────────────────────────────────────┤
+│ Layer 2: Server Infrastructure (the plumbing)      │
+│   src/gateway/server/*.ts                          │
+│   src/gateway/server-broadcast.ts                  │
+│   src/gateway/server-methods.ts (dispatcher)       │
+│   What: WS connection, auth, dispatch, broadcast   │
+│   When to read: "Why is my frame rejected/dropped?"│
+├────────────────────────────────────────────────────┤
+│ Layer 1: Server Startup (the bootstrap)            │
+│   src/gateway/server.impl.ts                       │
+│   What: Wires everything together                  │
+│   When to read: "How does the Gateway initialize?" │
+└────────────────────────────────────────────────────┘
+```
+
+**Rule of thumb:** Start at Layer 4 (schema) for "what", go to Layer 3 (handlers) for "how", drop to Layer 2 only when debugging connection/auth/broadcast issues.
+
+---
+
+## 2. Layer 4: Protocol Schema — The Contract
+
+### 2.1 Directory Map
+
+```
+src/gateway/protocol/
+├── schema.ts                    # barrel — re-exports everything
+├── index.ts                     # protocol validators (AJV compiled)
+├── client-info.ts               # client IDs, modes, capabilities
+├── AGENTS.md (= CLAUDE.md)     # boundary rules
+└── schema/
+    ├── protocol-schemas.ts      # ★ MASTER REGISTRY — PROTOCOL_VERSION, all schema exports
+    ├── primitives.ts            # shared types: NonEmptyString, SessionKey, InputProvenance
+    ├── frames.ts                # ★ RequestFrame, ResponseFrame, EventFrame, ConnectParams, HelloOk
+    ├── error-codes.ts           # ErrorCodes enum
+    ├── snapshot.ts              # PresenceEntry, HealthSnapshot, SessionDefaults, Snapshot
+    ├── logs-chat.ts             # chat.send/history/abort/inject params + ChatEvent
+    ├── agent.ts                 # agent/send/poll/wake params + AgentEvent
+    ├── sessions.ts              # sessions.* params (create/send/abort/list/patch/reset/delete/compact/usage)
+    ├── agents-models-skills.ts  # agents.*/models.list/tools.catalog/tools.effective/skills.*
+    ├── config.ts                # config.* params
+    ├── cron.ts                  # cron.* params + schedule/payload/delivery types
+    ├── nodes.ts                 # node.* params
+    ├── devices.ts               # device.* params
+    ├── exec-approvals.ts        # exec.approval.* params
+    ├── plugin-approvals.ts      # plugin.approval.* params
+    ├── channels.ts              # channels.status, talk.speak, web.login.* params
+    ├── push.ts                  # push.test params
+    ├── secrets.ts               # secrets.reload/resolve params
+    ├── wizard.ts                # wizard.* params
+    └── types.ts                 # utility type helpers
+```
+
+### 2.2 How to Read a Schema File
+
+Every schema uses `@sinclair/typebox`. Pattern:
+
+```typescript
+import { Type } from '@sinclair/typebox';
+
+export const ChatSendParamsSchema = Type.Object(
+  {
+    sessionKey: ChatSendSessionKeyString, // required field
+    message: Type.String(), // required field
+    thinking: Type.Optional(Type.String()), // optional field
+    deliver: Type.Optional(Type.Boolean()),
+    idempotencyKey: NonEmptyString, // required field
+  },
+  { additionalProperties: false },
+);
+```
+
+**Reading rules:**
+
+- `Type.Object({ ... })` = JSON object shape
+- `Type.Optional(...)` = field is optional
+- `Type.String()` / `Type.Integer()` / `Type.Boolean()` = primitives
+- `Type.Union([Type.Literal("a"), Type.Literal("b")])` = enum
+- `Type.Array(...)` = array
+- `Type.Unknown()` = any (opaque to validation)
+- `{ additionalProperties: false }` = strict — extra fields rejected
+- Named strings like `NonEmptyString`, `ChatSendSessionKeyString` = refined primitives in `primitives.ts`
+
+### 2.3 The Master Registry
+
+`protocol-schemas.ts` is the single source of truth for what version the protocol is at and what schemas exist:
+
+```typescript
+export const PROTOCOL_VERSION = 3;
+```
+
+If you need to know "does method X exist in the current protocol?", search this file first.
+
+### 2.4 Practical Workflow: Tracing a Method's Schema
+
+Example: you want to know the exact params for `sessions.patch`.
+
+```bash
+# Step 1: find which schema file defines it
+rg "SessionsPatch" src/gateway/protocol/schema/ --files-with-matches
+# → src/gateway/protocol/schema/sessions.ts
+
+# Step 2: read the schema
+# Look for SessionsPatchParamsSchema
+```
+
+This works for any method — search `<MethodName>Params` or `<MethodName>Result`.
+
+---
+
+## 3. Layer 3: Method Handlers — The Logic
+
+### 3.1 Directory Map
+
+```
+src/gateway/server-methods/
+├── types.ts                     # ★ GatewayRequestContext, GatewayRequestHandlers, RespondFn
+├── validation.ts                # payload validation helpers
+│
+├── chat.ts                      # ★ chat.send, chat.history, chat.abort, chat.inject (~800 LOC)
+├── chat-*.ts                    # chat helpers (transcript inject, test helpers, etc.)
+│
+├── sessions.ts                  # ★ sessions.list/create/send/abort/patch/reset/delete/compact (~600 LOC)
+│
+├── agent.ts                     # agent, agent.identity.get, agent.wait
+├── agent-*.ts                   # agent helpers (job, wait-dedupe, timestamp)
+│
+├── agents.ts                    # agents.list/create/update/delete, agents.files.*
+├── config.ts                    # config.get/set/apply/patch/schema/schema.lookup
+├── cron.ts                      # cron.list/add/update/remove/run/runs/status
+├── devices.ts                   # device.pair.*, device.token.*
+├── nodes.ts                     # node.list/describe/rename/invoke/pending.*/pair.*
+├── exec-approval.ts             # exec.approval.request/waitDecision/resolve
+├── exec-approvals.ts            # exec.approvals.get/set (settings)
+├── plugin-approval.ts           # plugin.approval.*
+├── channels.ts                  # channels.status/logout
+├── health.ts                    # health
+├── system.ts                    # status, gateway.identity.get, system-presence, system-event
+├── models.ts                    # models.list
+├── tools-catalog.ts             # tools.catalog
+├── tools-effective.ts           # tools.effective
+├── skills.ts                    # skills.*
+├── talk.ts                      # talk.config/speak/mode
+├── tts.ts                       # tts.*
+├── send.ts                      # send (external channel delivery)
+├── push.ts                      # push.test
+├── logs.ts                      # logs.tail
+├── usage.ts                     # usage.status/cost
+├── voicewake.ts                 # voicewake.get/set
+├── wizard.ts                    # wizard.*
+├── secrets.ts                   # secrets.reload/resolve
+├── doctor.ts                    # doctor.memory.status
+├── update.ts                    # update.run
+└── connect.ts                   # connect (internal handshake handler)
+```
+
+### 3.2 How to Read a Handler
+
+Every handler follows the same pattern:
+
+```typescript
+// In types.ts — the handler signature
+type GatewayRequestHandler = (ctx: {
+  req: { id: string; method: string; params?: unknown };
+  params: unknown; // raw params (pre-validation)
+  client: GatewayWsClient; // connection info + auth
+  respond: RespondFn; // call respond(true, payload) or respond(false, error)
+  context: GatewayRequestContext; // shared services (sessions, agents, config, etc.)
+}) => Promise<void>;
+```
+
+**Example: Reading chat.ts**
+
+```typescript
+// Simplified flow of chat.send handler:
+async function handleChatSend(ctx) {
+  // 1. Validate params against ChatSendParamsSchema
+  const params = validate(ctx.params, ChatSendParamsSchema);
+
+  // 2. Check idempotency (deduplicate repeat requests)
+  if (isDuplicate(params.idempotencyKey)) return respond(true, cached);
+
+  // 3. Resolve session
+  const session = await resolveSession(params.sessionKey);
+
+  // 4. Start agent run
+  const runId = await startAgentRun(session, params);
+
+  // 5. Respond with runId (streaming happens via events)
+  respond(true, { runId, sessionId: session.id });
+
+  // 6. Agent execution continues async → emits chat/agent events
+}
+```
+
+### 3.3 Practical Workflow: Tracing "What Happens When I Call X?"
+
+Example: you want to understand what `sessions.create` does.
+
+```bash
+# Step 1: find the handler file
+rg "sessions.create" src/gateway/server-methods/ --files-with-matches
+# → src/gateway/server-methods/sessions.ts
+
+# Step 2: find the handler function
+rg "sessions\.create" src/gateway/server-methods/sessions.ts
+# Look for the method registration or switch case
+
+# Step 3: read the handler logic
+# Follow: validation → business logic → respond()
+```
+
+---
+
+## 4. Layer 2: Server Infrastructure — The Plumbing
+
+### 4.1 Request Flow (Frame to Response)
+
+```
+WebSocket frame arrives
+        │
+        ▼
+┌─ ws-connection.ts ────────────────────────────────────┐
+│  attachGatewayWsConnectionHandler()                   │
+│  → generates connId, extracts headers                 │
+│  → sets handshake timeout (10s)                       │
+│  → attaches message handler                           │
+└───────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ server/ws-connection/message-handler.ts ─────────────┐
+│  attachGatewayWsMessageHandler()                      │
+│  → parse JSON frame                                   │
+│  → if first frame: validate ConnectParams, auth       │
+│  → if authed: send HelloOk, attach RPC handler        │
+│  → subsequent frames: validate RequestFrame           │
+│  → call handleGatewayRequest()                        │
+└───────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ server-methods.ts ───────────────────────────────────┐
+│  handleGatewayRequest()                               │
+│  → authorizeGatewayMethod(method, client)             │
+│    (checks role + scope via method-scopes.ts)         │
+│  → lookup handler in coreGatewayHandlers[method]      │
+│  → call handler({ req, params, client, respond })     │
+└───────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ server-methods/<domain>.ts ──────────────────────────┐
+│  Domain handler                                       │
+│  → validate params (TypeBox + AJV)                    │
+│  → business logic                                     │
+│  → respond(ok, payload) or respond(false, error)      │
+│  → may trigger broadcast events                       │
+└───────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ server-broadcast.ts ─────────────────────────────────┐
+│  broadcast(event, payload, opts)                      │
+│  → for each connected client:                         │
+│    → check scope guards (EVENT_SCOPE_GUARDS)          │
+│    → check slow consumer (bufferedAmount > 50MB)      │
+│    → send EventFrame JSON                             │
+└───────────────────────────────────────────────────────┘
+```
+
+### 4.2 Key Infrastructure Files
+
+| File                                               | Responsibility                                                 | When to read                         |
+| -------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------ |
+| `server.impl.ts`                                   | Bootstrap: wires config, auth, WS, HTTP, plugins, health, cron | "How does the Gateway start?"        |
+| `server/ws-connection.ts`                          | WS connection setup, connId, handshake timeout                 | "Why was my connection dropped?"     |
+| `server/ws-connection/message-handler.ts`          | Frame parsing, auth, HelloOk, RPC dispatch                     | "Why is my frame rejected?"          |
+| `server/ws-connection/auth-context.ts`             | Auth decision logic (token, device, password)                  | "Why did auth fail?"                 |
+| `server/ws-connection/connect-policy.ts`           | Device pairing, auto-approval, control-UI auth                 | "Why isn't my device approved?"      |
+| `server/ws-connection/handshake-auth-helpers.ts`   | Device signature verification (v2/v3)                          | "Signature verification failed"      |
+| `server/ws-connection/unauthorized-flood-guard.ts` | Rate limiting for bad auth                                     | "Why am I locked out?"               |
+| `server-methods.ts`                                | RPC dispatcher: authorize + route to handler                   | "Method not found / unauthorized"    |
+| `method-scopes.ts`                                 | Scope → method mapping (who can call what)                     | "PERMISSION_DENIED on method X"      |
+| `server-broadcast.ts`                              | Event broadcast engine, scope guards, slow consumer            | "Why don't I receive event X?"       |
+| `server-constants.ts`                              | MAX_PAYLOAD, MAX_BUFFERED, TICK_INTERVAL, DEDUPE               | "What are the limits?"               |
+| `auth-rate-limit.ts`                               | Rate limit config per auth scope                               | "Why am I getting rate limited?"     |
+| `handshake-timeouts.ts`                            | Pre-auth handshake timeout (10s)                               | "Connection closes before I connect" |
+| `events.ts`                                        | Event name constants                                           | "What's the exact event name?"       |
+
+### 4.3 Authentication Flow (Deep Dive)
+
+```
+ConnectParams arrives
+        │
+        ▼
+┌─ auth-context.ts ─────────────────────────────────────┐
+│  resolveConnectAuthState()                            │
+│  → check auth mode (none/token/password/trusted-proxy)│
+│  → if device auth: verify signature (v2/v3)           │
+│  → if device token: validate JWT                      │
+│  → if bootstrap token: validate + check expiry        │
+│  → rate limit check                                   │
+│  ▼                                                    │
+│  resolveConnectAuthDecision()                         │
+│  → determine role (operator/node)                     │
+│  → determine scopes                                   │
+│  → issue device token if new pairing                  │
+│  → return GatewayAuthResult                           │
+└───────────────────────────────────────────────────────┘
+```
+
+Files involved:
+
+```
+server/ws-connection/auth-context.ts        → main auth decision
+server/ws-connection/handshake-auth-helpers.ts → signature verification
+server/ws-connection/connect-policy.ts      → pairing and approval
+server/ws-connection/auth-messages.ts       → error message formatting
+auth-rate-limit.ts                          → sliding window rate limiter
+```
+
+---
+
+## 5. Layer 1: Startup — The Bootstrap
+
+`src/gateway/server.impl.ts` is the entry point. Simplified boot sequence:
+
+```
+startGatewayServer(options)
+  │
+  ├── load config
+  ├── initialize auth (token, device store)
+  ├── create HTTP server (server/http-listen.ts)
+  │     ├── /health, /healthz → liveness probe
+  │     ├── /ready, /readyz → readiness probe
+  │     ├── /v1/chat/completions → OpenAI-compat (openai-http.ts)
+  │     ├── /v1/responses → OpenResponses
+  │     └── plugin HTTP routes (server/plugins-http.ts)
+  │
+  ├── create WebSocket server (attached to HTTP)
+  │     └── on connection → ws-connection.ts
+  │
+  ├── create broadcaster (server-broadcast.ts)
+  ├── create RPC dispatcher (server-methods.ts)
+  ├── initialize session manager
+  ├── initialize agent engine
+  ├── initialize cron service
+  ├── start health refresh loop (60s)
+  ├── start tick loop (30s)
+  └── run BOOT.md if present (boot.ts)
+```
+
+---
+
+## 6. Common Debugging Scenarios
+
+### "Method X returns an error I don't understand"
+
+```bash
+# 1. Find the error code definition
+rg "INVALID_REQUEST\|UNAVAILABLE\|NOT_PAIRED" src/gateway/protocol/schema/error-codes.ts
+
+# 2. Find where that error is thrown
+rg "INVALID_REQUEST" src/gateway/server-methods/
+
+# 3. Read the handler to understand the condition
+```
+
+### "I'm not receiving event Y"
+
+```bash
+# 1. Check if event requires a scope guard
+rg "session.message\|session.tool" src/gateway/server-broadcast.ts
+# → EVENT_SCOPE_GUARDS shows: requires operator.read
+
+# 2. Check if event requires a capability
+rg "tool-events" src/gateway/
+# → agent tool events require caps: ["tool-events"]
+
+# 3. Check if you're subscribed (for session events)
+rg "sessions.messages.subscribe" src/gateway/server-methods/
+```
+
+### "I want to know what fields method X accepts"
+
+```bash
+# 1. Find the schema
+rg "SessionsPatchParamsSchema" src/gateway/protocol/schema/
+# → sessions.ts
+
+# 2. Read the TypeBox definition — every field, type, and constraint is there
+```
+
+### "I want to add support for a new method in ClawWork"
+
+```
+Step 1: Schema    → src/gateway/protocol/schema/<domain>.ts     (params + result)
+Step 2: Handler   → src/gateway/server-methods/<domain>.ts      (logic)
+Step 3: Method    → src/gateway/server-methods-list.ts           (registered?)
+Step 4: Scopes    → src/gateway/method-scopes.ts                 (auth requirements)
+Step 5: Events    → src/gateway/server-broadcast.ts              (scope guards on events)
+```
+
+### "The Gateway closed my connection"
+
+```bash
+# Check close codes
+rg "socket.close\|\.close(" src/gateway/server-broadcast.ts src/gateway/server/ws-connection/
+# 1008 = slow consumer (bufferedAmount > 50MB)
+# 1002 = protocol error
+# 1003 = invalid frame
+# 1011 = unexpected condition
+
+# Check handshake timeout
+# → handshake-timeouts.ts: 10s to complete connect handshake
+```
+
+---
+
+## 7. File Discovery Cheatsheet
+
+| I want to find...                    | Search command                                                    |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| Schema for any method                | `rg "<MethodName>Params" src/gateway/protocol/schema/`            |
+| Handler for any method               | `rg "<method.name>" src/gateway/server-methods/`                  |
+| Where an event is emitted            | `rg "broadcast.*\"<event-name>\"" src/gateway/`                   |
+| What scope a method requires         | `rg "<method.name>" src/gateway/method-scopes.ts`                 |
+| All TypeBox schemas in a file        | `rg "export const.*Schema" src/gateway/protocol/schema/<file>.ts` |
+| All methods registered               | Read `src/gateway/server-methods-list.ts` → `BASE_METHODS`        |
+| All events registered                | Read `src/gateway/server-methods-list.ts` → `GATEWAY_EVENTS`      |
+| All client IDs / modes / caps        | Read `src/gateway/protocol/client-info.ts`                        |
+| Server constants (limits, intervals) | Read `src/gateway/server-constants.ts`                            |
+| Error code definitions               | Read `src/gateway/protocol/schema/error-codes.ts`                 |
+| Test for a specific handler          | `ls src/gateway/server-methods/<domain>.test.ts`                  |
+| Shared primitive types               | Read `src/gateway/protocol/schema/primitives.ts`                  |
+
+---
+
+## 8. Understanding TypeBox ↔ Runtime Validation
+
+OpenClaw uses TypeBox to define schemas and AJV to validate at runtime:
+
+```
+TypeBox schema (compile-time type + runtime schema)
+        │
+        ▼
+src/gateway/protocol/index.ts
+  → compiles TypeBox → AJV validators
+  → exports: validateRequestFrame(), validateConnectParams(), etc.
+        │
+        ▼
+server/ws-connection/message-handler.ts
+  → calls validators on every incoming frame
+  → rejects with INVALID_REQUEST if validation fails
+```
+
+**Key implication for ClawWork:** If a field is marked `{ additionalProperties: false }` in the schema (and almost all are), sending extra fields in your request **will cause a validation error**. Only send fields defined in the schema.
+
+---
+
+## 9. Testing Gateway Code
+
+### Running Tests
+
+```bash
+# All gateway tests
+pnpm test -- src/gateway/
+
+# Specific handler tests
+pnpm test -- src/gateway/server-methods/chat.test.ts
+
+# Specific test by name
+pnpm test -- src/gateway/server-methods/chat.test.ts -t "chat.send"
+
+# Protocol schema tests
+pnpm test -- src/gateway/protocol/
+```
+
+### Test Organization
+
+- Tests are colocated: `chat.ts` → `chat.test.ts`
+- Test helpers: `src/gateway/test-helpers.ts`, `src/gateway/test-helpers.mocks.ts`
+- Server integration tests use `src/gateway/server/` test utils for mock setup
+- ~190 test files total under `src/gateway/`
+
+### Reading Tests as Documentation
+
+When the schema or handler isn't clear enough, the test file often has the best examples:
+
+```bash
+# Find real usage examples in tests
+rg "chat.send" src/gateway/server-methods/chat.test.ts
+# → shows exactly what params to send and what response to expect
+```
+
+---
+
+## 10. Documentation Map
+
+### Official Docs (`docs/gateway/`)
+
+| Document                     | Purpose                                                         | When to read                          |
+| ---------------------------- | --------------------------------------------------------------- | ------------------------------------- |
+| `protocol.md`                | WS protocol spec: handshake, framing, roles, scopes, versioning | First read for protocol understanding |
+| `authentication.md`          | Auth mechanisms and configuration                               | Implementing auth in ClawWork         |
+| `pairing.md`                 | Device pairing and trust model                                  | Implementing device pairing           |
+| `configuration.md`           | Task-oriented config guide                                      | Setting up Gateway for development    |
+| `configuration-reference.md` | All config keys (122KB)                                         | Looking up specific config options    |
+| `health.md`                  | Health monitoring                                               | Implementing health indicators        |
+| `troubleshooting.md`         | Symptom-first diagnostics                                       | When things go wrong                  |
+| `openai-http-api.md`         | OpenAI-compatible HTTP endpoints                                | If you need HTTP fallback             |
+| `index.md`                   | 5-minute runbook                                                | Quick start                           |
+
+### Source-Level Docs
+
+| Document          | Path                                   | Purpose                                          |
+| ----------------- | -------------------------------------- | ------------------------------------------------ |
+| Protocol Boundary | `src/gateway/protocol/AGENTS.md`       | Rules for changing protocol schemas              |
+| Server Methods    | `src/gateway/server-methods/CLAUDE.md` | Handler conventions and session transcript notes |
+
+---
+
+## 11. Recommended Reading Order
+
+For a developer going from zero to productive:
+
+### Week 1: Understand the Contract
+
+1. **Read** `openclaw-gateway-whitepaper.md` (your local copy — the protocol reference)
+2. **Skim** `src/gateway/protocol/schema/frames.ts` — understand the three frame types
+3. **Read** `src/gateway/protocol/schema/primitives.ts` — know the shared types
+4. **Read** `src/gateway/server-methods-list.ts` — see all methods and events
+5. **Read** `src/gateway/protocol/client-info.ts` — know client IDs, modes, caps
+
+### Week 2: Understand Your Core Methods
+
+6. **Read** `src/gateway/protocol/schema/logs-chat.ts` — chat schemas (your primary interface)
+7. **Read** `src/gateway/server-methods/chat.ts` — how chat.send/history/abort work
+8. **Read** `src/gateway/protocol/schema/sessions.ts` — session schemas
+9. **Read** `src/gateway/server-methods/sessions.ts` — session management logic
+10. **Read** `src/gateway/protocol/schema/agent.ts` — agent event schemas
+
+### Week 3: Understand Infrastructure
+
+11. **Skim** `src/gateway/server/ws-connection/message-handler.ts` — frame dispatch flow
+12. **Read** `src/gateway/method-scopes.ts` — authorization rules
+13. **Read** `src/gateway/server-broadcast.ts` — event broadcasting + scope guards
+14. **Read** `src/gateway/server-constants.ts` — limits and intervals
+15. **Read** `src/gateway/auth-rate-limit.ts` — rate limiting
+
+### Ongoing: Reference as Needed
+
+- Method schemas → `src/gateway/protocol/schema/<domain>.ts`
+- Method handlers → `src/gateway/server-methods/<domain>.ts`
+- Official docs → `docs/gateway/protocol.md`, `docs/gateway/authentication.md`, `docs/gateway/pairing.md`
+- Tests as examples → `src/gateway/server-methods/<domain>.test.ts`
+
+---
+
+## 12. Quick Reference Card
+
+```
+Protocol version:     src/gateway/protocol/schema/protocol-schemas.ts → PROTOCOL_VERSION
+Frame types:          src/gateway/protocol/schema/frames.ts
+All methods:          src/gateway/server-methods-list.ts → BASE_METHODS
+All events:           src/gateway/server-methods-list.ts → GATEWAY_EVENTS
+Method scopes:        src/gateway/method-scopes.ts
+Event scope guards:   src/gateway/server-broadcast.ts → EVENT_SCOPE_GUARDS
+Client IDs/modes:     src/gateway/protocol/client-info.ts
+Error codes:          src/gateway/protocol/schema/error-codes.ts
+Constants/limits:     src/gateway/server-constants.ts
+RPC dispatcher:       src/gateway/server-methods.ts → handleGatewayRequest()
+WS message handler:   src/gateway/server/ws-connection/message-handler.ts
+Auth decision:        src/gateway/server/ws-connection/auth-context.ts
+Broadcast engine:     src/gateway/server-broadcast.ts → createGatewayBroadcaster()
+Server startup:       src/gateway/server.impl.ts → startGatewayServer()
+```

--- a/docs/openclaw-gateway-whitepaper.md
+++ b/docs/openclaw-gateway-whitepaper.md
@@ -1,12 +1,14 @@
 # OpenClaw Gateway Protocol Whitepaper
 
-> Source of truth: reverse-engineered from `~/git/openclaw` (version 2026.3.14)
-> Date: 2026-03-16
+> Source of truth: reverse-engineered from `~/git/openclaw` (version 2026.4.2)
+> Date: 2026-04-02
 > Maintenance note: this whitepaper was originally organized from the 2026.3.12-era Gateway implementation and should be refreshed periodically as OpenClaw evolves.
 
 ---
 
 ## 1. Architecture Overview
+
+> Source: `src/gateway/server.impl.ts`, `src/gateway/server-broadcast.ts`, `src/gateway/server-http.ts`
 
 Gateway is a WebSocket-first server (default port `:18789`) sitting between clients and the OpenClaw Agent Engine. All client communication goes through a **single persistent WebSocket connection**.
 
@@ -19,10 +21,10 @@ Gateway is a WebSocket-first server (default port `:18789`) sitting between clie
 │                     │           │ │ (AJV/TypeBox schemas)  │ │
 │                     │           │ ├────────────────────────┤ │
 │                     │           │ │ RPC Dispatcher         │ │
-│                     │           │ │ (60+ methods)          │ │
+│                     │           │ │ (110+ methods)          │ │
 │                     │           │ ├────────────────────────┤ │
 │                     │           │ │ Broadcast Engine       │ │
-│                     │           │ │ (19 event types)       │ │
+│                     │           │ │ (24 event types)       │ │
 │                     │           │ ├────────────────────────┤ │
 │                     │           │ │ Agent Engine           │ │
 │                     │           │ │ Session Store          │ │
@@ -44,6 +46,8 @@ Key design decisions:
 ---
 
 ## 2. Frame Protocol
+
+> Source: `src/gateway/protocol/schema/frames.ts` (RequestFrame, ResponseFrame, EventFrame, GatewayFrame discriminated union)
 
 All communication uses JSON frames over WebSocket. Three frame types form a discriminated union on the `type` field.
 
@@ -76,15 +80,16 @@ All communication uses JSON frames over WebSocket. Three frame types form a disc
 }
 ```
 
-**Error Codes:**
+**Error Codes:** (source: `src/gateway/protocol/schema/error-codes.ts`)
 
-| Code              | Meaning                              |
-| ----------------- | ------------------------------------ |
-| `NOT_LINKED`      | Channel/account not linked           |
-| `NOT_PAIRED`      | Device not paired                    |
-| `AGENT_TIMEOUT`   | Agent execution timed out            |
-| `INVALID_REQUEST` | Bad parameters or validation failure |
-| `UNAVAILABLE`     | Service temporarily unavailable      |
+| Code                 | Meaning                              |
+| -------------------- | ------------------------------------ |
+| `NOT_LINKED`         | Channel/account not linked           |
+| `NOT_PAIRED`         | Device not paired                    |
+| `AGENT_TIMEOUT`      | Agent execution timed out            |
+| `INVALID_REQUEST`    | Bad parameters or validation failure |
+| `APPROVAL_NOT_FOUND` | Approval ID not found                |
+| `UNAVAILABLE`        | Service temporarily unavailable      |
 
 ### 2.3 Event Frame (Server → Client, broadcast)
 
@@ -103,6 +108,8 @@ All communication uses JSON frames over WebSocket. Three frame types form a disc
 
 ### 2.4 Constants
 
+> Source: `src/gateway/server-constants.ts`, `src/gateway/handshake-timeouts.ts`
+
 | Constant                     | Value                  |
 | ---------------------------- | ---------------------- |
 | `MAX_PAYLOAD_BYTES`          | 25 MB                  |
@@ -110,7 +117,7 @@ All communication uses JSON frames over WebSocket. Three frame types form a disc
 | `MAX_PREAUTH_PAYLOAD_BYTES`  | 64 KB                  |
 | `TICK_INTERVAL_MS`           | 30,000 ms              |
 | `HEALTH_REFRESH_INTERVAL_MS` | 60,000 ms              |
-| `HANDSHAKE_TIMEOUT_MS`       | 3,000 ms               |
+| `HANDSHAKE_TIMEOUT_MS`       | 10,000 ms              |
 | `DEDUPE_TTL_MS`              | 5 minutes              |
 | `DEDUPE_MAX`                 | 1,000 entries          |
 
@@ -144,10 +151,12 @@ Client                          Gateway
 
 ### 3.2 ConnectParams
 
+> Source: `src/gateway/protocol/schema/frames.ts` → `ConnectParamsSchema`
+
 ```typescript
 {
-  minProtocol: 1,
-  maxProtocol: 1,
+  minProtocol: 3,
+  maxProtocol: 3,
   client: {
     id: GatewayClientId,           // see §3.3
     displayName?: string,
@@ -184,12 +193,16 @@ Client                          Gateway
 
 ### 3.3 Client Identity
 
+> Source: `src/gateway/protocol/client-info.ts` → `GATEWAY_CLIENT_IDS`, `GATEWAY_CLIENT_MODES`, `GATEWAY_CLIENT_CAPS`
+
 **Client IDs** (for ClawWork, use `openclaw-macos`):
 
 | ID                    | Purpose               |
 | --------------------- | --------------------- |
 | `webchat-ui`          | Browser WebChat UI    |
+| `webchat`             | WebChat client        |
 | `openclaw-control-ui` | Admin Control UI      |
+| `openclaw-tui`        | Terminal UI client    |
 | `openclaw-macos`      | macOS desktop app     |
 | `openclaw-ios`        | iOS app               |
 | `openclaw-android`    | Android app           |
@@ -222,12 +235,14 @@ Capabilities are requested in `ConnectParams.caps` and gate access to specific e
 
 ### 3.5 HelloOk Response
 
+> Source: `src/gateway/protocol/schema/frames.ts` → `HelloOkSchema`, `src/gateway/protocol/schema/snapshot.ts` → `SnapshotSchema`
+
 ```typescript
 {
   type: "hello-ok",
-  protocol: 1,
+  protocol: 3,
   server: {
-    version: string,     // e.g. "2026.3.14"
+    version: string,     // e.g. "2026.4.2"
     connId: string       // UUID for this connection
   },
   features: {
@@ -276,39 +291,50 @@ Capabilities are requested in `ConnectParams.caps` and gate access to specific e
 
 ## 4. Events (Server → Client)
 
-Gateway broadcasts 19 event types. All events use the Event Frame format.
+Gateway broadcasts 24 event types. All events use the Event Frame format.
 
 ### 4.1 Event Types
 
-| Event                     | Payload                                      | `dropIfSlow`          | Scope Guard          | Purpose                   |
-| ------------------------- | -------------------------------------------- | --------------------- | -------------------- | ------------------------- |
-| `connect.challenge`       | `{ nonce, ts }`                              | No                    | —                    | Auth handshake            |
-| `chat`                    | ChatEvent                                    | delta: Yes, final: No | —                    | Message streaming         |
-| `agent`                   | AgentEvent                                   | Tool: Yes             | —                    | Agent execution events    |
-| `presence`                | PresenceEntry[]                              | No                    | —                    | Client connect/disconnect |
-| `tick`                    | `{ ts }`                                     | Yes                   | —                    | Heartbeat (30s)           |
-| `health`                  | HealthSnapshot                               | Yes                   | —                    | System health (60s)       |
-| `heartbeat`               | varies                                       | Yes                   | —                    | Agent heartbeat ACK       |
-| `shutdown`                | `{ reason, restartExpectedMs? }`             | No                    | —                    | Graceful shutdown         |
-| `talk.mode`               | varies                                       | No                    | —                    | Voice mode change         |
-| `cron`                    | CronEvent                                    | No                    | —                    | Cron job events           |
-| `node.pair.requested`     | varies                                       | No                    | `operator.pairing`   | Node pairing request      |
-| `node.pair.resolved`      | varies                                       | No                    | `operator.pairing`   | Node pairing result       |
-| `node.invoke.request`     | varies                                       | No                    | —                    | Node task dispatch        |
-| `device.pair.requested`   | varies                                       | No                    | `operator.pairing`   | Device pairing request    |
-| `device.pair.resolved`    | varies                                       | No                    | `operator.pairing`   | Device pairing result     |
-| `voicewake.changed`       | varies                                       | No                    | —                    | Voice wake config         |
-| `exec.approval.requested` | varies                                       | No                    | `operator.approvals` | Execution approval        |
-| `exec.approval.resolved`  | varies                                       | No                    | `operator.approvals` | Approval resolution       |
-| `update-available`        | `{ currentVersion, latestVersion, channel }` | No                    | —                    | Software update           |
+> Source: `src/gateway/server-methods-list.ts` → `GATEWAY_EVENTS`, `src/gateway/server-broadcast.ts` → `EVENT_SCOPE_GUARDS`
+
+| Event                       | Payload                                      | `dropIfSlow`          | Scope Guard          | Purpose                    |
+| --------------------------- | -------------------------------------------- | --------------------- | -------------------- | -------------------------- |
+| `connect.challenge`         | `{ nonce, ts }`                              | No                    | —                    | Auth handshake             |
+| `chat`                      | ChatEvent                                    | delta: Yes, final: No | —                    | Message streaming          |
+| `agent`                     | AgentEvent                                   | Tool: Yes             | —                    | Agent execution events     |
+| `session.message`           | varies                                       | No                    | `operator.read`      | Per-session message events |
+| `session.tool`              | varies                                       | No                    | `operator.read`      | Per-session tool events    |
+| `sessions.changed`          | varies                                       | No                    | `operator.read`      | Session list changed       |
+| `presence`                  | PresenceEntry[]                              | No                    | —                    | Client connect/disconnect  |
+| `tick`                      | `{ ts }`                                     | Yes                   | —                    | Heartbeat (30s)            |
+| `health`                    | HealthSnapshot                               | Yes                   | —                    | System health (60s)        |
+| `heartbeat`                 | varies                                       | Yes                   | —                    | Agent heartbeat ACK        |
+| `shutdown`                  | `{ reason, restartExpectedMs? }`             | No                    | —                    | Graceful shutdown          |
+| `talk.mode`                 | varies                                       | No                    | —                    | Voice mode change          |
+| `cron`                      | CronEvent                                    | No                    | —                    | Cron job events            |
+| `node.pair.requested`       | varies                                       | No                    | `operator.pairing`   | Node pairing request       |
+| `node.pair.resolved`        | varies                                       | No                    | `operator.pairing`   | Node pairing result        |
+| `node.invoke.request`       | varies                                       | No                    | —                    | Node task dispatch         |
+| `device.pair.requested`     | varies                                       | No                    | `operator.pairing`   | Device pairing request     |
+| `device.pair.resolved`      | varies                                       | No                    | `operator.pairing`   | Device pairing result      |
+| `voicewake.changed`         | varies                                       | No                    | —                    | Voice wake config          |
+| `exec.approval.requested`   | varies                                       | No                    | `operator.approvals` | Execution approval         |
+| `exec.approval.resolved`    | varies                                       | No                    | `operator.approvals` | Approval resolution        |
+| `plugin.approval.requested` | varies                                       | No                    | `operator.approvals` | Plugin install approval    |
+| `plugin.approval.resolved`  | varies                                       | No                    | `operator.approvals` | Plugin approval resolution |
+| `update.available`          | `{ currentVersion, latestVersion, channel }` | No                    | —                    | Software update            |
 
 **Scope Guards:**
 
 - `operator.admin` — has access to all scoped events
-- `operator.approvals` — exec approval events
+- `operator.read` — session message/tool/changed events
+- `operator.write` — write methods (implied by `operator.read` check)
+- `operator.approvals` — exec and plugin approval events
 - `operator.pairing` — device/node pairing events
 
 ### 4.2 Chat Event (event: `chat`)
+
+> Source: `src/gateway/protocol/schema/logs-chat.ts` → `ChatEventSchema`
 
 The primary event for receiving AI responses. Streams incrementally.
 
@@ -349,6 +375,8 @@ The primary event for receiving AI responses. Streams incrementally.
 - **error**: Execution failure. `errorMessage` contains details.
 
 ### 4.3 Agent Event (event: `agent`)
+
+> Source: `src/gateway/protocol/schema/agent.ts` → `AgentEventSchema`
 
 Requires `caps: ["tool-events"]` capability. Provides granular agent execution visibility.
 
@@ -393,6 +421,8 @@ receive tool events. Registration happens automatically when a client sends `cha
 
 ### 4.4 Broadcast Behavior
 
+> Source: `src/gateway/server-broadcast.ts` → `createGatewayBroadcaster`
+
 - Events broadcast to **all connected clients** (except targeted tool events)
 - **No server-side session filtering** — client must route by `sessionKey`
 - Slow consumers (bufferedAmount > 50MB) are disconnected with code `1008`
@@ -405,6 +435,8 @@ receive tool events. Registration happens automatically when a client sends `cha
 
 ### 5.1 Complete Method List
 
+> Source: `src/gateway/server-methods-list.ts` → `BASE_METHODS`, `listGatewayMethods()`
+
 ```
 health                    doctor.memory.status      logs.tail
 channels.status           channels.logout
@@ -416,10 +448,12 @@ config.patch              config.schema             config.schema.lookup
 exec.approvals.get        exec.approvals.set        exec.approvals.node.get
 exec.approvals.node.set   exec.approval.request     exec.approval.waitDecision
 exec.approval.resolve
+plugin.approval.request   plugin.approval.waitDecision
+plugin.approval.resolve
 wizard.start              wizard.next               wizard.cancel
 wizard.status
-talk.config               talk.mode
-models.list               tools.catalog
+talk.config               talk.speak                talk.mode
+models.list               tools.catalog             tools.effective
 agents.list               agents.create             agents.update
 agents.delete             agents.files.list         agents.files.get
 agents.files.set
@@ -428,8 +462,12 @@ skills.update
 update.run
 voicewake.get             voicewake.set
 secrets.reload            secrets.resolve
-sessions.list             sessions.preview          sessions.patch
+sessions.list             sessions.create           sessions.send
+sessions.subscribe        sessions.unsubscribe
+sessions.messages.subscribe                          sessions.messages.unsubscribe
+sessions.abort            sessions.preview          sessions.patch
 sessions.reset            sessions.delete           sessions.compact
+sessions.usage
 last-heartbeat            set-heartbeats            wake
 node.pair.request         node.pair.list            node.pair.approve
 node.pair.reject          node.pair.verify
@@ -443,14 +481,16 @@ cron.list                 cron.status               cron.add
 cron.update               cron.remove               cron.run
 cron.runs
 gateway.identity.get      system-presence           system-event
-send                      agent                     agent.identity.get
-agent.wait                browser.request
+send                      poll                      push.test
+agent                     agent.identity.get        agent.wait
 chat.history              chat.abort                chat.send
 ```
 
 Channel plugins may register additional methods.
 
 ### 5.2 Chat Methods (Core for ClawWork)
+
+> Source: schema `src/gateway/protocol/schema/logs-chat.ts`, impl `src/gateway/server-methods/chat.ts`
 
 #### `chat.send`
 
@@ -459,15 +499,22 @@ Send a user message to a session. Triggers agent execution and streaming respons
 ```typescript
 // Request
 {
-  sessionKey: string,               // e.g. "agent:main:clawwork:task:<taskId>"
+  sessionKey: string,               // e.g. "agent:main:clawwork:task:<taskId>" (max 512 chars)
   message: string,                  // user message text
   thinking?: string,                // thinking/reasoning prompt level
   deliver?: boolean,                // false = no external channel delivery (use false)
+  originatingChannel?: string,      // source channel (for cross-channel routing)
+  originatingTo?: string,           // originating recipient
+  originatingAccountId?: string,    // originating account
+  originatingThreadId?: string,     // originating thread
   attachments?: unknown[],          // file attachments
   timeoutMs?: number,               // request timeout
   systemInputProvenance?: {         // input source tracking
-    source: string,
-    channel?: string
+    kind: string,                   // provenance kind
+    originSessionId?: string,
+    sourceSessionKey?: string,
+    sourceChannel?: string,
+    sourceTool?: string
   },
   systemProvenanceReceipt?: string,
   idempotencyKey: string            // UUID for deduplication (REQUIRED)
@@ -493,7 +540,8 @@ Fetch session message history.
 // Request
 {
   sessionKey: string,
-  limit?: number                    // 1-1000, default 200
+  limit?: number,                   // 1-1000, default 200
+  maxChars?: number                 // 1-500,000 — cap total character count in response
 }
 
 // Response
@@ -539,6 +587,85 @@ Inject a system message into a session (admin/testing).
 ```
 
 ### 5.3 Session Methods
+
+> Source: schema `src/gateway/protocol/schema/sessions.ts`, impl `src/gateway/server-methods/sessions.ts`
+
+#### `sessions.create`
+
+Create a new session explicitly.
+
+```typescript
+// Request
+{
+  key?: string,                     // explicit session key (auto-generated if omitted)
+  agentId?: string,                 // bind to specific agent
+  label?: string,                   // session label (max 64 chars)
+  model?: string,                   // override model
+  parentSessionKey?: string,        // parent session (for sub-agents)
+  task?: string,                    // task description
+  message?: string                  // initial message
+}
+```
+
+#### `sessions.send`
+
+Send a message to a session (higher-level than `chat.send`).
+
+```typescript
+// Request
+{
+  key: string,
+  message: string,
+  thinking?: string,
+  attachments?: unknown[],
+  timeoutMs?: number,
+  idempotencyKey?: string
+}
+```
+
+#### `sessions.abort`
+
+Abort a running session.
+
+```typescript
+// Request
+{
+  key: string,
+  runId?: string                    // specific run to abort
+}
+```
+
+#### `sessions.subscribe` / `sessions.unsubscribe`
+
+Subscribe to or unsubscribe from session list change events (`sessions.changed`).
+
+#### `sessions.messages.subscribe` / `sessions.messages.unsubscribe`
+
+Subscribe to or unsubscribe from per-session message events (`session.message`, `session.tool`).
+
+```typescript
+// Request
+{
+  key: string; // session key to subscribe/unsubscribe
+}
+```
+
+#### `sessions.usage`
+
+Analyze token usage with date filtering and context weight breakdown.
+
+```typescript
+// Request
+{
+  key?: string,                     // specific session (omit for all)
+  startDate?: string,               // "YYYY-MM-DD"
+  endDate?: string,                 // "YYYY-MM-DD"
+  mode?: "utc" | "gateway" | "specific",
+  utcOffset?: string,               // e.g. "UTC-4" or "UTC+5:30"
+  limit?: number,                   // max sessions to return (default 50)
+  includeContextWeight?: boolean    // include systemPromptReport
+}
+```
 
 #### `sessions.list`
 
@@ -622,7 +749,8 @@ Modify session metadata.
 ```typescript
 {
   key: string,
-  deleteTranscript?: boolean        // also remove transcript files
+  deleteTranscript?: boolean,       // also remove transcript files
+  emitLifecycleHooks?: boolean      // emit lifecycle hooks (default true)
 }
 ```
 
@@ -639,6 +767,8 @@ Compress session transcript.
 
 ### 5.4 Agent Methods
 
+> Source: `src/gateway/protocol/schema/agent.ts` → `AgentParamsSchema`, `AgentIdentityParamsSchema`, `AgentWaitParamsSchema`
+
 #### `agent`
 
 Full-featured agent invocation (superset of `chat.send`).
@@ -647,6 +777,8 @@ Full-featured agent invocation (superset of `chat.send`).
 {
   message: string,                  // REQUIRED
   agentId?: string,                 // specific agent
+  provider?: string,                // override provider
+  model?: string,                   // override model
   to?: string,                      // delivery target
   replyTo?: string,                 // reply to message
   sessionId?: string,
@@ -698,6 +830,8 @@ Wait for an agent run to complete.
 ```
 
 ### 5.5 Agent & Model Management
+
+> Source: `src/gateway/protocol/schema/agents-models-skills.ts`
 
 #### `agents.list`
 
@@ -820,6 +954,8 @@ Manage agent configuration files (system prompt, etc).
 
 ### 5.6 External Messaging
 
+> Source: `src/gateway/protocol/schema/agent.ts` → `SendParamsSchema`, `PollParamsSchema`
+
 #### `send`
 
 Send a message to an external channel (Telegram, Discord, etc).
@@ -840,7 +976,30 @@ Send a message to an external channel (Telegram, Discord, etc).
 }
 ```
 
+#### `poll`
+
+Create a poll in an external channel.
+
+```typescript
+{
+  to: string,
+  question: string,
+  options: string[],                // 2-12 options
+  maxSelections?: number,           // 1-12
+  durationSeconds?: number,         // 1-604,800 (7 days)
+  durationHours?: number,
+  silent?: boolean,                 // no notification
+  isAnonymous?: boolean,
+  threadId?: string,
+  channel?: string,
+  accountId?: string,
+  idempotencyKey: string
+}
+```
+
 ### 5.7 Configuration Methods
+
+> Source: `src/gateway/protocol/schema/config.ts`
 
 #### `config.get` / `config.set` / `config.patch` / `config.apply`
 
@@ -851,6 +1010,8 @@ Read and modify server configuration at runtime.
 Get JSON Schema for configuration validation.
 
 ### 5.8 Cron Methods
+
+> Source: `src/gateway/protocol/schema/cron.ts`
 
 Scheduled task management.
 
@@ -947,7 +1108,36 @@ Get execution history.
 }
 ```
 
+#### `tools.effective`
+
+> Source: `src/gateway/protocol/schema/agents-models-skills.ts` → `ToolsEffectiveParamsSchema`, `ToolsEffectiveResultSchema`
+
+Get session-effective tool inventory (what tools are actually available for a session at runtime).
+
+```typescript
+// Request
+{ agentId?: string, sessionKey?: string }
+
+// Response
+{
+  groups: Array<{
+    id: string,
+    label: string,
+    tools: Array<{
+      id: string,
+      label: string,
+      description: string,
+      enabled: boolean,
+      source: "core" | "plugin",
+      pluginId?: string
+    }>
+  }>
+}
+```
+
 ### 5.9 Skills Methods
+
+> Source: `src/gateway/protocol/schema/agents-models-skills.ts` → `SkillsStatusParamsSchema`, `SkillsInstallParamsSchema`, `SkillsUpdateParamsSchema`
 
 #### `skills.status`
 
@@ -968,6 +1158,8 @@ Get execution history.
 ```
 
 ### 5.10 Node Methods
+
+> Source: `src/gateway/protocol/schema/nodes.ts`
 
 Remote compute node management.
 
@@ -991,6 +1183,8 @@ Remote compute node management.
 
 ### 5.11 Device Methods
 
+> Source: `src/gateway/protocol/schema/devices.ts`
+
 Device authentication lifecycle.
 
 | Method                | Purpose                      |
@@ -1004,6 +1198,8 @@ Device authentication lifecycle.
 
 ### 5.12 Execution Approval
 
+> Source: `src/gateway/protocol/schema/exec-approvals.ts`
+
 Interactive approval workflow for agent actions.
 
 | Method                       | Purpose                        |
@@ -1016,7 +1212,87 @@ Interactive approval workflow for agent actions.
 | `exec.approvals.node.get`    | Get node approval settings     |
 | `exec.approvals.node.set`    | Set node approval settings     |
 
-### 5.13 Other Methods
+### 5.13 Plugin Approval
+
+> Source: `src/gateway/protocol/schema/plugin-approvals.ts`
+
+Interactive approval workflow for plugin installations.
+
+| Method                         | Purpose                       |
+| ------------------------------ | ----------------------------- |
+| `plugin.approval.request`      | Request approval for a plugin |
+| `plugin.approval.waitDecision` | Wait for approval decision    |
+| `plugin.approval.resolve`      | Approve or reject             |
+
+### 5.14 Talk (Voice/TTS) Methods
+
+> Source: `src/gateway/protocol/schema/channels.ts` → `TalkSpeakParamsSchema`, `TalkSpeakResultSchema`, `TalkModeParamsSchema`, `TalkConfigResultSchema`
+
+#### `talk.speak`
+
+Text-to-speech synthesis.
+
+```typescript
+// Request
+{
+  text: string,                     // REQUIRED
+  voiceId?: string,
+  modelId?: string,
+  outputFormat?: string,
+  speed?: number,
+  stability?: number,
+  similarity?: number,
+  style?: number,
+  speakerBoost?: boolean,
+  seed?: number,
+  normalize?: string,
+  language?: string
+}
+
+// Response
+{
+  audioBase64: string,              // base64-encoded audio
+  provider: string,
+  outputFormat?: string,
+  voiceCompatible?: boolean,
+  mimeType?: string,
+  fileExtension?: string
+}
+```
+
+### 5.15 Push Notification Testing
+
+> Source: `src/gateway/protocol/schema/push.ts` → `PushTestParamsSchema`, `PushTestResultSchema`
+
+#### `push.test`
+
+Test push notification delivery.
+
+### 5.16 Web Login
+
+> Source: `src/gateway/protocol/schema/channels.ts` → `WebLoginStartParamsSchema`, `WebLoginWaitParamsSchema`
+
+#### `web.login.start` / `web.login.wait`
+
+Web-based login flow (e.g. WhatsApp QR scan).
+
+```typescript
+// web.login.start
+{
+  force?: boolean,
+  timeoutMs?: number,
+  verbose?: boolean,
+  accountId?: string
+}
+
+// web.login.wait
+{
+  timeoutMs?: number,
+  accountId?: string
+}
+```
+
+### 5.17 Other Methods
 
 | Method                            | Purpose                                             |
 | --------------------------------- | --------------------------------------------------- |
@@ -1029,9 +1305,8 @@ Interactive approval workflow for agent actions.
 | `system-presence`                 | Current presence snapshot                           |
 | `system-event`                    | Emit system event                                   |
 | `wake`                            | `{ mode: "now" \| "next-heartbeat", text: string }` |
-| `browser.request`                 | Browser integration                                 |
 | `wizard.start/next/cancel/status` | Onboarding wizard                                   |
-| `channels.status`                 | Channel connection status                           |
+| `channels.status`                 | Channel connection status (with optional probe)     |
 | `channels.logout`                 | Disconnect channel                                  |
 | `update.run`                      | Trigger software update                             |
 | `doctor.memory.status`            | Memory diagnostics                                  |
@@ -1039,6 +1314,8 @@ Interactive approval workflow for agent actions.
 ---
 
 ## 6. HTTP Endpoints
+
+> Source: `src/gateway/server-http.ts`, `src/gateway/openai-http.ts`
 
 In addition to WebSocket, Gateway exposes HTTP endpoints:
 
@@ -1060,6 +1337,8 @@ The `/v1/chat/completions` endpoint allows OpenAI-compatible integration, but fo
 
 ### 7.1 Auth Modes
 
+> Source: `src/gateway/protocol/schema/snapshot.ts` → `SnapshotSchema.authMode`
+
 Gateway supports four authentication modes (configured server-side):
 
 | Mode            | ConnectParams field | Description                 |
@@ -1073,6 +1352,8 @@ Device-based auth (`auth.deviceToken` or `device.*` fields) is an additional lay
 
 ### 7.2 Rate Limiting
 
+> Source: `src/gateway/auth-rate-limit.ts` → `RateLimitConfig`, defaults: `DEFAULT_MAX_ATTEMPTS=10`, `DEFAULT_WINDOW_MS=60_000`, `DEFAULT_LOCKOUT_MS=300_000`
+
 | Scope           | Max Attempts | Window | Lockout |
 | --------------- | ------------ | ------ | ------- |
 | `shared-secret` | 10           | 60s    | 300s    |
@@ -1084,6 +1365,8 @@ Loopback addresses (`127.0.0.1`, `::1`) are exempt by default.
 
 ### 7.3 Roles & Scopes
 
+> Source: `src/gateway/method-scopes.ts` → `ADMIN_SCOPE`, `READ_SCOPE`, `WRITE_SCOPE`, `APPROVALS_SCOPE`, `PAIRING_SCOPE`, `METHOD_SCOPE_GROUPS`, `NODE_ROLE_METHODS`
+
 Roles control method and event access:
 
 - `operator` — default role for human users
@@ -1091,13 +1374,17 @@ Roles control method and event access:
 
 Scopes (carried in `ConnectParams.scopes`):
 
-- `operator.admin` — full access to all scoped events
-- `operator.approvals` — exec approval events
-- `operator.pairing` — device/node pairing events
+- `operator.admin` — full access; supersedes all other scopes
+- `operator.read` — read-only access (status, list, history, usage, config.get)
+- `operator.write` — write access (send, chat.send, agent, sessions.create, talk, node.invoke, etc.); implies read
+- `operator.approvals` — exec and plugin approval events and methods
+- `operator.pairing` — device/node pairing events and methods
 
 ---
 
 ## 8. Session Key Format
+
+> Source: `src/gateway/protocol/schema/primitives.ts` → `ChatSendSessionKeyString` (regex: max 512 chars), `src/gateway/protocol/schema/sessions.ts` → `SessionsCreateParamsSchema`
 
 Session keys uniquely identify conversation contexts:
 
@@ -1120,6 +1407,8 @@ agent:main:clawwork:task:<taskId>
 
 ## 9. Message Format
 
+> Source: `src/gateway/protocol/schema/logs-chat.ts` → `ChatEventSchema.message`, `src/gateway/protocol/schema/agent.ts` → content block types
+
 Messages in `chat` events and `chat.history` responses follow this structure:
 
 ```typescript
@@ -1137,6 +1426,8 @@ Messages in `chat` events and `chat.history` responses follow this structure:
 ---
 
 ## 10. ClawWork Integration Guide
+
+> Source: composite — see inline references in §2–§9; connection flow from `src/gateway/protocol/schema/frames.ts` → `ConnectParamsSchema`, `HelloOkSchema`
 
 ### 10.1 Connection Setup
 
@@ -1179,22 +1470,26 @@ ws.send(
 
 ### 10.3 Capabilities ClawWork Can Leverage
 
-| Capability          | Gateway Support                        | ClawWork Feature             |
-| ------------------- | -------------------------------------- | ---------------------------- |
-| Multi-session       | `sessions.list`, unique sessionKeys    | Parallel task execution      |
-| Streaming responses | `chat` events with delta/final         | Real-time response rendering |
-| Tool visibility     | `agent` events with tool-events cap    | Tool-call progress UI        |
-| Session management  | `sessions.patch`, `sessions.reset`     | Task configuration           |
-| Model selection     | `models.list`, `sessions.patch(model)` | Per-task model override      |
-| Agent management    | `agents.*` methods                     | Multi-agent workflows        |
-| Cron scheduling     | `cron.*` methods                       | Automated recurring tasks    |
-| Message history     | `chat.history`                         | Session restoration          |
-| Abort               | `chat.abort`                           | Cancel running tasks         |
-| Usage tracking      | `usage.status`, `usage.cost`           | Token/cost dashboard         |
-| Skills              | `skills.*` methods                     | Skill management UI          |
-| Exec approval       | `exec.approval.*` events/methods       | Interactive approval gates   |
-| Health monitoring   | `health` events                        | Server status indicator      |
-| Thinking/reasoning  | `sessions.patch(thinkingLevel)`        | Thinking mode toggle         |
+| Capability            | Gateway Support                                | ClawWork Feature             |
+| --------------------- | ---------------------------------------------- | ---------------------------- |
+| Multi-session         | `sessions.list`, `sessions.create`             | Parallel task execution      |
+| Streaming responses   | `chat` events with delta/final                 | Real-time response rendering |
+| Tool visibility       | `agent` events with tool-events cap            | Tool-call progress UI        |
+| Session management    | `sessions.patch`, `sessions.reset`             | Task configuration           |
+| Session subscriptions | `sessions.subscribe`, `sessions.messages.*`    | Real-time session updates    |
+| Model selection       | `models.list`, `sessions.patch(model)`         | Per-task model override      |
+| Agent management      | `agents.*` methods                             | Multi-agent workflows        |
+| Cron scheduling       | `cron.*` methods                               | Automated recurring tasks    |
+| Message history       | `chat.history`                                 | Session restoration          |
+| Abort                 | `chat.abort`, `sessions.abort`                 | Cancel running tasks         |
+| Usage tracking        | `usage.status`, `usage.cost`, `sessions.usage` | Token/cost dashboard         |
+| Skills                | `skills.*` methods                             | Skill management UI          |
+| Exec approval         | `exec.approval.*` events/methods               | Interactive approval gates   |
+| Plugin approval       | `plugin.approval.*` events/methods             | Plugin install gates         |
+| Health monitoring     | `health` events                                | Server status indicator      |
+| Thinking/reasoning    | `sessions.patch(thinkingLevel)`                | Thinking mode toggle         |
+| TTS                   | `talk.speak`                                   | Text-to-speech playback      |
+| Tools inventory       | `tools.catalog`, `tools.effective`             | Tool management UI           |
 
 ### 10.4 What ClawWork Should NOT Do
 
@@ -1206,25 +1501,28 @@ ws.send(
 
 ---
 
-## 11. Source File Reference
+## 11. Quick Source Index
 
-| Domain                    | Key File                                              | Lines |
-| ------------------------- | ----------------------------------------------------- | ----- |
-| Frame types               | `src/gateway/protocol/schema/frames.ts`               | 165   |
-| Client identity           | `src/gateway/protocol/client-info.ts`                 | 87    |
-| Method registry           | `src/gateway/server-methods-list.ts`                  | 134   |
-| Chat schemas              | `src/gateway/protocol/schema/logs-chat.ts`            | 84    |
-| Agent schemas             | `src/gateway/protocol/schema/agent.ts`                | 138   |
-| Session schemas           | `src/gateway/protocol/schema/sessions.ts`             | 140   |
-| Snapshot schema           | `src/gateway/protocol/schema/snapshot.ts`             | 73    |
-| Agent/model/skill schemas | `src/gateway/protocol/schema/agents-models-skills.ts` | 271   |
-| Cron schemas              | `src/gateway/protocol/schema/cron.ts`                 | 376   |
-| Error codes               | `src/gateway/protocol/schema/error-codes.ts`          | 24    |
-| Chat streaming            | `src/gateway/server-chat.ts`                          | 643   |
-| Broadcast engine          | `src/gateway/server-broadcast.ts`                     | 132   |
-| Constants                 | `src/gateway/server-constants.ts`                     | 34    |
-| Server startup            | `src/gateway/server.impl.ts`                          | ~1500 |
-| WS message handler        | `src/gateway/server/ws-connection/message-handler.ts` | ~1300 |
-| Chat RPC impl             | `src/gateway/server-methods/chat.ts`                  | ~1500 |
-| Session RPC impl          | `src/gateway/server-methods/sessions.ts`              | —     |
-| Command registry          | `src/auto-reply/commands-registry.data.ts`            | ~600  |
+All sources are annotated inline at each section. This condensed index maps domain → primary schema file for fast lookup:
+
+| Domain           | Schema File                                           | Implementation                           |
+| ---------------- | ----------------------------------------------------- | ---------------------------------------- |
+| Frames           | `src/gateway/protocol/schema/frames.ts`               | `src/gateway/server.impl.ts`             |
+| Chat             | `src/gateway/protocol/schema/logs-chat.ts`            | `src/gateway/server-methods/chat.ts`     |
+| Sessions         | `src/gateway/protocol/schema/sessions.ts`             | `src/gateway/server-methods/sessions.ts` |
+| Agent            | `src/gateway/protocol/schema/agent.ts`                | —                                        |
+| Agents/Models    | `src/gateway/protocol/schema/agents-models-skills.ts` | —                                        |
+| Cron             | `src/gateway/protocol/schema/cron.ts`                 | —                                        |
+| Nodes            | `src/gateway/protocol/schema/nodes.ts`                | —                                        |
+| Devices          | `src/gateway/protocol/schema/devices.ts`              | —                                        |
+| Config           | `src/gateway/protocol/schema/config.ts`               | —                                        |
+| Exec Approvals   | `src/gateway/protocol/schema/exec-approvals.ts`       | —                                        |
+| Plugin Approvals | `src/gateway/protocol/schema/plugin-approvals.ts`     | —                                        |
+| Methods list     | `src/gateway/server-methods-list.ts`                  | —                                        |
+| Method scopes    | `src/gateway/method-scopes.ts`                        | —                                        |
+| Broadcast        | `src/gateway/server-broadcast.ts`                     | —                                        |
+| Constants        | `src/gateway/server-constants.ts`                     | —                                        |
+| Rate limit       | `src/gateway/auth-rate-limit.ts`                      | —                                        |
+| Error codes      | `src/gateway/protocol/schema/error-codes.ts`          | —                                        |
+| Client IDs       | `src/gateway/protocol/client-info.ts`                 | —                                        |
+| Primitives       | `src/gateway/protocol/schema/primitives.ts`           | —                                        |


### PR DESCRIPTION
## Summary

Add three comprehensive Gateway reference documents and a Claude skill for periodic maintenance. These docs bridge the gap between OpenClaw Gateway source code and ClawWork development.

## Type of change

- [x] `[Docs]` documentation-only change

## Why is this needed?

ClawWork communicates with OpenClaw entirely through the Gateway WebSocket protocol. Developers need:
1. A protocol contract reference (what Gateway exposes)
2. A source code navigation guide (where to find things in openclaw)
3. A capability inventory (what ClawWork uses vs. what is available)
4. A repeatable process to keep these docs current

## What changed?

- `docs/openclaw-gateway-whitepaper.md` — updated to protocol v3 (2026.4.2): 110+ methods, 24 events, inline source annotations per section
- `docs/openclaw-gateway-source-guide.md` — new: four-layer mental model, directory maps, request flow diagrams, debugging scenarios, reading order
- `docs/clawwork-gateway-capability-map.md` — new: inventories 30 used RPC methods + 6 handled events, maps 80+ unused methods with priorities, includes step-by-step checklists for adding new capabilities
- `.claude/skills/sync-gateway-docs/SKILL.md` — new: three-phase update workflow for periodic refresh
- `.claude/rules/architecture.md` — no functional change (linter formatting only)

## Architecture impact

- Owning layer: docs / tooling (no runtime code)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: documentation-only change

## Linked issues

N/A

## Validation

- [x] Not run

Documentation-only change. No runtime code modified.

```text
N/A — docs and skill files only
```

## Screenshots or recordings

N/A

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Docs]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate