### PR TITLE
[Bug] Roll back failed agent creation when follow-up update fails

### DIFF
--- a/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
@@ -38,6 +38,7 @@ import EmptyState from '@/components/semantic/EmptyState';
 import LoadingBlock from '@/components/semantic/LoadingBlock';
 import SettingGroup from '@/components/semantic/SettingGroup';
 import ToolbarButton from '@/components/semantic/ToolbarButton';
+import { createAgentWithRollback } from '@/lib/agent-builder';
 import { AVATAR_ACCEPT, readFileAsDataUrl, validateAvatarFile } from '@/lib/avatar-utils';
 
 const EMPTY_MODELS: ModelCatalogEntry[] = [];
@@ -829,20 +830,16 @@ export default function AgentsSection() {
         toast.error(res.error ?? t('errors.failed'));
       }
     } else {
-      const res = await window.clawwork.createAgent(selectedGatewayId, {
+      const res = await createAgentWithRollback(window.clawwork, {
+        gatewayId: selectedGatewayId,
         name: form.name.trim(),
         workspace: form.workspace.trim(),
         avatar: isNewUpload ? form.avatar : undefined,
+        model: form.model.trim() || undefined,
       });
       if (res.ok) {
         const created = res.result as Record<string, unknown> | undefined;
         const newAgentId = (created?.agentId as string) ?? '';
-        if (form.model.trim() && newAgentId) {
-          await window.clawwork.updateAgent(selectedGatewayId, {
-            agentId: newAgentId,
-            model: form.model.trim(),
-          });
-        }
         if (isNewUpload && newAgentId) {
           window.clawwork.saveAgentAvatar(selectedGatewayId, newAgentId, form.avatar).catch(() => {});
         }
@@ -850,6 +847,7 @@ export default function AgentsSection() {
         closeForm();
         await refreshAgents();
       } else {
+        await refreshAgents();
         toast.error(res.error ?? t('errors.failed'));
       }
     }

--- a/packages/desktop/src/renderer/lib/agent-builder.ts
+++ b/packages/desktop/src/renderer/lib/agent-builder.ts
@@ -1,0 +1,56 @@
+interface AgentMutationResult {
+  ok: boolean;
+  result?: Record<string, unknown>;
+  error?: string;
+  errorCode?: string;
+  errorDetails?: Record<string, unknown>;
+}
+
+interface AgentBuilderApi {
+  createAgent: (
+    gatewayId: string,
+    params: { name: string; workspace: string; avatar?: string },
+  ) => Promise<AgentMutationResult>;
+  updateAgent: (gatewayId: string, params: { agentId: string; model?: string }) => Promise<AgentMutationResult>;
+  deleteAgent: (gatewayId: string, params: { agentId: string; deleteFiles?: boolean }) => Promise<AgentMutationResult>;
+}
+
+export async function createAgentWithRollback(
+  api: AgentBuilderApi,
+  params: {
+    gatewayId: string;
+    name: string;
+    workspace: string;
+    avatar?: string;
+    model?: string;
+  },
+): Promise<AgentMutationResult> {
+  const createRes = await api.createAgent(params.gatewayId, {
+    name: params.name,
+    workspace: params.workspace,
+    avatar: params.avatar,
+  });
+  if (!createRes.ok) return createRes;
+
+  const created = createRes.result;
+  const agentId = typeof created?.agentId === 'string' ? created.agentId : '';
+  const model = params.model?.trim();
+  if (!model || !agentId) return createRes;
+
+  const updateRes = await api.updateAgent(params.gatewayId, {
+    agentId,
+    model,
+  });
+  if (updateRes.ok) return createRes;
+
+  const rollbackRes = await api.deleteAgent(params.gatewayId, {
+    agentId,
+    deleteFiles: true,
+  });
+  if (rollbackRes.ok) return updateRes;
+
+  return {
+    ...updateRes,
+    error: `${updateRes.error ?? 'agent update failed'} (rollback failed: ${rollbackRes.error ?? 'unknown error'})`,
+  };
+}

--- a/packages/desktop/test/agent-builder.test.ts
+++ b/packages/desktop/test/agent-builder.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAgentWithRollback } from '../src/renderer/lib/agent-builder';
+
+describe('createAgentWithRollback', () => {
+  it('rolls back the created agent when model update fails', async () => {
+    const api = {
+      createAgent: vi.fn(async () => ({ ok: true, result: { agentId: 'agent-1' } })),
+      updateAgent: vi.fn(async () => ({ ok: false, error: 'invalid model' })),
+      deleteAgent: vi.fn(async () => ({ ok: true })),
+    };
+
+    const result = await createAgentWithRollback(api, {
+      gatewayId: 'gw-1',
+      name: 'Writer',
+      workspace: 'agents/writer',
+      avatar: 'avatar-data',
+      model: 'bad-model',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'invalid model' });
+    expect(api.createAgent).toHaveBeenCalledWith('gw-1', {
+      name: 'Writer',
+      workspace: 'agents/writer',
+      avatar: 'avatar-data',
+    });
+    expect(api.updateAgent).toHaveBeenCalledWith('gw-1', {
+      agentId: 'agent-1',
+      model: 'bad-model',
+    });
+    expect(api.deleteAgent).toHaveBeenCalledWith('gw-1', {
+      agentId: 'agent-1',
+      deleteFiles: true,
+    });
+  });
+
+  it('includes rollback failure in the surfaced error', async () => {
+    const api = {
+      createAgent: vi.fn(async () => ({ ok: true, result: { agentId: 'agent-1' } })),
+      updateAgent: vi.fn(async () => ({ ok: false, error: 'invalid model' })),
+      deleteAgent: vi.fn(async () => ({ ok: false, error: 'permission denied' })),
+    };
+
+    const result = await createAgentWithRollback(api, {
+      gatewayId: 'gw-1',
+      name: 'Writer',
+      workspace: 'agents/writer',
+      model: 'bad-model',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'invalid model (rollback failed: permission denied)',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract the new-agent creation flow into a helper that rolls back the created agent if the follow-up model update fails
- stop reporting success when the second step fails, and refresh the agent list after a failed create attempt
- add a regression test covering rollback on partial creation failure

## Validation
- `pnpm --filter @clawwork/desktop test -- agent-builder.test.ts`
- `pnpm --filter @clawwork/desktop exec eslint src/renderer/lib/agent-builder.ts src/renderer/layouts/Settings/sections/AgentsSection.tsx test/agent-builder.test.ts`

## Notes
- `pnpm --filter @clawwork/desktop exec tsc --noEmit` currently fails on unrelated `teams` / `system-session` type errors already present on latest `origin/main` (commit `0445f11`) and not touched by this PR.