### PR TITLE
[Feat] Local-first agent avatar with custom Electron protocol and fallback chain

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, Menu, ipcMain, globalShortcut, dialog } from 'electron';
+import { app, shell, BrowserWindow, Menu, ipcMain, globalShortcut, dialog, protocol } from 'electron';
 import { join } from 'path';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
 import { nativeTheme } from 'electron';
@@ -18,12 +18,17 @@ import { registerTrayHandlers } from './ipc/tray-handlers.js';
 import { registerQuickLaunchHandlers } from './ipc/quick-launch-handlers.js';
 import { registerContextHandlers } from './ipc/context-handlers.js';
 import { registerNotificationHandlers } from './ipc/notification-handlers.js';
+import { registerAvatarHandlers, registerAvatarProtocol } from './ipc/avatar-handlers.js';
 import { unwatchAll } from './context/file-watcher.js';
 import { isInstallingUpdate } from './auto-updater.js';
 import { initTray, destroyTray } from './tray.js';
 import { initQuickLaunch, destroyQuickLaunch } from './quick-launch.js';
 import { getWorkspacePath, readConfig, updateConfig } from './workspace/config.js';
 import { initDatabase, closeDatabase } from './db/index.js';
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'clawwork-avatar', privileges: { secure: true, supportFetchAPI: true } },
+]);
 
 let isQuitting = false;
 
@@ -184,6 +189,8 @@ app.whenReady().then(() => {
   registerQuickLaunchHandlers();
   registerContextHandlers();
   registerNotificationHandlers();
+  registerAvatarHandlers();
+  registerAvatarProtocol();
 
   ipcMain.handle('app:rebuild-menu', () => {
     const dm = readConfig()?.devMode === true;

--- a/packages/desktop/src/main/ipc/avatar-handlers.ts
+++ b/packages/desktop/src/main/ipc/avatar-handlers.ts
@@ -1,0 +1,121 @@
+import { app, ipcMain, net, protocol } from 'electron';
+import { join, extname } from 'path';
+import { mkdir, writeFile, readdir, unlink } from 'fs/promises';
+import { pathToFileURL } from 'url';
+import { getDebugLogger } from '../debug/index.js';
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/svg+xml': '.svg',
+};
+
+const VALID_EXT = new Set(Object.values(MIME_TO_EXT));
+
+const ID_PATTERN = /^[\w][\w.:-]*$/;
+
+function avatarsDir(): string {
+  return join(app.getPath('userData'), 'avatars');
+}
+
+function gatewayDir(gatewayId: string): string {
+  return join(avatarsDir(), gatewayId);
+}
+
+function validateId(value: string): boolean {
+  return ID_PATTERN.test(value) && !value.includes('..');
+}
+
+async function findAvatarFile(gatewayId: string, agentId: string): Promise<string | null> {
+  const dir = gatewayDir(gatewayId);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  const prefix = `${agentId}.`;
+  const match = entries.find((f) => f.startsWith(prefix) && VALID_EXT.has(extname(f)));
+  return match ? join(dir, match) : null;
+}
+
+async function removeExisting(gatewayId: string, agentId: string): Promise<void> {
+  const existing = await findAvatarFile(gatewayId, agentId);
+  if (existing) await unlink(existing);
+}
+
+export function registerAvatarProtocol(): void {
+  protocol.handle('clawwork-avatar', async (request) => {
+    try {
+      const url = new URL(request.url);
+      const gatewayId = decodeURIComponent(url.hostname);
+      const agentId = decodeURIComponent(url.pathname.slice(1));
+      if (!validateId(gatewayId) || !validateId(agentId)) {
+        return new Response('invalid id', { status: 400 });
+      }
+      const filePath = await findAvatarFile(gatewayId, agentId);
+      if (!filePath) return new Response('not found', { status: 404 });
+      return net.fetch(pathToFileURL(filePath).toString());
+    } catch {
+      return new Response('error', { status: 500 });
+    }
+  });
+}
+
+export function registerAvatarHandlers(): void {
+  ipcMain.handle('avatar:save', async (_event, payload: { gatewayId: string; agentId: string; dataUrl: string }) => {
+    const { gatewayId, agentId, dataUrl } = payload;
+    if (!validateId(gatewayId) || !validateId(agentId)) {
+      return { ok: false, error: 'invalid id' };
+    }
+    const mimeMatch = dataUrl.match(/^data:(image\/[\w+.-]+);base64,/);
+    if (!mimeMatch) return { ok: false, error: 'invalid data URL' };
+    const mime = mimeMatch[1];
+    const ext = MIME_TO_EXT[mime];
+    if (!ext) return { ok: false, error: `unsupported MIME type: ${mime}` };
+    const base64 = dataUrl.slice(mimeMatch[0].length);
+    const buffer = Buffer.from(base64, 'base64');
+    const dir = gatewayDir(gatewayId);
+    await mkdir(dir, { recursive: true });
+    await removeExisting(gatewayId, agentId);
+    const filePath = join(dir, `${agentId}${ext}`);
+    await writeFile(filePath, buffer);
+    getDebugLogger().info({
+      domain: 'avatar',
+      event: 'avatar.saved',
+      data: { gatewayId, agentId, size: buffer.length },
+    });
+    return { ok: true };
+  });
+
+  ipcMain.handle('avatar:delete', async (_event, payload: { gatewayId: string; agentId: string }) => {
+    const { gatewayId, agentId } = payload;
+    if (!validateId(gatewayId) || !validateId(agentId)) {
+      return { ok: false, error: 'invalid id' };
+    }
+    try {
+      await removeExisting(gatewayId, agentId);
+      return { ok: true };
+    } catch {
+      return { ok: true };
+    }
+  });
+
+  ipcMain.handle('avatar:list-local', async (_event, payload: { gatewayId: string }) => {
+    const { gatewayId } = payload;
+    if (!validateId(gatewayId)) return { ok: true, result: [] };
+    const dir = gatewayDir(gatewayId);
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return { ok: true, result: [] };
+    }
+    const agentIds = entries
+      .filter((f) => VALID_EXT.has(extname(f)))
+      .map((f) => f.slice(0, f.length - extname(f).length));
+    return { ok: true, result: agentIds };
+  });
+}

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -457,6 +457,10 @@ export interface ClawWorkAPI {
   removeCronJob: (gatewayId: string, jobId: string) => Promise<IpcResult>;
   runCronJob: (gatewayId: string, jobId: string, mode?: 'due' | 'force') => Promise<IpcResult<CronRunResult>>;
   listCronRuns: (gatewayId: string, params?: CronRunsParams) => Promise<IpcResult>;
+
+  saveAgentAvatar: (gatewayId: string, agentId: string, dataUrl: string) => Promise<IpcResult>;
+  deleteAgentAvatar: (gatewayId: string, agentId: string) => Promise<IpcResult>;
+  listLocalAvatars: (gatewayId: string) => Promise<IpcResult<{ result: string[] }>>;
 }
 
 declare global {

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -349,6 +349,12 @@ function buildApi(): ClawWorkAPI {
       ipcRenderer.invoke('ws:cron-run', { gatewayId, jobId, mode }),
     listCronRuns: (gatewayId: string, params?: CronRunsParams) =>
       ipcRenderer.invoke('ws:cron-runs', { gatewayId, ...params }),
+
+    saveAgentAvatar: (gatewayId: string, agentId: string, dataUrl: string) =>
+      ipcRenderer.invoke('avatar:save', { gatewayId, agentId, dataUrl }),
+    deleteAgentAvatar: (gatewayId: string, agentId: string) =>
+      ipcRenderer.invoke('avatar:delete', { gatewayId, agentId }),
+    listLocalAvatars: (gatewayId: string) => ipcRenderer.invoke('avatar:list-local', { gatewayId }),
   };
 }
 

--- a/packages/desktop/src/renderer/components/AgentIcon.tsx
+++ b/packages/desktop/src/renderer/components/AgentIcon.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { Bot } from 'lucide-react';
+
+interface AgentIconProps {
+  gatewayId?: string | null;
+  agentId: string;
+  gatewayAvatarUrl?: string;
+  emoji?: string;
+  imgClass?: string;
+  emojiClass?: string;
+  iconSize?: number;
+  iconClass?: string;
+}
+
+export default function AgentIcon({
+  gatewayId,
+  agentId,
+  gatewayAvatarUrl,
+  emoji,
+  imgClass = 'w-4 h-4 rounded-full object-cover',
+  emojiClass = 'emoji-sm',
+  iconSize = 14,
+  iconClass = 'text-[var(--accent)]',
+}: AgentIconProps) {
+  const [failCount, setFailCount] = useState(0);
+  const localUrl = gatewayId ? `clawwork-avatar://${gatewayId}/${agentId}` : undefined;
+  const urls = [localUrl, gatewayAvatarUrl].filter(Boolean) as string[];
+  const resolved = urls[failCount];
+
+  if (resolved) {
+    return <img src={resolved} alt="" className={imgClass} onError={() => setFailCount((c) => c + 1)} />;
+  }
+  if (emoji) return <span className={emojiClass}>{emoji}</span>;
+  return <Bot size={iconSize} className={iconClass} />;
+}

--- a/packages/desktop/src/renderer/components/ChatInput/index.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput/index.tsx
@@ -2,7 +2,6 @@ import { useRef, useCallback, useState, useEffect, useMemo, type KeyboardEvent }
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import {
-  Bot,
   Send,
   Square,
   X,
@@ -20,6 +19,7 @@ import {
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { motion as motionPresets, motionDuration } from '@/styles/design-tokens';
+import AgentIcon from '@/components/AgentIcon';
 import ToolbarButton from '@/components/semantic/ToolbarButton';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -84,11 +84,12 @@ export default function ChatInput() {
         agentName: p.agentName,
         emoji: p.emoji,
         avatarUrl: catalogEntry?.identity?.avatarUrl,
+        gatewayId: activeTaskGatewayId,
         sessionKey: p.sessionKey,
       });
     }
     return [...byAgent.values()];
-  }, [performers, agentCatalog]);
+  }, [performers, agentCatalog, activeTaskGatewayId]);
 
   const {
     slashMenuVisible,
@@ -537,10 +538,16 @@ export default function ChatInput() {
                       >
                         {a.agentId === MENTION_ALL_AGENT_ID ? (
                           <Users size={14} className="flex-shrink-0" />
-                        ) : a.emoji ? (
-                          <span className="emoji-sm">{a.emoji}</span>
                         ) : (
-                          <Bot size={14} className="flex-shrink-0" />
+                          <span className="flex-shrink-0">
+                            <AgentIcon
+                              gatewayId={a.gatewayId}
+                              agentId={a.agentId}
+                              gatewayAvatarUrl={a.avatarUrl}
+                              emoji={a.emoji}
+                              imgClass="w-3.5 h-3.5 rounded-full object-cover"
+                            />
+                          </span>
                         )}
                         {a.agentName}
                         <button

--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -18,6 +18,8 @@ interface ChatMessageProps {
   message: Message;
   agentName?: string;
   agentEmoji?: string;
+  localAvatarUrl?: string;
+  gatewayAvatarUrl?: string;
   agentRoleLabel?: string;
   highlighted?: boolean;
   onHighlightDone?: () => void;
@@ -154,6 +156,8 @@ const ChatMessage = memo(function ChatMessage({
   message,
   agentName,
   agentEmoji,
+  localAvatarUrl,
+  gatewayAvatarUrl,
   agentRoleLabel,
   highlighted,
   onHighlightDone,
@@ -237,7 +241,12 @@ const ChatMessage = memo(function ChatMessage({
         highlighted && 'animate-highlight rounded-lg',
       )}
     >
-      <MessageAvatar role={isUser ? 'user' : 'assistant'} agentEmoji={agentEmoji} />
+      <MessageAvatar
+        role={isUser ? 'user' : 'assistant'}
+        agentEmoji={agentEmoji}
+        localAvatarUrl={localAvatarUrl}
+        gatewayAvatarUrl={gatewayAvatarUrl}
+      />
 
       <div className={cn('min-w-0 flex-1', isUser && 'text-right')}>
         {!isUser && (agentName || agentRoleLabel) && (

--- a/packages/desktop/src/renderer/components/MentionPicker.tsx
+++ b/packages/desktop/src/renderer/components/MentionPicker.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { Task, Artifact, FileIndexEntry } from '@clawwork/shared';
 import { useFileStore } from '@/stores/fileStore';
 import { cn, formatFileSize } from '@/lib/utils';
+import AgentIcon from './AgentIcon';
 import { MENTION_ALL_AGENT_ID } from './ChatInput/constants';
 
 export type MentionTab = 'local' | 'tasks' | 'files' | 'agents';
@@ -13,6 +14,7 @@ export interface AgentMentionEntry {
   agentName: string;
   emoji?: string;
   avatarUrl?: string;
+  gatewayId?: string;
   sessionKey: string;
 }
 
@@ -198,12 +200,17 @@ export default function MentionPicker({
               >
                 {a.agentId === MENTION_ALL_AGENT_ID ? (
                   <Users size={14} className="text-[var(--accent)] flex-shrink-0" />
-                ) : a.avatarUrl ? (
-                  <img src={a.avatarUrl} alt="" className="w-4 h-4 rounded-full object-cover flex-shrink-0" />
-                ) : a.emoji ? (
-                  <span className="emoji-sm flex-shrink-0">{a.emoji}</span>
                 ) : (
-                  <Bot size={14} className="text-[var(--accent)] flex-shrink-0" />
+                  <span className="flex-shrink-0">
+                    <AgentIcon
+                      gatewayId={a.gatewayId}
+                      agentId={a.agentId}
+                      gatewayAvatarUrl={a.avatarUrl}
+                      emoji={a.emoji}
+                      imgClass="w-4 h-4 rounded-full object-cover"
+                      iconClass="text-[var(--accent)]"
+                    />
+                  </span>
                 )}
                 <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{a.agentName}</span>
                 <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{a.agentId}</span>

--- a/packages/desktop/src/renderer/components/MessageAvatar.tsx
+++ b/packages/desktop/src/renderer/components/MessageAvatar.tsx
@@ -1,21 +1,36 @@
+import { useState } from 'react';
 import { Bot, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface MessageAvatarProps {
   role: 'user' | 'assistant';
   agentEmoji?: string;
+  localAvatarUrl?: string;
+  gatewayAvatarUrl?: string;
 }
 
-export default function MessageAvatar({ role, agentEmoji }: MessageAvatarProps) {
+export default function MessageAvatar({ role, agentEmoji, localAvatarUrl, gatewayAvatarUrl }: MessageAvatarProps) {
+  const [failCount, setFailCount] = useState(0);
+  const urls = [localAvatarUrl, gatewayAvatarUrl].filter(Boolean) as string[];
+  const avatarUrl = urls[failCount];
+  const showImg = role === 'assistant' && avatarUrl;
+
   return (
     <div
       className={cn(
-        'flex-shrink-0 size-[var(--density-avatar-size)] rounded-full flex items-center justify-center',
-        role === 'user' ? 'bg-[var(--bg-tertiary)]' : 'bg-[var(--accent-dim)]',
+        'flex-shrink-0 size-[var(--density-avatar-size)] rounded-full flex items-center justify-center overflow-hidden',
+        role === 'user' ? 'bg-[var(--bg-tertiary)]' : !showImg && 'bg-[var(--accent-dim)]',
       )}
     >
       {role === 'user' ? (
         <User className="size-[calc(var(--density-avatar-size)*0.6)] text-[var(--text-secondary)]" />
+      ) : showImg ? (
+        <img
+          src={avatarUrl}
+          alt=""
+          className="size-[var(--density-avatar-size)] rounded-full object-cover"
+          onError={() => setFailCount((c) => c + 1)}
+        />
       ) : agentEmoji ? (
         <span className="emoji-md leading-none">{agentEmoji}</span>
       ) : (

--- a/packages/desktop/src/renderer/components/StreamingMessage.tsx
+++ b/packages/desktop/src/renderer/components/StreamingMessage.tsx
@@ -12,6 +12,8 @@ interface StreamingMessageProps {
   thinkingContent?: string;
   toolCalls?: ToolCall[];
   agentEmoji?: string;
+  localAvatarUrl?: string;
+  gatewayAvatarUrl?: string;
   agentName?: string;
   agentRoleLabel?: string;
 }
@@ -21,6 +23,8 @@ const StreamingMessage = memo(function StreamingMessage({
   thinkingContent,
   toolCalls,
   agentEmoji,
+  localAvatarUrl,
+  gatewayAvatarUrl,
   agentName,
   agentRoleLabel,
 }: StreamingMessageProps) {
@@ -39,7 +43,12 @@ const StreamingMessage = memo(function StreamingMessage({
       transition={motionPresets.fadeIn.transition}
       className="flex gap-3.5 py-4"
     >
-      <MessageAvatar role="assistant" agentEmoji={agentEmoji} />
+      <MessageAvatar
+        role="assistant"
+        agentEmoji={agentEmoji}
+        localAvatarUrl={localAvatarUrl}
+        gatewayAvatarUrl={gatewayAvatarUrl}
+      />
       <div className="min-w-0 flex-1">
         {(agentName || agentRoleLabel) && (
           <div className="mb-1.5 flex min-w-0 flex-wrap items-center gap-2 text-[var(--text-muted)]">

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -9,7 +9,6 @@ import {
   Search,
   MessageSquare,
   Server,
-  Bot,
   ArrowUp,
   ArrowDown,
   ChevronRight,
@@ -36,6 +35,7 @@ import ChatMessage from '@/components/ChatMessage';
 import StreamingMessage from '@/components/StreamingMessage';
 import ThinkingIndicator from '@/components/ThinkingIndicator';
 import ChatInput from '@/components/ChatInput';
+import AgentIcon from '@/components/AgentIcon';
 import ImageLightbox from '@/components/ImageLightbox';
 import FilePreviewModal from '@/components/FilePreviewModal';
 import FileBrowser from '../FileBrowser';
@@ -64,13 +64,21 @@ interface ArchivedTaskRow {
 interface AssistantIdentity {
   agentName?: string;
   agentEmoji?: string;
+  localAvatarUrl?: string;
+  gatewayAvatarUrl?: string;
   agentRoleLabel?: string;
+}
+
+function buildLocalAvatarUrl(gatewayId: string | undefined, agentId: string | undefined): string | undefined {
+  if (!gatewayId || !agentId) return undefined;
+  return `clawwork-avatar://${gatewayId}/${agentId}`;
 }
 
 function resolveAssistantIdentity({
   task,
   sessionKey,
   agentId,
+  gatewayId,
   performerBySessionKey,
   performerByAgentId,
   catalogAgentById,
@@ -79,9 +87,10 @@ function resolveAssistantIdentity({
   task?: { sessionKey: string; agentId?: string; ensemble?: boolean };
   sessionKey?: string;
   agentId?: string;
+  gatewayId?: string;
   performerBySessionKey: Map<string, { sessionKey: string; agentId: string; agentName: string; emoji?: string }>;
   performerByAgentId: Map<string, { sessionKey: string; agentId: string; agentName: string; emoji?: string }>;
-  catalogAgentById: Map<string, { id: string; name?: string; identity?: { emoji?: string } }>;
+  catalogAgentById: Map<string, { id: string; name?: string; identity?: { emoji?: string; avatarUrl?: string } }>;
   conductorLabel: string;
 }): AssistantIdentity {
   const resolvedAgentId = agentId ?? (sessionKey ? parseAgentIdFromSessionKey(sessionKey) : undefined);
@@ -99,10 +108,13 @@ function resolveAssistantIdentity({
   );
 
   if (isConductor) {
+    const targetId = conductorAgentId ?? resolvedAgentId;
     const agentName = conductorCatalogEntry?.name ?? catalogEntry?.name ?? conductorAgentId ?? conductorLabel;
     return {
       agentName,
       agentEmoji: conductorCatalogEntry?.identity?.emoji ?? catalogEntry?.identity?.emoji,
+      localAvatarUrl: buildLocalAvatarUrl(gatewayId, targetId),
+      gatewayAvatarUrl: conductorCatalogEntry?.identity?.avatarUrl ?? catalogEntry?.identity?.avatarUrl,
       agentRoleLabel: agentName === conductorLabel ? undefined : conductorLabel,
     };
   }
@@ -110,6 +122,8 @@ function resolveAssistantIdentity({
   return {
     agentName: performer?.agentName ?? catalogEntry?.name ?? resolvedAgentId,
     agentEmoji: performer?.emoji ?? catalogEntry?.identity?.emoji,
+    localAvatarUrl: buildLocalAvatarUrl(gatewayId, resolvedAgentId),
+    gatewayAvatarUrl: catalogEntry?.identity?.avatarUrl,
   };
 }
 
@@ -238,13 +252,15 @@ function WelcomeScreen() {
                   : 'border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]',
               )}
             >
-              {agent.identity?.avatarUrl ? (
-                <img src={agent.identity.avatarUrl} alt="" className="w-3.5 h-3.5 rounded-full object-cover" />
-              ) : agent.identity?.emoji ? (
-                <span className="emoji-sm">{agent.identity.emoji}</span>
-              ) : (
-                <Bot size={12} />
-              )}
+              <AgentIcon
+                gatewayId={selectedGwId}
+                agentId={agent.id}
+                gatewayAvatarUrl={agent.identity?.avatarUrl}
+                emoji={agent.identity?.emoji}
+                imgClass="w-3.5 h-3.5 rounded-full object-cover"
+                emojiClass="emoji-sm"
+                iconSize={12}
+              />
               <span className="max-w-24 truncate">{agent.name ?? agent.id}</span>
             </button>
           ))}
@@ -692,6 +708,7 @@ function ChatContent() {
                       task: activeTask,
                       sessionKey: item.message.sessionKey,
                       agentId: item.message.agentId,
+                      gatewayId: activeTask?.gatewayId,
                       performerBySessionKey,
                       performerByAgentId,
                       catalogAgentById,
@@ -707,6 +724,8 @@ function ChatContent() {
                     message={item.message}
                     agentName={identity?.agentName}
                     agentEmoji={identity?.agentEmoji}
+                    localAvatarUrl={identity?.localAvatarUrl}
+                    gatewayAvatarUrl={identity?.gatewayAvatarUrl}
                     agentRoleLabel={identity?.agentRoleLabel}
                     highlighted={item.message.id === highlightedId}
                     onHighlightDone={handleHighlightDone}
@@ -722,6 +741,7 @@ function ChatContent() {
                 task: activeTask,
                 sessionKey: item.sessionKey,
                 agentId: parseAgentIdFromSessionKey(item.sessionKey),
+                gatewayId: activeTask?.gatewayId,
                 performerBySessionKey,
                 performerByAgentId,
                 catalogAgentById,
@@ -733,6 +753,8 @@ function ChatContent() {
                   message={activeTurnToMessage(item.turn, activeTaskId!, item.sessionKey)}
                   agentName={identity.agentName}
                   agentEmoji={identity.agentEmoji}
+                  localAvatarUrl={identity.localAvatarUrl}
+                  gatewayAvatarUrl={identity.gatewayAvatarUrl}
                   agentRoleLabel={identity.agentRoleLabel}
                   highlighted={false}
                   onHighlightDone={handleHighlightDone}
@@ -747,6 +769,7 @@ function ChatContent() {
                 task: activeTask,
                 sessionKey: item.sessionKey,
                 agentId: parseAgentIdFromSessionKey(item.sessionKey),
+                gatewayId: activeTask?.gatewayId,
                 performerBySessionKey,
                 performerByAgentId,
                 catalogAgentById,
@@ -759,6 +782,8 @@ function ChatContent() {
                   thinkingContent={item.turn.streamingThinking || undefined}
                   toolCalls={item.turn.toolCalls}
                   agentEmoji={identity.agentEmoji}
+                  localAvatarUrl={identity.localAvatarUrl}
+                  gatewayAvatarUrl={identity.gatewayAvatarUrl}
                   agentName={identity.agentName}
                   agentRoleLabel={identity.agentRoleLabel}
                 />

--- a/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
@@ -60,6 +60,7 @@ const inputClass = cn(
 
 function AgentCard({
   agent,
+  gatewayId,
   isDefault,
   isEditing,
   workspace,
@@ -85,6 +86,7 @@ function AgentCard({
   onEditFileContentChange,
 }: {
   agent: AgentInfo;
+  gatewayId: string | null;
   isDefault: boolean;
   isEditing: boolean;
   workspace: string | null;
@@ -111,6 +113,10 @@ function AgentCard({
 }) {
   const { t } = useTranslation();
   const emoji = agent.identity?.emoji;
+  const localAvatarUrl = gatewayId ? `clawwork-avatar://${gatewayId}/${agent.id}` : undefined;
+  const [avatarFails, setAvatarFails] = useState(0);
+  const avatarUrls = [localAvatarUrl, agent.identity?.avatarUrl].filter(Boolean) as string[];
+  const resolvedAvatar = avatarUrls[avatarFails];
   const availableSkills = skills.filter((skill) => skill.eligible);
   const unavailableSkills = skills.filter((skill) => !skill.eligible);
   const [collapsedSections, setCollapsedSections] = useState<Record<'available' | 'unavailable', boolean>>({
@@ -162,8 +168,13 @@ function AgentCard({
             isDefault ? 'bg-[var(--accent-soft)]' : 'bg-[var(--bg-tertiary)]',
           )}
         >
-          {agent.identity?.avatarUrl ? (
-            <img src={agent.identity.avatarUrl} alt="" className="w-9 h-9 rounded-lg object-cover" />
+          {resolvedAvatar ? (
+            <img
+              src={resolvedAvatar}
+              alt=""
+              className="w-9 h-9 rounded-lg object-cover"
+              onError={() => setAvatarFails((c) => c + 1)}
+            />
           ) : emoji ? (
             <span className="emoji-lg">{emoji}</span>
           ) : (
@@ -755,16 +766,18 @@ export default function AgentsSection() {
   const openEditForm = useCallback(
     (agent: AgentInfo) => {
       setEditingAgentId(agent.id);
+      const gatewayAvatar = agent.identity?.avatarUrl ?? agent.identity?.avatar ?? '';
+      const localAvatar = selectedGatewayId ? `clawwork-avatar://${selectedGatewayId}/${agent.id}` : '';
       setForm({
         name: agent.name ?? agent.id,
         workspace: agentWorkspaceMap[agent.id] ?? '',
-        avatar: agent.identity?.avatarUrl ?? agent.identity?.avatar ?? '',
+        avatar: gatewayAvatar || localAvatar,
         model: '',
       });
       setShowForm(true);
       fetchAgentMeta(agent.id);
     },
-    [agentWorkspaceMap, fetchAgentMeta],
+    [agentWorkspaceMap, selectedGatewayId, fetchAgentMeta],
   );
 
   useEffect(() => {
@@ -792,16 +805,20 @@ export default function AgentsSection() {
       return;
     }
 
+    const isNewUpload = form.avatar.startsWith('data:');
     setSaving(true);
     if (editingAgentId) {
       const res = await window.clawwork.updateAgent(selectedGatewayId, {
         agentId: editingAgentId,
         name: form.name.trim() || undefined,
         workspace: form.workspace.trim() || undefined,
-        avatar: form.avatar || undefined,
+        avatar: isNewUpload ? form.avatar : undefined,
         model: form.model.trim() || undefined,
       });
       if (res.ok) {
+        if (isNewUpload) {
+          window.clawwork.saveAgentAvatar(selectedGatewayId, editingAgentId, form.avatar).catch(() => {});
+        }
         toast.success(t('settings.agentUpdated'));
         closeForm();
         await refreshAgents();
@@ -812,7 +829,7 @@ export default function AgentsSection() {
       const res = await window.clawwork.createAgent(selectedGatewayId, {
         name: form.name.trim(),
         workspace: form.workspace.trim(),
-        avatar: form.avatar || undefined,
+        avatar: isNewUpload ? form.avatar : undefined,
       });
       if (res.ok) {
         const created = res.result as Record<string, unknown> | undefined;
@@ -822,6 +839,9 @@ export default function AgentsSection() {
             agentId: newAgentId,
             model: form.model.trim(),
           });
+        }
+        if (isNewUpload && newAgentId) {
+          window.clawwork.saveAgentAvatar(selectedGatewayId, newAgentId, form.avatar).catch(() => {});
         }
         toast.success(t('settings.agentCreated'));
         closeForm();
@@ -840,6 +860,7 @@ export default function AgentsSection() {
       deleteFiles,
     });
     if (res.ok) {
+      window.clawwork.deleteAgentAvatar(selectedGatewayId, deletingAgentId).catch(() => {});
       toast.success(t('settings.agentDeleted'));
       if (expandedFilesAgentId === deletingAgentId) {
         setExpandedFilesAgentId(null);
@@ -999,6 +1020,7 @@ export default function AgentsSection() {
               <Fragment key={agent.id}>
                 <AgentCard
                   agent={agent}
+                  gatewayId={selectedGatewayId}
                   isDefault={agent.id === defaultAgentId}
                   isEditing={editingAgentId === agent.id && showForm}
                   workspace={agentWorkspaceMap[agent.id] ?? null}

--- a/packages/desktop/test/avatar-handlers.test.ts
+++ b/packages/desktop/test/avatar-handlers.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+let protocolHandler: ((request: { url: string }) => Promise<Response>) | null = null;
+
+const mkdirMock = vi.fn();
+const writeFileMock = vi.fn();
+const readdirMock = vi.fn<() => Promise<string[]>>(() => Promise.resolve([]));
+const unlinkMock = vi.fn();
+const netFetchMock = vi.fn(() => new Response('ok'));
+const debugInfoMock = vi.fn();
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/mock-userData' },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handleMap.set(channel, handler);
+    }),
+  },
+  net: { fetch: (...args: unknown[]) => netFetchMock(...args) },
+  protocol: {
+    handle: vi.fn((_scheme: string, handler: (req: { url: string }) => Promise<Response>) => {
+      protocolHandler = handler;
+    }),
+  },
+}));
+
+vi.mock('fs/promises', () => ({
+  mkdir: (...args: unknown[]) => mkdirMock(...args),
+  writeFile: (...args: unknown[]) => writeFileMock(...args),
+  readdir: (...args: unknown[]) => readdirMock(...args),
+  unlink: (...args: unknown[]) => unlinkMock(...args),
+}));
+
+vi.mock('../src/main/debug/index.js', () => ({
+  getDebugLogger: () => ({ info: debugInfoMock, error: vi.fn(), warn: vi.fn(), debug: vi.fn() }),
+}));
+
+const PNG_1x1 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('avatar handlers', () => {
+  beforeEach(async () => {
+    handleMap.clear();
+    protocolHandler = null;
+    vi.clearAllMocks();
+    readdirMock.mockResolvedValue([]);
+
+    const mod = await import('../src/main/ipc/avatar-handlers.js');
+    mod.registerAvatarHandlers();
+    mod.registerAvatarProtocol();
+  });
+
+  describe('avatar:save', () => {
+    it('saves a valid PNG data URL to disk', async () => {
+      const handler = handleMap.get('avatar:save')!;
+      const result = await handler({}, { gatewayId: 'gw1', agentId: 'agent1', dataUrl: PNG_1x1 });
+
+      expect(result).toEqual({ ok: true });
+      expect(mkdirMock).toHaveBeenCalledWith(expect.stringContaining('gw1'), { recursive: true });
+      expect(writeFileMock).toHaveBeenCalledWith(expect.stringMatching(/agent1\.png$/), expect.any(Buffer));
+      expect(debugInfoMock).toHaveBeenCalledWith(expect.objectContaining({ domain: 'avatar', event: 'avatar.saved' }));
+    });
+
+    it('removes existing avatar before saving new one', async () => {
+      readdirMock.mockResolvedValue(['agent1.jpg']);
+
+      const handler = handleMap.get('avatar:save')!;
+      await handler({}, { gatewayId: 'gw1', agentId: 'agent1', dataUrl: PNG_1x1 });
+
+      expect(unlinkMock).toHaveBeenCalledWith(expect.stringMatching(/agent1\.jpg$/));
+      expect(writeFileMock).toHaveBeenCalledWith(expect.stringMatching(/agent1\.png$/), expect.any(Buffer));
+    });
+
+    it('rejects traversal IDs', async () => {
+      const handler = handleMap.get('avatar:save')!;
+      const result = await handler({}, { gatewayId: '../etc', agentId: 'a', dataUrl: PNG_1x1 });
+      expect(result).toEqual({ ok: false, error: 'invalid id' });
+      expect(writeFileMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid data URL', async () => {
+      const handler = handleMap.get('avatar:save')!;
+      const result = await handler({}, { gatewayId: 'gw1', agentId: 'a', dataUrl: 'not-a-data-url' });
+      expect(result).toEqual({ ok: false, error: 'invalid data URL' });
+    });
+
+    it('rejects unsupported MIME type', async () => {
+      const handler = handleMap.get('avatar:save')!;
+      const result = await handler(
+        {},
+        {
+          gatewayId: 'gw1',
+          agentId: 'a',
+          dataUrl: 'data:image/bmp;base64,AA==',
+        },
+      );
+      expect(result).toEqual({ ok: false, error: 'unsupported MIME type: image/bmp' });
+    });
+  });
+
+  describe('avatar:delete', () => {
+    it('deletes an existing avatar file', async () => {
+      readdirMock.mockResolvedValue(['agent1.png']);
+      const handler = handleMap.get('avatar:delete')!;
+      const result = await handler({}, { gatewayId: 'gw1', agentId: 'agent1' });
+      expect(result).toEqual({ ok: true });
+      expect(unlinkMock).toHaveBeenCalledWith(expect.stringMatching(/agent1\.png$/));
+    });
+
+    it('succeeds even when no avatar exists', async () => {
+      const handler = handleMap.get('avatar:delete')!;
+      const result = await handler({}, { gatewayId: 'gw1', agentId: 'agent1' });
+      expect(result).toEqual({ ok: true });
+      expect(unlinkMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects traversal IDs', async () => {
+      const handler = handleMap.get('avatar:delete')!;
+      const result = await handler({}, { gatewayId: 'gw1', agentId: '../../passwd' });
+      expect(result).toEqual({ ok: false, error: 'invalid id' });
+    });
+  });
+
+  describe('avatar:list-local', () => {
+    it('returns agent IDs with valid image extensions', async () => {
+      readdirMock.mockResolvedValue(['agent1.png', 'agent2.jpg', 'readme.txt']);
+      const handler = handleMap.get('avatar:list-local')!;
+      const result = (await handler({}, { gatewayId: 'gw1' })) as { ok: boolean; result: string[] };
+      expect(result.ok).toBe(true);
+      expect(result.result).toEqual(['agent1', 'agent2']);
+    });
+
+    it('returns empty array when directory does not exist', async () => {
+      readdirMock.mockRejectedValue(new Error('ENOENT'));
+      const handler = handleMap.get('avatar:list-local')!;
+      const result = await handler({}, { gatewayId: 'gw1' });
+      expect(result).toEqual({ ok: true, result: [] });
+    });
+
+    it('returns empty array for invalid gateway ID', async () => {
+      const handler = handleMap.get('avatar:list-local')!;
+      const result = await handler({}, { gatewayId: '../bad' });
+      expect(result).toEqual({ ok: true, result: [] });
+    });
+  });
+
+  describe('clawwork-avatar protocol', () => {
+    it('serves an existing avatar via net.fetch', async () => {
+      readdirMock.mockResolvedValue(['agent1.png']);
+      const resp = await protocolHandler!({ url: 'clawwork-avatar://gw1/agent1' });
+      expect(netFetchMock).toHaveBeenCalledWith(expect.stringContaining('agent1.png'));
+      expect(resp).toBeTruthy();
+    });
+
+    it('returns 404 when no avatar file exists', async () => {
+      const resp = await protocolHandler!({ url: 'clawwork-avatar://gw1/missing' });
+      expect(resp.status).toBe(404);
+    });
+
+    it('returns 400 for invalid IDs', async () => {
+      const resp = await protocolHandler!({ url: 'clawwork-avatar://..%2F..%2Fetc/passwd' });
+      expect(resp.status).toBe(400);
+    });
+  });
+});

--- a/packages/shared/src/debug.ts
+++ b/packages/shared/src/debug.ts
@@ -14,7 +14,8 @@ export type DebugDomain =
   | 'debug'
   | 'tray'
   | 'quick-launch'
-  | 'updater';
+  | 'updater'
+  | 'avatar';
 
 export interface DebugError {
   name?: string;


### PR DESCRIPTION
## Summary

Implement a local-first agent avatar system using a custom Electron protocol (`clawwork-avatar://`), with a unified fallback chain across all 8 display sites: local file → gateway URL → emoji → Bot icon.

## Type of change

- [x] `[Feat]` new feature

## Why is this needed?

Agent avatars were previously fetched only from the Gateway URL, which meant avatars were unavailable offline, slow to load on poor connections, and not displayed at all in several UI locations (edit form, mention picker badges, welcome screen agent selector). The local-first approach ensures avatars load instantly from disk and degrade gracefully when no local file exists.

## What changed?

- **Main process**: Added `avatar-handlers.ts` with `saveAgentAvatar`, `deleteAgentAvatar`, `listLocalAvatars` IPC handlers and a `clawwork-avatar://gatewayId/agentId` custom protocol handler with path traversal protection
- **Preload**: Exposed the three avatar IPC methods through the typed bridge
- **Shared**: Added `avatar` to `DebugDomain` union for structured logging
- **Renderer — new `AgentIcon` component**: Shared component encapsulating the local→gateway→emoji→icon fallback chain, used across all agent display sites
- **Renderer — `MessageAvatar`**: Changed from single `avatarUrl` to dual `localAvatarUrl` + `gatewayAvatarUrl` with `failCount` state for automatic degradation
- **Renderer — `MainArea`**: `resolveAssistantIdentity()` now returns both URL types; welcome screen agent selector uses `AgentIcon`
- **Renderer — `ChatMessage` / `StreamingMessage`**: Forward both URL props to `MessageAvatar`
- **Renderer — `MentionPicker`**: Added `gatewayId` to `AgentMentionEntry`; agent items use `AgentIcon`
- **Renderer — `ChatInput`**: Added `gatewayId` to `mentionAgents` builder; selected agent badges use `AgentIcon` with avatar display
- **Renderer — `AgentsSection`**: Agent cards show local-first avatars; edit form initializes from local URL as fallback; `handleSave` uses `isNewUpload` guard to only send `data:` URLs to gateway/local storage

## Architecture impact

- Owning layer: main (protocol + IPC), renderer (display), shared (debug domain), preload (bridge)
- Cross-layer impact: yes — new IPC channel for avatar persistence, new custom protocol for renderer→main file serving
- Invariants touched from `docs/architecture-invariants.md`:
  - Preload bridge exposes only minimal API surface — three new methods added, all typed
  - No Node builtins in renderer — file access goes through `clawwork-avatar://` protocol
- Why those invariants remain protected: renderer never touches the filesystem directly; all file I/O goes through IPC handlers with ID pattern validation and path traversal rejection

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate — 228 tests pass)
- [ ] Manual smoke test

```text
pnpm check — all passed (lint, architecture, ui-contract, renderer-copy, i18n, dead-code, format, typecheck, 228 tests)
```

## Screenshots or recordings

N/A — requires running Electron app with a connected Gateway to verify avatar display.

Avatar fallback chain preserved across all display sites: `clawwork-avatar://` (local disk) → Gateway URL → emoji → Bot icon. The `AgentIcon` shared component and `MessageAvatar` both use a `failCount` + URL array pattern for automatic degradation on `img.onError`.

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Agent avatars now load instantly from local storage using a custom protocol, with automatic fallback to gateway URL, emoji, or default icon. All avatar display sites (chat messages, mention picker, agent settings, welcome screen) are unified.
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate