### PR TITLE
[Fix] Avoid stale Zustand selector for model and tools catalog

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -378,8 +378,7 @@ export function registerWsHandlers(): void {
       const result = await gw.listModels();
       return { ok: true, result };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'unknown error';
-      return { ok: false, error: msg };
+      return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };
     }
   });
 

--- a/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
@@ -102,10 +102,10 @@ export function useChatSend(opts: UseChatSendOpts) {
   });
 
   const taskGwId = activeTask?.gatewayId ?? pendingNewTask?.gatewayId;
-  const modelCatalog = useUiStore(
-    (s) => (taskGwId ? s.modelCatalogByGateway[taskGwId] : undefined) ?? EMPTY_MODELS_CATALOG,
-  );
-  const toolsCatalog = useUiStore((s) => (taskGwId ? s.toolsCatalogByGateway[taskGwId] : undefined));
+  const modelCatalogByGateway = useUiStore((s) => s.modelCatalogByGateway);
+  const modelCatalog = (taskGwId ? modelCatalogByGateway[taskGwId] : undefined) ?? EMPTY_MODELS_CATALOG;
+  const toolsCatalogByGateway = useUiStore((s) => s.toolsCatalogByGateway);
+  const toolsCatalog = taskGwId ? toolsCatalogByGateway[taskGwId] : undefined;
   const currentModel = activeTask
     ? activeTask.model === GATEWAY_INJECTED_MODEL
       ? undefined


### PR DESCRIPTION
## Summary

Fix model/tools catalog not appearing in ChatInput after upgrading OpenClaw to 2026.4.1. The Zustand v5 selector captured `taskGwId` (from the task store) inside a uiStore selector closure, causing a reactivity gap when catalog data arrived before `taskGwId` was resolved.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

After upgrading the local OpenClaw gateway to 2026.4.1, the model selection dropdown in ChatInput showed "no models available" despite the gateway correctly returning model data through IPC. The root cause is a cross-store selector reactivity issue in Zustand v5: the `useSyncExternalStore` subscription callback uses the previous render's `getSnapshot` function, which captures a stale `taskGwId` from its closure. When model catalog data arrives while `taskGwId` is still empty, the `Object.is` comparison sees no change (`EMPTY_MODELS_CATALOG === EMPTY_MODELS_CATALOG`), and no re-render is triggered.

## What changed?

- **`useChatSend.ts`**: Changed `modelCatalog` and `toolsCatalog` from using a Zustand selector with a closure-captured `taskGwId` to reading the entire `modelCatalogByGateway` / `toolsCatalogByGateway` map object and performing the keyed lookup in the render function. The map reference changes on every mutation (immutable spread), guaranteeing re-render.
- **`ws-handlers.ts`**: Removed leftover debug logging variable from previous investigation.

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is internal to the ChatInput rendering path

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] Manual smoke test

Commands, screenshots, or notes:

```text
pnpm check — all lint, typecheck, architecture, i18n, dead-code, and test checks pass
Manual verification: model dropdown correctly shows vllm and zai providers with all configured models
```

## Screenshots or recordings

N/A — model dropdown restored to expected behavior, no UI layout changes.

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Fix model selection dropdown not showing available models after OpenClaw gateway upgrade
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate