### PR TITLE
[Feat] Ensemble agent avatar bar for multi-agent tasks

### DIFF
--- a/packages/desktop/src/renderer/components/EnsembleAgentBar.tsx
+++ b/packages/desktop/src/renderer/components/EnsembleAgentBar.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useTaskStore } from '@/stores/taskStore';
+import { useRoomStore } from '@/stores/roomStore';
+import { useUiStore } from '@/stores/uiStore';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import AgentIcon from '@/components/AgentIcon';
+import type { RoomPerformer } from '@clawwork/shared';
+import { motionDuration } from '@/styles/design-tokens';
+
+const EMPTY_PERFORMERS: readonly RoomPerformer[] = [];
+
+interface EnsembleAgentBarProps {
+  taskId: string;
+}
+
+export default function EnsembleAgentBar({ taskId }: EnsembleAgentBarProps) {
+  const task = useTaskStore((s) => s.tasks.find((t) => t.id === taskId));
+  const performers = useRoomStore((s) => s.rooms[taskId]?.performers ?? EMPTY_PERFORMERS);
+  const agents = useUiStore((s) => (task?.gatewayId ? s.agentCatalogByGateway[task.gatewayId]?.agents : undefined));
+
+  const catalogById = useMemo(() => new Map((agents ?? []).map((a) => [a.id, a])), [agents]);
+
+  const uniquePerformers = useMemo(() => {
+    const seen = new Set<string>();
+    return performers.filter((p) => {
+      if (seen.has(p.agentId)) return false;
+      seen.add(p.agentId);
+      return true;
+    });
+  }, [performers]);
+
+  if (!task?.ensemble || uniquePerformers.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-[var(--density-toolbar-height)] z-10 px-5 pt-2">
+      <div className="pointer-events-auto inline-flex items-center gap-2">
+        <AnimatePresence initial={false}>
+          {uniquePerformers.map((p) => {
+            const catalog = catalogById.get(p.agentId);
+            const modelName = catalog?.model?.primary;
+            return (
+              <motion.div
+                key={p.agentId}
+                initial={{ opacity: 0, scale: 0.5 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.5 }}
+                transition={{ duration: motionDuration.moderate }}
+              >
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div
+                      data-testid="agent-avatar"
+                      className="flex h-9 w-9 shrink-0 cursor-default items-center justify-center rounded-full bg-[var(--bg-secondary)] ring-1 ring-[var(--border-subtle)] transition-transform hover:scale-110"
+                    >
+                      <AgentIcon
+                        gatewayId={task.gatewayId}
+                        agentId={p.agentId}
+                        emoji={catalog?.identity?.emoji ?? p.emoji}
+                        gatewayAvatarUrl={catalog?.identity?.avatarUrl}
+                        imgClass="w-9 h-9 rounded-full object-cover"
+                        emojiClass="emoji-md"
+                        iconSize={20}
+                        iconClass="text-[var(--accent)]"
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <div className="type-label">{p.agentName}</div>
+                    {modelName && <div className="type-meta text-[var(--text-muted)]">{modelName}</div>}
+                  </TooltipContent>
+                </Tooltip>
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -38,6 +38,7 @@ import ChatInput from '@/components/ChatInput';
 import AgentIcon from '@/components/AgentIcon';
 import ImageLightbox from '@/components/ImageLightbox';
 import FilePreviewModal from '@/components/FilePreviewModal';
+import EnsembleAgentBar from '@/components/EnsembleAgentBar';
 import FileBrowser from '../FileBrowser';
 import CronPanel from '@/layouts/CronPanel';
 import TeamsPanel from '@/layouts/TeamsPanel';
@@ -962,12 +963,13 @@ export default function MainArea({ onTogglePanel }: MainAreaProps) {
           <TeamsPanel />
         </div>
       ) : (
-        <div key={`chat-${activeTaskId ?? 'welcome'}`} className="flex flex-col flex-1 min-h-0">
+        <div key={`chat-${activeTaskId ?? 'welcome'}`} className="relative flex flex-col flex-1 min-h-0">
           <ChatHeader
             onTogglePanel={onTogglePanel}
             messageLayout={messageLayout}
             onToggleMessageLayout={toggleMessageLayout}
           />
+          {activeTaskId && <EnsembleAgentBar taskId={activeTaskId} />}
           <ChatContent />
         </div>
       )}

--- a/packages/desktop/test/ensemble-agent-bar.test.tsx
+++ b/packages/desktop/test/ensemble-agent-bar.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RoomPerformer } from '@clawwork/shared';
+import '../src/renderer/i18n';
+import { useTaskStore } from '../src/renderer/stores/taskStore';
+import { useRoomStore } from '../src/renderer/stores/roomStore';
+import { useUiStore } from '../src/renderer/stores/uiStore';
+import EnsembleAgentBar from '../src/renderer/components/EnsembleAgentBar';
+
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+
+  const motion = new Proxy(
+    {},
+    {
+      get: (_target, tag: string) =>
+        React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(({ children, ...props }, ref) =>
+          React.createElement(tag, { ...props, ref }, children),
+        ),
+    },
+  );
+
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    motion,
+  };
+});
+
+vi.mock('@radix-ui/react-tooltip', async () => {
+  const React = await import('react');
+  return {
+    Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Root: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Trigger: React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement> & { asChild?: boolean }>(
+      ({ children }, _ref) => <>{children}</>,
+    ),
+    Content: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ children, ...props }, ref) => (
+      <div ref={ref} data-testid="tooltip-content" {...props}>
+        {children}
+      </div>
+    )),
+    Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const TASK_ID = 'task-1';
+const GATEWAY_ID = 'gw-1';
+
+function buildPerformer(overrides: Partial<RoomPerformer> & { agentId: string }): RoomPerformer {
+  return {
+    sessionKey: `agent:${overrides.agentId}:subagent:${crypto.randomUUID()}`,
+    agentName: overrides.agentId,
+    verifiedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function seedTask(ensemble: boolean): void {
+  useTaskStore.setState({
+    tasks: [
+      {
+        id: TASK_ID,
+        sessionKey: `agent:main:clawwork:task:${TASK_ID}`,
+        sessionId: 'sid-1',
+        title: 'Test Task',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        tags: [],
+        artifactDir: '/tmp',
+        gatewayId: GATEWAY_ID,
+        ensemble,
+      },
+    ],
+  });
+}
+
+function seedRoom(performers: RoomPerformer[]): void {
+  useRoomStore.setState({
+    rooms: {
+      [TASK_ID]: {
+        taskId: TASK_ID,
+        conductorSessionKey: `agent:main:clawwork:task:${TASK_ID}`,
+        conductorReady: true,
+        status: 'active',
+        performers,
+      },
+    },
+  });
+}
+
+function render(ui: ReactElement): { container: HTMLDivElement; unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+const cleanups: Array<() => void> = [];
+
+describe('EnsembleAgentBar', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    useTaskStore.setState({ tasks: [] });
+    useRoomStore.setState({ rooms: {}, subagentKeyMap: {} });
+    useUiStore.setState({ agentCatalogByGateway: {} });
+  });
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.();
+    }
+  });
+
+  it('renders nothing when task is not ensemble', () => {
+    seedTask(false);
+    seedRoom([buildPerformer({ agentId: 'researcher', agentName: 'Researcher', emoji: '🔬' })]);
+
+    const { container, unmount } = render(<EnsembleAgentBar taskId={TASK_ID} />);
+    cleanups.push(unmount);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when no performers exist', () => {
+    seedTask(true);
+
+    const { container, unmount } = render(<EnsembleAgentBar taskId={TASK_ID} />);
+    cleanups.push(unmount);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders one avatar per unique agent', () => {
+    seedTask(true);
+    seedRoom([
+      buildPerformer({ agentId: 'researcher', agentName: 'Researcher', emoji: '🔬' }),
+      buildPerformer({ agentId: 'coder', agentName: 'Coder', emoji: '💻' }),
+    ]);
+
+    const { container, unmount } = render(<EnsembleAgentBar taskId={TASK_ID} />);
+    cleanups.push(unmount);
+
+    expect(container.querySelectorAll('[data-testid="agent-avatar"]').length).toBe(2);
+  });
+
+  it('deduplicates performers with the same agentId', () => {
+    seedTask(true);
+    seedRoom([
+      buildPerformer({ agentId: 'researcher', agentName: 'Researcher', emoji: '🔬' }),
+      buildPerformer({ agentId: 'researcher', agentName: 'Researcher', emoji: '🔬' }),
+      buildPerformer({ agentId: 'researcher', agentName: 'Researcher', emoji: '🔬' }),
+      buildPerformer({ agentId: 'coder', agentName: 'Coder', emoji: '💻' }),
+    ]);
+
+    const { container, unmount } = render(<EnsembleAgentBar taskId={TASK_ID} />);
+    cleanups.push(unmount);
+
+    expect(container.querySelectorAll('[data-testid="agent-avatar"]').length).toBe(2);
+  });
+
+  it('displays agent name in tooltip content', () => {
+    seedTask(true);
+    seedRoom([buildPerformer({ agentId: 'researcher', agentName: 'Researcher', emoji: '🔬' })]);
+
+    const { container, unmount } = render(<EnsembleAgentBar taskId={TASK_ID} />);
+    cleanups.push(unmount);
+
+    const tooltips = container.querySelectorAll('[data-testid="tooltip-content"]');
+    expect(tooltips.length).toBe(1);
+    expect(tooltips[0].textContent).toContain('Researcher');
+  });
+});


### PR DESCRIPTION
## Summary

Show floating agent avatars below the chat header for ensemble (multi-agent) tasks, so users can immediately see which agents are participating.

## Type of change

- [x] `[Feat]` new feature
- [x] `[UI]` UI or UX change

## Why is this needed?

When a user creates an ensemble task with multiple agents, there is no visual indicator in the chat view that multiple agents exist. Users have to infer it from message content. This adds a lightweight, non-intrusive signal.

## What changed?

- New `EnsembleAgentBar` component: renders circular agent avatars (36px) floating below the chat header
- Avatars are deduplicated by `agentId` (same agent spawned multiple times shows once)
- Hover tooltip shows agent name and model
- Component self-contained: reads `ensemble` flag, `gatewayId`, performers, and catalog from stores internally
- Only renders for ensemble tasks with ≥1 registered performer
- Stable empty-array reference (`EMPTY_PERFORMERS`) prevents Zustand infinite re-render
- `MainArea` integration: 3 lines changed — import, `relative` on container, conditional render
- 5 test cases covering: non-ensemble no-render, empty performers no-render, correct avatar count, agentId dedup, tooltip content

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: component only reads from existing stores (`taskStore`, `roomStore`, `uiStore`), no new write paths

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate — 28 test files, 186 tests passed)
- [x] Manual smoke test

```text
pnpm check — all 186 tests passed, 0 lint/format/architecture/i18n/dead-code issues
```

## Screenshots or recordings

Circular avatars with `ring-1 ring-[var(--border-subtle)]` border, `bg-[var(--bg-secondary)]` background. Uses existing `AgentIcon` fallback chain (local avatar → gateway avatar → emoji → Bot icon). Theme-aware border color works in both dark and light modes.

## Release note

- [x] User-facing change. Release note is included below.

```release-note
Ensemble tasks now show participating agent avatars below the chat header
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate