### PR TITLE
[Feat] Wire skills.install, skills.update, skills.bins and config.* Gateway IPC channels

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -3,7 +3,15 @@ import { getGatewayClient, getAllGatewayClients, reconnectGateway } from '../ws/
 import { readConfig, ensureDeviceId } from '../workspace/config.js';
 import { isClawWorkSession, parseTaskIdFromSessionKey, parseAgentIdFromSessionKey } from '@clawwork/shared';
 import { parseToolArgs } from '@clawwork/core';
-import type { ApprovalDecision, ChatAttachment, ExecApprovalResolveParams } from '@clawwork/shared';
+import type {
+  ApprovalDecision,
+  ChatAttachment,
+  ConfigPatchParams,
+  ConfigSetParams,
+  ExecApprovalResolveParams,
+  SkillInstallParams,
+  SkillUpdateParams,
+} from '@clawwork/shared';
 import { getDebugLogger } from '../debug/index.js';
 import type { GatewayClient } from '../ws/gateway-client.js';
 
@@ -508,6 +516,42 @@ export function registerWsHandlers(): void {
         agentId?: string;
       },
     ) => gatewayRpc(payload.gatewayId, (gw) => gw.getSkillsStatus(payload.agentId)),
+  );
+
+  ipcMain.handle('ws:skills-install', async (_event, payload: { gatewayId: string } & SkillInstallParams) => {
+    const { gatewayId, ...params } = payload;
+    return gatewayRpc(gatewayId, (gw) => gw.installSkill(params));
+  });
+
+  ipcMain.handle('ws:skills-update', async (_event, payload: { gatewayId: string } & SkillUpdateParams) => {
+    const { gatewayId, ...params } = payload;
+    return gatewayRpc(gatewayId, (gw) => gw.updateSkill(params));
+  });
+
+  ipcMain.handle('ws:skills-bins', async (_event, payload: { gatewayId: string }) =>
+    gatewayRpc(payload.gatewayId, (gw) => gw.getSkillBins()),
+  );
+
+  ipcMain.handle('ws:config-get', async (_event, payload: { gatewayId: string }) =>
+    gatewayRpc(payload.gatewayId, (gw) => gw.getConfig()),
+  );
+
+  ipcMain.handle('ws:config-set', async (_event, payload: { gatewayId: string } & ConfigSetParams) => {
+    const { gatewayId, ...params } = payload;
+    return gatewayRpc(gatewayId, (gw) => gw.setConfig(params));
+  });
+
+  ipcMain.handle('ws:config-patch', async (_event, payload: { gatewayId: string } & ConfigPatchParams) => {
+    const { gatewayId, ...params } = payload;
+    return gatewayRpc(gatewayId, (gw) => gw.patchConfig(params));
+  });
+
+  ipcMain.handle('ws:config-schema', async (_event, payload: { gatewayId: string }) =>
+    gatewayRpc(payload.gatewayId, (gw) => gw.getConfigSchema()),
+  );
+
+  ipcMain.handle('ws:config-schema-lookup', async (_event, payload: { gatewayId: string; path: string }) =>
+    gatewayRpc(payload.gatewayId, (gw) => gw.lookupConfigSchema(payload.path)),
   );
 
   ipcMain.handle('ws:usage-status', async (_event, payload: { gatewayId: string }) =>

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -628,6 +628,52 @@ export class GatewayClient {
     return this.sendReq('skills.status', params);
   }
 
+  async installSkill(
+    params:
+      | { name: string; installId: string; dangerouslyForceUnsafeInstall?: boolean; timeoutMs?: number }
+      | { source: 'clawhub'; slug: string; version?: string; force?: boolean; timeoutMs?: number },
+  ): Promise<Record<string, unknown>> {
+    return this.sendReq('skills.install', params);
+  }
+
+  async updateSkill(
+    params:
+      | { skillKey: string; enabled?: boolean; apiKey?: string; env?: Record<string, string> }
+      | { source: 'clawhub'; slug?: string; all?: boolean },
+  ): Promise<Record<string, unknown>> {
+    return this.sendReq('skills.update', params);
+  }
+
+  async getSkillBins(): Promise<Record<string, unknown>> {
+    return this.sendReq('skills.bins', {});
+  }
+
+  async getConfig(): Promise<Record<string, unknown>> {
+    return this.sendReq('config.get', {});
+  }
+
+  async setConfig(params: { raw: string; baseHash?: string }): Promise<Record<string, unknown>> {
+    return this.sendReq('config.set', params);
+  }
+
+  async patchConfig(params: {
+    raw: string;
+    baseHash?: string;
+    sessionKey?: string;
+    note?: string;
+    restartDelayMs?: number;
+  }): Promise<Record<string, unknown>> {
+    return this.sendReq('config.patch', params);
+  }
+
+  async getConfigSchema(): Promise<Record<string, unknown>> {
+    return this.sendReq('config.schema', {});
+  }
+
+  async lookupConfigSchema(path: string): Promise<Record<string, unknown>> {
+    return this.sendReq('config.schema.lookup', { path });
+  }
+
   async getUsageStatus(): Promise<Record<string, unknown>> {
     return this.sendReq('usage.status', {});
   }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -10,6 +10,18 @@ import type {
   CronRunResult,
   CronRunsParams,
   CronStatusResult,
+  SkillInstallParams,
+  SkillInstallResult,
+  SkillUpdateParams,
+  SkillUpdateResult,
+  SkillBinsResult,
+  ConfigSnapshot,
+  ConfigSetParams,
+  ConfigPatchParams,
+  ConfigSetResult,
+  ConfigPatchResult,
+  ConfigSchemaResult,
+  ConfigSchemaLookupResult,
 } from '@clawwork/shared';
 
 type IpcResult<T = Record<string, unknown>> = SharedIpcResult<T>;
@@ -244,6 +256,14 @@ export interface ClawWorkAPI {
   patchSession: (gatewayId: string, sessionKey: string, patch: Record<string, unknown>) => Promise<IpcResult>;
   getToolsCatalog: (gatewayId: string, agentId?: string) => Promise<IpcResult>;
   getSkillsStatus: (gatewayId: string, agentId?: string) => Promise<IpcResult>;
+  installSkill: (gatewayId: string, params: SkillInstallParams) => Promise<IpcResult<SkillInstallResult>>;
+  updateSkill: (gatewayId: string, params: SkillUpdateParams) => Promise<IpcResult<SkillUpdateResult>>;
+  getSkillBins: (gatewayId: string) => Promise<IpcResult<SkillBinsResult>>;
+  getConfig: (gatewayId: string) => Promise<IpcResult<ConfigSnapshot>>;
+  setConfig: (gatewayId: string, params: ConfigSetParams) => Promise<IpcResult<ConfigSetResult>>;
+  patchConfig: (gatewayId: string, params: ConfigPatchParams) => Promise<IpcResult<ConfigPatchResult>>;
+  getConfigSchema: (gatewayId: string) => Promise<IpcResult<ConfigSchemaResult>>;
+  lookupConfigSchema: (gatewayId: string, path: string) => Promise<IpcResult<ConfigSchemaLookupResult>>;
 
   gatewayStatus: () => Promise<GatewayStatusMap>;
   syncSessions: () => Promise<SyncResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -6,6 +6,10 @@ import type {
   CronListParams,
   CronRunParams,
   CronRunsParams,
+  SkillInstallParams,
+  SkillUpdateParams,
+  ConfigSetParams,
+  ConfigPatchParams,
 } from '@clawwork/shared';
 import type { ClawWorkAPI, GatewayServerConfig } from './clawwork';
 
@@ -53,6 +57,19 @@ function buildApi(): ClawWorkAPI {
       ipcRenderer.invoke('ws:tools-catalog', { gatewayId, agentId }),
     getSkillsStatus: (gatewayId: string, agentId?: string) =>
       ipcRenderer.invoke('ws:skills-status', { gatewayId, agentId }),
+    installSkill: (gatewayId: string, params: SkillInstallParams) =>
+      ipcRenderer.invoke('ws:skills-install', { gatewayId, ...params }),
+    updateSkill: (gatewayId: string, params: SkillUpdateParams) =>
+      ipcRenderer.invoke('ws:skills-update', { gatewayId, ...params }),
+    getSkillBins: (gatewayId: string) => ipcRenderer.invoke('ws:skills-bins', { gatewayId }),
+    getConfig: (gatewayId: string) => ipcRenderer.invoke('ws:config-get', { gatewayId }),
+    setConfig: (gatewayId: string, params: ConfigSetParams) =>
+      ipcRenderer.invoke('ws:config-set', { gatewayId, ...params }),
+    patchConfig: (gatewayId: string, params: ConfigPatchParams) =>
+      ipcRenderer.invoke('ws:config-patch', { gatewayId, ...params }),
+    getConfigSchema: (gatewayId: string) => ipcRenderer.invoke('ws:config-schema', { gatewayId }),
+    lookupConfigSchema: (gatewayId: string, path: string) =>
+      ipcRenderer.invoke('ws:config-schema-lookup', { gatewayId, path }),
 
     onGatewayEvent: (callback) => {
       const listener = (_event: Electron.IpcRendererEvent, data: unknown): void => {

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+
+const installSkillMock = vi.fn();
+const updateSkillMock = vi.fn();
+const getSkillBinsMock = vi.fn();
+const getConfigMock = vi.fn();
+const setConfigMock = vi.fn();
+const patchConfigMock = vi.fn();
+const getConfigSchemaMock = vi.fn();
+const lookupConfigSchemaMock = vi.fn();
+
+const fakeGatewayClient = {
+  isConnected: true,
+  installSkill: installSkillMock,
+  updateSkill: updateSkillMock,
+  getSkillBins: getSkillBinsMock,
+  getConfig: getConfigMock,
+  setConfig: setConfigMock,
+  patchConfig: patchConfigMock,
+  getConfigSchema: getConfigSchemaMock,
+  lookupConfigSchema: lookupConfigSchemaMock,
+};
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handleMap.set(channel, handler);
+    }),
+  },
+}));
+
+vi.mock('../src/main/ws/index.js', () => ({
+  getGatewayClient: vi.fn((id: string) => (id === 'gw-1' ? fakeGatewayClient : null)),
+  getAllGatewayClients: vi.fn(() => new Map([['gw-1', fakeGatewayClient]])),
+  reconnectGateway: vi.fn(),
+}));
+
+vi.mock('../src/main/workspace/config.js', () => ({
+  readConfig: vi.fn(() => null),
+  ensureDeviceId: vi.fn(() => 'test-device'),
+}));
+
+vi.mock('../src/main/debug/index.js', () => ({
+  getDebugLogger: vi.fn(() => ({ emit: vi.fn() })),
+}));
+
+vi.mock('@clawwork/shared', () => ({
+  isClawWorkSession: vi.fn(() => true),
+  parseTaskIdFromSessionKey: vi.fn(() => 'task-1'),
+  parseAgentIdFromSessionKey: vi.fn(() => 'main'),
+}));
+
+vi.mock('@clawwork/core', () => ({
+  parseToolArgs: vi.fn(() => ({})),
+}));
+
+async function invoke(channel: string, payload: unknown): Promise<unknown> {
+  const handler = handleMap.get(channel);
+  if (!handler) throw new Error(`no handler registered for ${channel}`);
+  return handler({}, payload);
+}
+
+describe('ws-handlers: skills + config IPC channels', () => {
+  beforeEach(async () => {
+    handleMap.clear();
+    vi.clearAllMocks();
+    fakeGatewayClient.isConnected = true;
+
+    vi.resetModules();
+    const { registerWsHandlers } = await import('../src/main/ipc/ws-handlers.js');
+    registerWsHandlers();
+  });
+
+  it('registers all expected channels', () => {
+    const expected = [
+      'ws:skills-install',
+      'ws:skills-update',
+      'ws:skills-bins',
+      'ws:config-get',
+      'ws:config-set',
+      'ws:config-patch',
+      'ws:config-schema',
+      'ws:config-schema-lookup',
+    ];
+    for (const ch of expected) {
+      expect(handleMap.has(ch), `missing handler for ${ch}`).toBe(true);
+    }
+  });
+
+  describe('gateway error handling', () => {
+    it('returns GATEWAY_NOT_CONNECTED when gateway is disconnected', async () => {
+      fakeGatewayClient.isConnected = false;
+
+      const result = await invoke('ws:skills-install', { gatewayId: 'gw-1', source: 'clawhub', slug: 'test' });
+
+      expect(result).toEqual({ ok: false, error: 'gateway not connected', errorCode: 'GATEWAY_NOT_CONNECTED' });
+      expect(installSkillMock).not.toHaveBeenCalled();
+    });
+
+    it('returns GATEWAY_NOT_CONNECTED when gateway id is unknown', async () => {
+      const result = await invoke('ws:config-get', { gatewayId: 'nonexistent' });
+
+      expect(result).toEqual({ ok: false, error: 'gateway not connected', errorCode: 'GATEWAY_NOT_CONNECTED' });
+      expect(getConfigMock).not.toHaveBeenCalled();
+    });
+
+    it('surfaces gateway error code and details on RPC failure', async () => {
+      const err = Object.assign(new Error('install failed'), {
+        code: 'INSTALL_ERROR',
+        details: { bin: 'npm', reason: 'not found' },
+      });
+      installSkillMock.mockRejectedValue(err);
+
+      const result = await invoke('ws:skills-install', { gatewayId: 'gw-1', source: 'clawhub', slug: 'broken' });
+
+      expect(result).toEqual({
+        ok: false,
+        error: 'install failed',
+        errorCode: 'INSTALL_ERROR',
+        errorDetails: { bin: 'npm', reason: 'not found' },
+      });
+    });
+  });
+
+  describe('ws:skills-install', () => {
+    it('forwards clawhub install params without gatewayId', async () => {
+      installSkillMock.mockResolvedValue({ ok: true, message: 'installed', stdout: '', stderr: '', code: 0 });
+
+      const result = await invoke('ws:skills-install', {
+        gatewayId: 'gw-1',
+        source: 'clawhub',
+        slug: 'web-search',
+        version: '1.0.0',
+      });
+
+      const args = installSkillMock.mock.calls[0][0];
+      expect(args).toEqual({ source: 'clawhub', slug: 'web-search', version: '1.0.0' });
+      expect(args).not.toHaveProperty('gatewayId');
+      expect(result).toEqual({
+        ok: true,
+        result: { ok: true, message: 'installed', stdout: '', stderr: '', code: 0 },
+      });
+    });
+
+    it('forwards direct install params without gatewayId', async () => {
+      installSkillMock.mockResolvedValue({ ok: true, message: 'done', stdout: '', stderr: '', code: 0 });
+
+      await invoke('ws:skills-install', {
+        gatewayId: 'gw-1',
+        name: 'my-skill',
+        installId: 'brew',
+        timeoutMs: 30_000,
+      });
+
+      const args = installSkillMock.mock.calls[0][0];
+      expect(args).toEqual({ name: 'my-skill', installId: 'brew', timeoutMs: 30_000 });
+      expect(args).not.toHaveProperty('gatewayId');
+    });
+
+    it('forwards dangerouslyForceUnsafeInstall flag', async () => {
+      installSkillMock.mockResolvedValue({ ok: true, message: 'forced', stdout: '', stderr: '', code: 0 });
+
+      await invoke('ws:skills-install', {
+        gatewayId: 'gw-1',
+        name: 'risky-skill',
+        installId: 'npm',
+        dangerouslyForceUnsafeInstall: true,
+      });
+
+      expect(installSkillMock.mock.calls[0][0]).toMatchObject({ dangerouslyForceUnsafeInstall: true });
+    });
+  });
+
+  describe('ws:skills-update', () => {
+    it('forwards config update params without gatewayId', async () => {
+      updateSkillMock.mockResolvedValue({ ok: true, skillKey: 'web-search', config: { enabled: true } });
+
+      await invoke('ws:skills-update', {
+        gatewayId: 'gw-1',
+        skillKey: 'web-search',
+        enabled: true,
+        apiKey: 'sk-xxx',
+        env: { NODE_ENV: 'production' },
+      });
+
+      const args = updateSkillMock.mock.calls[0][0];
+      expect(args).toEqual({
+        skillKey: 'web-search',
+        enabled: true,
+        apiKey: 'sk-xxx',
+        env: { NODE_ENV: 'production' },
+      });
+      expect(args).not.toHaveProperty('gatewayId');
+    });
+
+    it('forwards clawhub update-all params without gatewayId', async () => {
+      updateSkillMock.mockResolvedValue({ ok: true });
+
+      await invoke('ws:skills-update', { gatewayId: 'gw-1', source: 'clawhub', all: true });
+
+      const args = updateSkillMock.mock.calls[0][0];
+      expect(args).toEqual({ source: 'clawhub', all: true });
+      expect(args).not.toHaveProperty('gatewayId');
+    });
+  });
+
+  describe('ws:skills-bins', () => {
+    it('calls getSkillBins with no arguments', async () => {
+      getSkillBinsMock.mockResolvedValue({ bins: ['node', 'python3', 'brew'] });
+
+      const result = await invoke('ws:skills-bins', { gatewayId: 'gw-1' });
+
+      expect(getSkillBinsMock).toHaveBeenCalledWith();
+      expect(result).toEqual({ ok: true, result: { bins: ['node', 'python3', 'brew'] } });
+    });
+  });
+
+  describe('ws:config-get', () => {
+    it('calls getConfig with no arguments', async () => {
+      const snapshot = { raw: '{}', hash: 'abc123', config: { model: 'claude' }, path: '/etc/openclaw.json5' };
+      getConfigMock.mockResolvedValue(snapshot);
+
+      const result = await invoke('ws:config-get', { gatewayId: 'gw-1' });
+
+      expect(getConfigMock).toHaveBeenCalledWith();
+      expect(result).toEqual({ ok: true, result: snapshot });
+    });
+  });
+
+  describe('ws:config-set', () => {
+    it('passes raw and baseHash without gatewayId', async () => {
+      setConfigMock.mockResolvedValue({ ok: true, path: '/etc/openclaw.json5', config: {} });
+
+      await invoke('ws:config-set', {
+        gatewayId: 'gw-1',
+        raw: '{ model: "claude" }',
+        baseHash: 'abc123',
+      });
+
+      const args = setConfigMock.mock.calls[0][0];
+      expect(args).toEqual({ raw: '{ model: "claude" }', baseHash: 'abc123' });
+      expect(args).not.toHaveProperty('gatewayId');
+    });
+
+    it('passes undefined baseHash when omitted', async () => {
+      setConfigMock.mockResolvedValue({ ok: true, path: '/etc/openclaw.json5', config: {} });
+
+      await invoke('ws:config-set', { gatewayId: 'gw-1', raw: '{}' });
+
+      expect(setConfigMock.mock.calls[0][0]).toEqual({ raw: '{}', baseHash: undefined });
+    });
+  });
+
+  describe('ws:config-patch', () => {
+    it('passes all fields explicitly without gatewayId', async () => {
+      patchConfigMock.mockResolvedValue({ ok: true, noop: false, path: '/etc/openclaw.json5', config: {} });
+
+      await invoke('ws:config-patch', {
+        gatewayId: 'gw-1',
+        raw: '{ model: "claude" }',
+        baseHash: 'abc123',
+        sessionKey: 'agent:main:clawwork:task:t1',
+        note: 'enable skill',
+        restartDelayMs: 2000,
+      });
+
+      const args = patchConfigMock.mock.calls[0][0];
+      expect(args).toEqual({
+        raw: '{ model: "claude" }',
+        baseHash: 'abc123',
+        sessionKey: 'agent:main:clawwork:task:t1',
+        note: 'enable skill',
+        restartDelayMs: 2000,
+      });
+      expect(args).not.toHaveProperty('gatewayId');
+    });
+
+    it('passes undefined for omitted optional fields', async () => {
+      patchConfigMock.mockResolvedValue({ ok: true, noop: true, path: '/etc/openclaw.json5', config: {} });
+
+      await invoke('ws:config-patch', { gatewayId: 'gw-1', raw: '{}' });
+
+      expect(patchConfigMock.mock.calls[0][0]).toEqual({
+        raw: '{}',
+        baseHash: undefined,
+        sessionKey: undefined,
+        note: undefined,
+        restartDelayMs: undefined,
+      });
+    });
+  });
+
+  describe('ws:config-schema', () => {
+    it('calls getConfigSchema with no arguments', async () => {
+      const schema = { schema: { type: 'object' }, uiHints: {}, version: '1.0', generatedAt: '2026-04-02' };
+      getConfigSchemaMock.mockResolvedValue(schema);
+
+      const result = await invoke('ws:config-schema', { gatewayId: 'gw-1' });
+
+      expect(getConfigSchemaMock).toHaveBeenCalledWith();
+      expect(result).toEqual({ ok: true, result: schema });
+    });
+  });
+
+  describe('ws:config-schema-lookup', () => {
+    it('passes path to lookupConfigSchema without gatewayId', async () => {
+      const lookupResult = {
+        path: 'model',
+        schema: { type: 'string' },
+        hint: { widget: 'select' },
+        children: [],
+      };
+      lookupConfigSchemaMock.mockResolvedValue(lookupResult);
+
+      const result = await invoke('ws:config-schema-lookup', { gatewayId: 'gw-1', path: 'model' });
+
+      expect(lookupConfigSchemaMock).toHaveBeenCalledWith('model');
+      expect(result).toEqual({ ok: true, result: lookupResult });
+    });
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -299,6 +299,83 @@ export interface SkillStatusReport {
   skills: SkillStatusEntry[];
 }
 
+export type SkillInstallParams =
+  | { name: string; installId: string; dangerouslyForceUnsafeInstall?: boolean; timeoutMs?: number }
+  | { source: 'clawhub'; slug: string; version?: string; force?: boolean; timeoutMs?: number };
+
+export interface SkillInstallResult {
+  ok: boolean;
+  message: string;
+  stdout: string;
+  stderr: string;
+  code: number;
+  slug?: string;
+  version?: string;
+  targetDir?: string;
+}
+
+export type SkillUpdateParams =
+  | { skillKey: string; enabled?: boolean; apiKey?: string; env?: Record<string, string> }
+  | { source: 'clawhub'; slug?: string; all?: boolean };
+
+export interface SkillUpdateResult {
+  ok: boolean;
+  skillKey?: string;
+  config?: Record<string, unknown>;
+}
+
+export interface SkillBinsResult {
+  bins: string[];
+}
+
+export interface ConfigSnapshot {
+  raw: string;
+  hash: string;
+  config: Record<string, unknown>;
+  path: string;
+}
+
+export interface ConfigSetParams {
+  raw: string;
+  baseHash?: string;
+}
+
+export interface ConfigPatchParams {
+  raw: string;
+  baseHash?: string;
+  sessionKey?: string;
+  note?: string;
+  restartDelayMs?: number;
+}
+
+export interface ConfigSetResult {
+  ok: boolean;
+  path: string;
+  config: Record<string, unknown>;
+}
+
+export interface ConfigPatchResult {
+  ok: boolean;
+  noop?: boolean;
+  path: string;
+  config: Record<string, unknown>;
+}
+
+export interface ConfigSchemaResult {
+  schema: unknown;
+  uiHints: Record<string, unknown>;
+  version: string;
+  generatedAt: string;
+}
+
+export interface ConfigSchemaLookupResult {
+  path: string;
+  schema: unknown;
+  hint?: unknown;
+  hintPath?: string;
+  children: Array<{ path: string; schema: unknown; hint?: unknown }>;
+}
+
 export interface SessionPatchParams {
   sessionKey: string;
   thinkingLevel?: string | null;


### PR DESCRIPTION
## Summary

Wire 8 new Gateway RPC methods through the 5-layer IPC pattern (shared types → gateway-client → ws-handlers → preload → d.ts), enabling one-click skill installation, skill configuration, and Gateway config management from the renderer.

## Type of change

- [x] `[Feat]` new feature

## Why is this needed?

Skill installation (`skills.install`), configuration (`skills.update`, `config.*`), and binary discovery (`skills.bins`) were missing from the desktop IPC bridge. Only `skills.status` was wired. Without these channels, the renderer cannot trigger skill installs, toggle skills, set API keys/env vars, or read/write Gateway configuration — all prerequisites for the upcoming skill management UI.

## What changed?

- **`packages/shared/src/types.ts`** — Added 11 types: `SkillInstallParams`, `SkillInstallResult`, `SkillUpdateParams`, `SkillUpdateResult`, `SkillBinsResult`, `ConfigSnapshot`, `ConfigSetParams`, `ConfigPatchParams`, `ConfigSetResult`, `ConfigPatchResult`, `ConfigSchemaResult`, `ConfigSchemaLookupResult`
- **`packages/desktop/src/main/ws/gateway-client.ts`** — Added 8 methods with inline strong types: `installSkill`, `updateSkill`, `getSkillBins`, `getConfig`, `setConfig`, `patchConfig`, `getConfigSchema`, `lookupConfigSchema`
- **`packages/desktop/src/main/ipc/ws-handlers.ts`** — Registered 8 IPC handlers (`ws:skills-install`, `ws:skills-update`, `ws:skills-bins`, `ws:config-get`, `ws:config-set`, `ws:config-patch`, `ws:config-schema`, `ws:config-schema-lookup`) with explicit payload field types
- **`packages/desktop/src/preload/index.ts`** — Exposed 8 typed bridge methods using shared param types
- **`packages/desktop/src/preload/clawwork.d.ts`** — Declared 8 methods on `ClawWorkAPI` with full `IpcResult<T>` return types
- **`packages/desktop/test/ws-handlers-skills-config.test.ts`** — 17 tests covering channel registration, gateway error handling, param forwarding, gatewayId leak prevention, and optional field handling

## Architecture impact

- Owning layer: shared / main / preload
- Cross-layer impact: yes — types defined in shared, consumed by main (gateway-client, ws-handlers) and preload (bridge, d.ts)
- Invariants touched from `docs/architecture-invariants.md`:
  - Single WS connection to Gateway via `sendReq`
  - `ipcMain.handle()` registered once at startup via `registerWsHandlers()`
  - Preload bridge exposes minimal API surface
  - Dependency direction: shared ← desktop
- Why those invariants remain protected: All 8 methods follow the exact same 5-layer wiring pattern as existing Agent CRUD and Cron APIs. No new IPC patterns introduced. Gateway-client methods use `sendReq` exclusively. No raw `ipcRenderer` exposed.

## Linked issues

Part of skill management feature track.

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate — lint, architecture, ui-contract, renderer-copy, i18n, dead-code, format, typecheck, test)
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check — all passed, 165 tests (including 17 new) green
```

## Screenshots or recordings

No UI changes in this PR.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate