### PR TITLE
[Feat] System sessions — ephemeral OpenClaw channels decoupled from Task/Chat

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,11 +8,15 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "scripts": {
+    "test": "vitest run"
+  },
   "dependencies": {
     "@clawwork/shared": "workspace:*",
     "zustand": "^5.0.11"
   },
   "devDependencies": {
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,9 @@ export type { TaskState, TaskStoreDeps, PendingNewTask } from './stores/task-sto
 export { createRoomStore } from './stores/room-store.js';
 export type { RoomState, RoomStoreDeps, PerformerAgent } from './stores/room-store.js';
 
+export { createSystemSessionStore } from './stores/system-session-store.js';
+export type { SystemSessionState, SystemSessionMessage, SystemSessionStatus } from './stores/system-session-store.js';
+
 export { createUiStore } from './stores/ui-store.js';
 export type {
   UiState,
@@ -89,3 +92,6 @@ export type { GatewayDispatcherDeps } from './services/gateway-dispatcher.js';
 
 export { createChatComposer } from './services/chat-composer.js';
 export type { ChatComposerDeps, ChatComposer, SendOptions } from './services/chat-composer.js';
+
+export { createSystemSessionService } from './services/system-session-service.js';
+export type { SystemSessionServiceDeps, SystemSessionService } from './services/system-session-service.js';

--- a/packages/core/src/ports/gateway-transport.ts
+++ b/packages/core/src/ports/gateway-transport.ts
@@ -87,6 +87,8 @@ export interface GatewayTransportPort {
   listAgents: (gatewayId: string) => Promise<IpcResult>;
   getToolsCatalog: (gatewayId: string, agentId?: string) => Promise<IpcResult>;
   getSkillsStatus: (gatewayId: string, agentId?: string) => Promise<IpcResult>;
+  createSession: (gatewayId: string, params: { key: string; agentId: string; message?: string }) => Promise<IpcResult>;
+  deleteSession: (gatewayId: string, sessionKey: string) => Promise<IpcResult>;
   onGatewayEvent: (callback: (data: GatewayEvent) => void) => () => void;
   onGatewayStatus: (callback: (status: GatewayStatusEvent) => void) => () => void;
 }

--- a/packages/core/src/services/gateway-dispatcher.ts
+++ b/packages/core/src/services/gateway-dispatcher.ts
@@ -1,4 +1,4 @@
-import { parseTaskIdFromSessionKey, isSubagentSession } from '@clawwork/shared';
+import { parseTaskIdFromSessionKey, isSubagentSession, isSystemSession } from '@clawwork/shared';
 import type {
   ToolCall,
   ToolCallStatus,
@@ -217,6 +217,8 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
       return;
     }
 
+    if (isSystemSession(sessionKey)) return;
+
     const taskId = resolveTaskId(sessionKey);
     if (!taskId) {
       if (isSubagentSession(sessionKey)) {
@@ -354,6 +356,8 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
       });
       return;
     }
+
+    if (isSystemSession(sessionKey)) return;
 
     const taskId = resolveTaskId(sessionKey);
     if (!taskId) {

--- a/packages/core/src/services/system-session-service.ts
+++ b/packages/core/src/services/system-session-service.ts
@@ -1,0 +1,146 @@
+import type { IpcResult } from '@clawwork/shared';
+import { buildSystemSessionKey, mergeGatewayStreamText } from '@clawwork/shared';
+import type { GatewayEvent } from '../ports/gateway-transport.js';
+import type { SystemSessionState } from '../stores/system-session-store.js';
+
+interface SystemSessionGateway {
+  createSession: (gatewayId: string, params: { key: string; agentId: string; message?: string }) => Promise<IpcResult>;
+  deleteSession: (gatewayId: string, sessionKey: string) => Promise<IpcResult>;
+  sendMessage: (gatewayId: string, sessionKey: string, content: string) => Promise<IpcResult>;
+  onGatewayEvent: (callback: (data: GatewayEvent) => void) => () => void;
+}
+
+export interface SystemSessionServiceDeps {
+  gateway: SystemSessionGateway;
+  getStore: () => SystemSessionState;
+}
+
+export interface SystemSessionService {
+  start(opts: { gatewayId: string; agentId: string; purpose: string; initialMessage?: string }): Promise<IpcResult>;
+  send(content: string): Promise<IpcResult>;
+  abort(): void;
+  end(): Promise<void>;
+}
+
+interface ChatEventPayload {
+  sessionKey: string;
+  state?: 'delta' | 'final' | 'aborted' | 'error';
+  text?: string;
+  errorMessage?: string;
+  error?: { message?: string };
+}
+
+export function createSystemSessionService(deps: SystemSessionServiceDeps): SystemSessionService {
+  let removeListener: (() => void) | null = null;
+
+  function handleEvent(data: GatewayEvent): void {
+    if (data.event !== 'chat') return;
+    const store = deps.getStore();
+    const payload = data.payload as unknown as ChatEventPayload;
+    if (!store.sessionKey || payload.sessionKey !== store.sessionKey) return;
+
+    const text = payload.text ?? '';
+
+    switch (payload.state) {
+      case 'delta': {
+        const msgs = store.messages;
+        const last = msgs[msgs.length - 1];
+        if (last?.role === 'assistant') {
+          store.updateLastAssistant(mergeGatewayStreamText(last.content, text));
+        }
+        store.setStatus('streaming');
+        break;
+      }
+      case 'final': {
+        if (text) {
+          const msgs = store.messages;
+          const last = msgs[msgs.length - 1];
+          if (last?.role === 'assistant') {
+            store.updateLastAssistant(mergeGatewayStreamText(last.content, text));
+          }
+        }
+        store.setStatus('active');
+        break;
+      }
+      case 'aborted':
+        store.setStatus('active');
+        break;
+      case 'error': {
+        const errMsg = payload.errorMessage ?? payload.error?.message ?? 'unknown error';
+        store.setError(errMsg);
+        break;
+      }
+    }
+  }
+
+  return {
+    async start(opts) {
+      const store = deps.getStore();
+      if (store.sessionKey) {
+        return { ok: false, error: 'system session already active' };
+      }
+
+      const sessionKey = buildSystemSessionKey(opts.purpose);
+      store.open({
+        sessionKey,
+        gatewayId: opts.gatewayId,
+        agentId: opts.agentId,
+        purpose: opts.purpose,
+      });
+
+      removeListener = deps.gateway.onGatewayEvent(handleEvent);
+
+      const res = await deps.gateway.createSession(opts.gatewayId, {
+        key: sessionKey,
+        agentId: opts.agentId,
+      });
+
+      if (!res.ok) {
+        removeListener();
+        removeListener = null;
+        store.close();
+        return res;
+      }
+
+      if (opts.initialMessage) {
+        return this.send(opts.initialMessage);
+      }
+
+      return { ok: true };
+    },
+
+    async send(content) {
+      const store = deps.getStore();
+      if (!store.sessionKey || !store.gatewayId) {
+        return { ok: false, error: 'no active system session' };
+      }
+
+      const now = new Date().toISOString();
+      store.appendMessage({ role: 'user', content, timestamp: now });
+      store.appendMessage({ role: 'assistant', content: '', timestamp: now });
+      store.setStatus('streaming');
+
+      return deps.gateway.sendMessage(store.gatewayId, store.sessionKey, content);
+    },
+
+    abort() {
+      removeListener?.();
+      removeListener = null;
+      deps.getStore().close();
+    },
+
+    async end() {
+      const store = deps.getStore();
+      const { gatewayId, sessionKey } = store;
+
+      removeListener?.();
+      removeListener = null;
+
+      if (gatewayId && sessionKey) {
+        await deps.gateway.deleteSession(gatewayId, sessionKey).catch(() => {});
+      }
+
+      store.close();
+    },
+  };
+}

--- a/packages/core/src/stores/system-session-store.ts
+++ b/packages/core/src/stores/system-session-store.ts
@@ -1,0 +1,86 @@
+import { createStore } from 'zustand/vanilla';
+
+export interface SystemSessionMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+}
+
+export type SystemSessionStatus = 'idle' | 'active' | 'streaming' | 'error';
+
+export interface SystemSessionState {
+  sessionKey: string | null;
+  gatewayId: string | null;
+  agentId: string | null;
+  purpose: string | null;
+  status: SystemSessionStatus;
+  messages: SystemSessionMessage[];
+  error: string | null;
+
+  open(opts: { sessionKey: string; gatewayId: string; agentId: string; purpose: string }): void;
+  appendMessage(msg: SystemSessionMessage): void;
+  updateLastAssistant(content: string): void;
+  setStatus(status: SystemSessionStatus): void;
+  setError(error: string): void;
+  close(): void;
+}
+
+const INITIAL: Pick<
+  SystemSessionState,
+  'sessionKey' | 'gatewayId' | 'agentId' | 'purpose' | 'status' | 'messages' | 'error'
+> = {
+  sessionKey: null,
+  gatewayId: null,
+  agentId: null,
+  purpose: null,
+  status: 'idle',
+  messages: [],
+  error: null,
+};
+
+export function createSystemSessionStore() {
+  return createStore<SystemSessionState>((set) => ({
+    ...INITIAL,
+
+    open(opts) {
+      set({
+        sessionKey: opts.sessionKey,
+        gatewayId: opts.gatewayId,
+        agentId: opts.agentId,
+        purpose: opts.purpose,
+        status: 'active',
+        messages: [],
+        error: null,
+      });
+    },
+
+    appendMessage(msg) {
+      set((s) => ({ messages: [...s.messages, msg] }));
+    },
+
+    updateLastAssistant(content) {
+      set((s) => {
+        const msgs = [...s.messages];
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          if (msgs[i].role === 'assistant') {
+            msgs[i] = { ...msgs[i], content };
+            return { messages: msgs };
+          }
+        }
+        return s;
+      });
+    },
+
+    setStatus(status) {
+      set({ status });
+    },
+
+    setError(error) {
+      set({ error, status: 'error' });
+    },
+
+    close() {
+      set({ ...INITIAL });
+    },
+  }));
+}

--- a/packages/core/test/system-session-service.test.ts
+++ b/packages/core/test/system-session-service.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createSystemSessionStore } from '../src/stores/system-session-store';
+import { createSystemSessionService } from '../src/services/system-session-service';
+import type { GatewayEvent } from '../src/ports/gateway-transport';
+
+type EventCallback = (data: GatewayEvent) => void;
+
+function setup() {
+  const storeApi = createSystemSessionStore();
+  const listeners = new Set<EventCallback>();
+
+  const gateway = {
+    createSession: vi.fn().mockResolvedValue({ ok: true }),
+    deleteSession: vi.fn().mockResolvedValue({ ok: true }),
+    sendMessage: vi.fn().mockResolvedValue({ ok: true }),
+    onGatewayEvent: vi.fn((cb: EventCallback) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    }),
+  };
+
+  const service = createSystemSessionService({
+    gateway,
+    getStore: () => storeApi.getState(),
+  });
+
+  function emitGatewayEvent(data: GatewayEvent) {
+    for (const cb of listeners) cb(data);
+  }
+
+  return { storeApi, gateway, service, emitGatewayEvent, listeners };
+}
+
+describe('system session service', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('start() creates a session and registers a listener', async () => {
+    const { service, gateway, storeApi, listeners } = setup();
+
+    const res = await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+
+    expect(res.ok).toBe(true);
+    expect(gateway.createSession).toHaveBeenCalledOnce();
+    const createArgs = gateway.createSession.mock.calls[0];
+    expect(createArgs[0]).toBe('gw-1');
+    expect(createArgs[1].key).toMatch(/^clawwork:system:test:/);
+    expect(createArgs[1].agentId).toBe('main');
+    expect(listeners.size).toBe(1);
+
+    const s = storeApi.getState();
+    expect(s.status).toBe('active');
+    expect(s.sessionKey).toBe(createArgs[1].key);
+  });
+
+  it('start() with initialMessage sends the message immediately', async () => {
+    const { service, gateway, storeApi } = setup();
+
+    await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test', initialMessage: 'hello' });
+
+    expect(gateway.sendMessage).toHaveBeenCalledOnce();
+    const s = storeApi.getState();
+    expect(s.messages).toHaveLength(2);
+    expect(s.messages[0]).toMatchObject({ role: 'user', content: 'hello' });
+    expect(s.messages[1]).toMatchObject({ role: 'assistant', content: '' });
+    expect(s.status).toBe('streaming');
+  });
+
+  it('start() cleans up on gateway createSession failure', async () => {
+    const { service, gateway, storeApi, listeners } = setup();
+    gateway.createSession.mockResolvedValue({ ok: false, error: 'refused' });
+
+    const res = await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('refused');
+    expect(storeApi.getState().status).toBe('idle');
+    expect(storeApi.getState().sessionKey).toBeNull();
+    expect(listeners.size).toBe(0);
+  });
+
+  it('start() rejects when a session is already active', async () => {
+    const { service } = setup();
+    await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+
+    const res = await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'other' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('system session already active');
+  });
+
+  it('send() appends user + assistant placeholder and calls gateway', async () => {
+    const { service, gateway, storeApi } = setup();
+    await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+
+    const res = await service.send('question');
+
+    expect(res.ok).toBe(true);
+    expect(gateway.sendMessage).toHaveBeenCalledOnce();
+    const msgs = storeApi.getState().messages;
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]).toMatchObject({ role: 'user', content: 'question' });
+    expect(msgs[1]).toMatchObject({ role: 'assistant', content: '' });
+    expect(storeApi.getState().status).toBe('streaming');
+  });
+
+  it('send() rejects when no session is active', async () => {
+    const { service } = setup();
+    const res = await service.send('hello');
+    expect(res.ok).toBe(false);
+  });
+
+  describe('gateway event handling', () => {
+    it('delta events update the assistant message and set streaming', async () => {
+      const { service, storeApi, emitGatewayEvent } = setup();
+      await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+      await service.send('go');
+
+      const sessionKey = storeApi.getState().sessionKey!;
+      emitGatewayEvent({
+        event: 'chat',
+        gatewayId: 'gw-1',
+        payload: { sessionKey, state: 'delta', text: 'Hel' } as unknown as Record<string, unknown>,
+      });
+
+      expect(storeApi.getState().messages[1].content).toBe('Hel');
+      expect(storeApi.getState().status).toBe('streaming');
+
+      emitGatewayEvent({
+        event: 'chat',
+        gatewayId: 'gw-1',
+        payload: { sessionKey, state: 'delta', text: 'Hello world' } as unknown as Record<string, unknown>,
+      });
+
+      expect(storeApi.getState().messages[1].content).toBe('Hello world');
+    });
+
+    it('final event finalizes the assistant message and sets active', async () => {
+      const { service, storeApi, emitGatewayEvent } = setup();
+      await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+      await service.send('go');
+
+      const sessionKey = storeApi.getState().sessionKey!;
+      emitGatewayEvent({
+        event: 'chat',
+        gatewayId: 'gw-1',
+        payload: { sessionKey, state: 'delta', text: 'partial ' } as unknown as Record<string, unknown>,
+      });
+      emitGatewayEvent({
+        event: 'chat',
+        gatewayId: 'gw-1',
+        payload: { sessionKey, state: 'final', text: 'partial answer complete' } as unknown as Record<string, unknown>,
+      });
+
+      expect(storeApi.getState().messages[1].content).toBe('partial answer complete');
+      expect(storeApi.getState().status).toBe('active');
+    });
+
+    it('error event sets error status', async () => {
+      const { service, storeApi, emitGatewayEvent } = setup();
+      await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+      await service.send('go');
+
+      const sessionKey = storeApi.getState().sessionKey!;
+      emitGatewayEvent({
+        event: 'chat',
+        gatewayId: 'gw-1',
+        payload: { sessionKey, state: 'error', errorMessage: 'model overloaded' } as unknown as Record<string, unknown>,
+      });
+
+      expect(storeApi.getState().status).toBe('error');
+      expect(storeApi.getState().error).toBe('model overloaded');
+    });
+
+    it('ignores events for other session keys', async () => {
+      const { service, storeApi, emitGatewayEvent } = setup();
+      await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+      await service.send('go');
+
+      emitGatewayEvent({
+        event: 'chat',
+        gatewayId: 'gw-1',
+        payload: {
+          sessionKey: 'agent:main:clawwork:task:task-1',
+          state: 'delta',
+          text: 'leaked',
+        } as unknown as Record<string, unknown>,
+      });
+
+      expect(storeApi.getState().messages[1].content).toBe('');
+    });
+
+    it('ignores non-chat events', async () => {
+      const { service, storeApi, emitGatewayEvent } = setup();
+      await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+      await service.send('go');
+
+      const sessionKey = storeApi.getState().sessionKey!;
+      emitGatewayEvent({
+        event: 'agent',
+        gatewayId: 'gw-1',
+        payload: { sessionKey, state: 'delta', text: 'ignored' } as unknown as Record<string, unknown>,
+      });
+
+      expect(storeApi.getState().messages[1].content).toBe('');
+    });
+  });
+
+  it('end() removes listener, deletes session on gateway, and resets store', async () => {
+    const { service, gateway, storeApi, listeners } = setup();
+    await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+    const sessionKey = storeApi.getState().sessionKey!;
+
+    await service.end();
+
+    expect(gateway.deleteSession).toHaveBeenCalledWith('gw-1', sessionKey);
+    expect(listeners.size).toBe(0);
+    expect(storeApi.getState().status).toBe('idle');
+    expect(storeApi.getState().sessionKey).toBeNull();
+    expect(storeApi.getState().messages).toEqual([]);
+  });
+
+  it('abort() cleans up without calling deleteSession', () => {
+    const { service, gateway, storeApi, listeners } = setup();
+    service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'test' });
+
+    service.abort();
+
+    expect(gateway.deleteSession).not.toHaveBeenCalled();
+    expect(listeners.size).toBe(0);
+    expect(storeApi.getState().status).toBe('idle');
+  });
+
+  it('full lifecycle: start → send → receive → end', async () => {
+    const { service, storeApi, emitGatewayEvent } = setup();
+
+    await service.start({ gatewayId: 'gw-1', agentId: 'main', purpose: 'agent-scaffold' });
+    expect(storeApi.getState().purpose).toBe('agent-scaffold');
+
+    await service.send('Create a Python assistant');
+    const sessionKey = storeApi.getState().sessionKey!;
+
+    emitGatewayEvent({
+      event: 'chat',
+      gatewayId: 'gw-1',
+      payload: { sessionKey, state: 'delta', text: 'Creating' } as unknown as Record<string, unknown>,
+    });
+    emitGatewayEvent({
+      event: 'chat',
+      gatewayId: 'gw-1',
+      payload: {
+        sessionKey,
+        state: 'final',
+        text: 'Creating your Python assistant...',
+      } as unknown as Record<string, unknown>,
+    });
+
+    expect(storeApi.getState().messages[1].content).toBe('Creating your Python assistant...');
+    expect(storeApi.getState().status).toBe('active');
+
+    await service.end();
+    expect(storeApi.getState().status).toBe('idle');
+    expect(storeApi.getState().messages).toEqual([]);
+  });
+});

--- a/packages/core/test/system-session-store.test.ts
+++ b/packages/core/test/system-session-store.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { createSystemSessionStore } from '../src/stores/system-session-store';
+
+function setup() {
+  const store = createSystemSessionStore();
+  return store;
+}
+
+describe('system session store', () => {
+  it('starts in idle state with no session', () => {
+    const store = setup();
+    const s = store.getState();
+    expect(s.status).toBe('idle');
+    expect(s.sessionKey).toBeNull();
+    expect(s.messages).toEqual([]);
+  });
+
+  it('open() transitions to active with session metadata', () => {
+    const store = setup();
+    store.getState().open({
+      sessionKey: 'clawwork:system:test:abc-123',
+      gatewayId: 'gw-1',
+      agentId: 'main',
+      purpose: 'test',
+    });
+    const s = store.getState();
+    expect(s.status).toBe('active');
+    expect(s.sessionKey).toBe('clawwork:system:test:abc-123');
+    expect(s.gatewayId).toBe('gw-1');
+    expect(s.agentId).toBe('main');
+    expect(s.purpose).toBe('test');
+    expect(s.error).toBeNull();
+  });
+
+  it('appendMessage() adds messages in order', () => {
+    const store = setup();
+    store.getState().open({
+      sessionKey: 'k',
+      gatewayId: 'gw',
+      agentId: 'main',
+      purpose: 'test',
+    });
+    store.getState().appendMessage({ role: 'user', content: 'hello', timestamp: '2026-01-01T00:00:00Z' });
+    store.getState().appendMessage({ role: 'assistant', content: '', timestamp: '2026-01-01T00:00:01Z' });
+    expect(store.getState().messages).toHaveLength(2);
+    expect(store.getState().messages[0].role).toBe('user');
+    expect(store.getState().messages[1].role).toBe('assistant');
+  });
+
+  it('updateLastAssistant() updates the last assistant message content', () => {
+    const store = setup();
+    store.getState().open({ sessionKey: 'k', gatewayId: 'gw', agentId: 'main', purpose: 'test' });
+    store.getState().appendMessage({ role: 'user', content: 'q', timestamp: 't1' });
+    store.getState().appendMessage({ role: 'assistant', content: '', timestamp: 't2' });
+    store.getState().updateLastAssistant('streaming...');
+    expect(store.getState().messages[1].content).toBe('streaming...');
+    store.getState().updateLastAssistant('streaming... done');
+    expect(store.getState().messages[1].content).toBe('streaming... done');
+  });
+
+  it('updateLastAssistant() is a no-op when no assistant message exists', () => {
+    const store = setup();
+    store.getState().open({ sessionKey: 'k', gatewayId: 'gw', agentId: 'main', purpose: 'test' });
+    store.getState().appendMessage({ role: 'user', content: 'q', timestamp: 't1' });
+    store.getState().updateLastAssistant('oops');
+    expect(store.getState().messages).toHaveLength(1);
+    expect(store.getState().messages[0].content).toBe('q');
+  });
+
+  it('setError() sets error and transitions status to error', () => {
+    const store = setup();
+    store.getState().open({ sessionKey: 'k', gatewayId: 'gw', agentId: 'main', purpose: 'test' });
+    store.getState().setError('something broke');
+    expect(store.getState().status).toBe('error');
+    expect(store.getState().error).toBe('something broke');
+  });
+
+  it('close() resets everything to initial state', () => {
+    const store = setup();
+    store.getState().open({ sessionKey: 'k', gatewayId: 'gw', agentId: 'main', purpose: 'test' });
+    store.getState().appendMessage({ role: 'user', content: 'hi', timestamp: 't1' });
+    store.getState().setStatus('streaming');
+    store.getState().close();
+    const s = store.getState();
+    expect(s.status).toBe('idle');
+    expect(s.sessionKey).toBeNull();
+    expect(s.gatewayId).toBeNull();
+    expect(s.messages).toEqual([]);
+    expect(s.error).toBeNull();
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/desktop/src/renderer/platform/electron-adapter.ts
+++ b/packages/desktop/src/renderer/platform/electron-adapter.ts
@@ -25,6 +25,8 @@ export function createElectronPorts(): PlatformPorts {
       listAgents: api.listAgents,
       getToolsCatalog: api.getToolsCatalog,
       getSkillsStatus: api.getSkillsStatus,
+      createSession: api.createSession,
+      deleteSession: api.deleteSession,
       onGatewayEvent: api.onGatewayEvent,
       onGatewayStatus: api.onGatewayStatus,
     },

--- a/packages/pwa/src/gateway/client.ts
+++ b/packages/pwa/src/gateway/client.ts
@@ -253,6 +253,14 @@ export class BrowserGatewayClient {
     return this.sendReq('chat.history', { sessionKey, limit }, this.sessionMeta(sessionKey));
   }
 
+  async createSession(params: { key: string; agentId: string; message?: string }): Promise<Record<string, unknown>> {
+    return this.sendReq('sessions.create', params, { requestId: this.nextReqId() });
+  }
+
+  async deleteSession(sessionKey: string, deleteTranscript = true): Promise<Record<string, unknown>> {
+    return this.sendReq('sessions.delete', { key: sessionKey, deleteTranscript }, this.sessionMeta(sessionKey));
+  }
+
   async listSessions(): Promise<Record<string, unknown>> {
     return this.sendReq('sessions.list', {}, { requestId: this.nextReqId() });
   }

--- a/packages/pwa/src/platform/gateway-adapter.ts
+++ b/packages/pwa/src/platform/gateway-adapter.ts
@@ -356,6 +356,32 @@ export function createBrowserGatewayTransport(
       }
     },
 
+    async createSession(gatewayId, params) {
+      const client = getClient(gatewayId);
+      if (!client?.isConnected)
+        return { ok: false, error: 'gateway not connected', errorCode: 'GATEWAY_NOT_CONNECTED' };
+      try {
+        await client.createSession(params);
+        return { ok: true };
+      } catch (err) {
+        const typed = err as Error & { code?: string };
+        return { ok: false, error: typed.message, errorCode: typed.code };
+      }
+    },
+
+    async deleteSession(gatewayId, sessionKey) {
+      const client = getClient(gatewayId);
+      if (!client?.isConnected)
+        return { ok: false, error: 'gateway not connected', errorCode: 'GATEWAY_NOT_CONNECTED' };
+      try {
+        await client.deleteSession(sessionKey);
+        return { ok: true };
+      } catch (err) {
+        const typed = err as Error & { code?: string };
+        return { ok: false, error: typed.message, errorCode: typed.code };
+      }
+    },
+
     onGatewayEvent(callback) {
       eventListeners.add(callback);
       return () => {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -52,6 +52,16 @@ export function isClawWorkSession(sessionKey: string, deviceId?: string): boolea
   return CLAWWORK_DEVICE_SESSION_RE.test(sessionKey) || CLAWWORK_SESSION_RE.test(sessionKey);
 }
 
+const SYSTEM_SESSION_RE = /^clawwork:system:[^:]+:[a-f0-9-]+$/;
+
+export function buildSystemSessionKey(purpose: string): string {
+  return `clawwork:system:${purpose}:${crypto.randomUUID()}`;
+}
+
+export function isSystemSession(sessionKey: string): boolean {
+  return SYSTEM_SESSION_RE.test(sessionKey);
+}
+
 export const HEARTBEAT_INTERVAL_MS = 30_000;
 
 export const RECONNECT_DELAY_MS = 3_000;

--- a/packages/shared/test/session-key.test.ts
+++ b/packages/shared/test/session-key.test.ts
@@ -1,5 +1,12 @@
-import { test, expect } from 'vitest';
-import { buildSessionKey, parseTaskIdFromSessionKey } from '../src/constants';
+import { test, expect, describe } from 'vitest';
+import {
+  buildSessionKey,
+  parseTaskIdFromSessionKey,
+  buildSystemSessionKey,
+  isSystemSession,
+  isClawWorkSession,
+  isSubagentSession,
+} from '../src/constants';
 
 test('parseTaskIdFromSessionKey parses current ClawWork session keys', () => {
   const taskId = 'task-current';
@@ -9,4 +16,40 @@ test('parseTaskIdFromSessionKey parses current ClawWork session keys', () => {
 
 test('parseTaskIdFromSessionKey keeps accepting legacy task session keys', () => {
   expect(parseTaskIdFromSessionKey('agent:main:task-task-legacy')).toBe('task-legacy');
+});
+
+describe('system session keys', () => {
+  test('buildSystemSessionKey produces valid format', () => {
+    const key = buildSystemSessionKey('agent-scaffold');
+    expect(key).toMatch(/^clawwork:system:agent-scaffold:[a-f0-9-]+$/);
+  });
+
+  test('buildSystemSessionKey generates unique keys', () => {
+    const a = buildSystemSessionKey('test');
+    const b = buildSystemSessionKey('test');
+    expect(a).not.toBe(b);
+  });
+
+  test('isSystemSession recognizes system session keys', () => {
+    const key = buildSystemSessionKey('avatar-gen');
+    expect(isSystemSession(key)).toBe(true);
+  });
+
+  test('isSystemSession rejects task session keys', () => {
+    const taskKey = buildSessionKey('task-1');
+    expect(isSystemSession(taskKey)).toBe(false);
+  });
+
+  test('isSystemSession rejects arbitrary strings', () => {
+    expect(isSystemSession('random-string')).toBe(false);
+    expect(isSystemSession('')).toBe(false);
+    expect(isSystemSession('clawwork:system:')).toBe(false);
+  });
+
+  test('system session keys are invisible to task routing', () => {
+    const key = buildSystemSessionKey('agent-scaffold');
+    expect(parseTaskIdFromSessionKey(key)).toBeNull();
+    expect(isClawWorkSession(key)).toBe(false);
+    expect(isSubagentSession(key)).toBe(false);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)
 
   packages/desktop:
     dependencies:


### PR DESCRIPTION
## Summary

Add infrastructure for **system sessions** — ephemeral, in-memory OpenClaw chat channels that are fully decoupled from the Task/Chat persistence layer. These are temporary channels used for scenarios like conversational agent creation or avatar generation, where a short-lived OpenClaw session is needed but should never appear in the UI, database, or sync flow.

## Type of change

- [x] `[Feat]` new feature

## Why is this needed?

ClawWork needs a mechanism to open short-lived OpenClaw sessions for internal tooling flows (agent scaffolding, avatar generation, etc.) without polluting the Task list, message database, or session sync. The existing Task-based session model is too heavy for ephemeral use cases.

## What changed?

- **shared/constants.ts**: Added `buildSystemSessionKey()` and `isSystemSession()` using a distinct key format (`clawwork:system:{purpose}:{uuid}`) that is invisible to all existing session routing
- **core/ports/gateway-transport.ts**: Extended `GatewayTransportPort` with `createSession` and `deleteSession` methods
- **core/stores/system-session-store.ts**: New pure in-memory Zustand store (no persistence calls)
- **core/services/system-session-service.ts**: New service managing the full lifecycle: `start` → `send` → `abort`/`end`, with independent Gateway event listener
- **core/services/gateway-dispatcher.ts**: Added explicit `isSystemSession()` early-return in both `handleChatEvent` and `handleAgentEvent` to avoid processing noise
- **desktop/electron-adapter.ts**: Wired `createSession`/`deleteSession` through to preload API
- **pwa/gateway/client.ts**: Added `createSession`/`deleteSession` RPC methods
- **pwa/platform/gateway-adapter.ts**: Wired transport methods for PWA
- **core/package.json + vitest.config.ts**: Set up vitest for the core package
- **Tests**: 27 new tests across shared (session key isolation), core store (all state transitions), and core service (full lifecycle + event handling)

## Architecture impact

- Owning layer: shared + core
- Cross-layer impact: yes — desktop adapter and PWA adapter each received 2-line wiring changes to expose existing preload/client methods through the port interface
- Invariants touched from `docs/architecture-invariants.md`:
  - Session key format: new `clawwork:system:*` format deliberately does NOT match the `agent:*:clawwork:task:*` pattern
  - Session routing: dispatcher explicitly skips system sessions via `isSystemSession()` guard
- Why those invariants remain protected:
  - `parseTaskIdFromSessionKey()` returns `null` for system session keys (tested)
  - `isClawWorkSession()` returns `false` (tested)
  - `isSubagentSession()` returns `false` (tested)
  - Dispatcher has explicit early-return, not implicit fall-through

## Linked issues

N/A — infrastructure PR for upcoming agent-scaffold and avatar-gen features

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate — 241 tests, 0 failures)
- [ ] Manual smoke test
- [ ] `pnpm build`

Commands, screenshots, or notes:

```text
pnpm check — all 241 tests pass, 0 failures
New tests: 6 (shared) + 7 (core store) + 14 (core service) = 27
```

## Screenshots or recordings

No UI changes in this PR. System sessions are infrastructure-only; UI (SystemChatDialog) will be a follow-up PR.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate