### PR TITLE
[Fix] Trim auth credentials and URL in test-gateway handler

### DIFF
--- a/packages/desktop/src/main/ipc/settings-handlers.ts
+++ b/packages/desktop/src/main/ipc/settings-handlers.ts
@@ -82,12 +82,12 @@ export function registerSettingsHandlers(): void {
         return { ok: false, error: 'pairing-code test is not supported' };
       }
       const testAuth: GatewayAuth = auth.token
-        ? { token: auth.token }
+        ? { token: auth.token.trim() }
         : auth.password
-          ? { password: auth.password }
+          ? { password: auth.password.trim() }
           : { token: '' };
       const testClient = new GatewayClient(
-        { id: `test-${Date.now()}`, name: 'test', url, auth: testAuth },
+        { id: `test-${Date.now()}`, name: 'test', url: url.trim(), auth: testAuth },
         { noReconnect: true },
       );
       try {


### PR DESCRIPTION
## Summary

Trim whitespace from token, password, and URL in the `settings:test-gateway` IPC handler, matching the behavior of the save path.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

When users paste gateway credentials with trailing newlines or spaces, the test connection fails with `unauthorized: gateway token mismatch` while saving the same gateway succeeds — because the save path trims inputs but the test path did not.

## What changed?

- Added `.trim()` to `auth.token` and `auth.password` in the test-gateway handler
- Added `.trim()` to the `url` parameter passed to the test `GatewayClient`

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is limited to input sanitization in a single IPC handler

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate)
- [ ] Not run

```text
pnpm check — all passed
```

## Screenshots or recordings

N/A — no UI change.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate