### PR TITLE
[Fix] Add scroll to model selector dropdown when providers overflow

### DIFF
--- a/packages/desktop/src/renderer/components/ChatInput/index.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput/index.tsx
@@ -704,13 +704,13 @@ export default function ChatInput() {
                             <ChevronDown size={14} className="opacity-50" />
                           </ToolbarButton>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent align="start">
+                        <DropdownMenuContent align="start" className="max-h-96 overflow-y-auto">
                           {Object.entries(modelsByProvider).map(([provider, models]) => (
                             <DropdownMenuSub key={provider}>
                               <DropdownMenuSubTrigger>
                                 <span>{provider}</span>
                               </DropdownMenuSubTrigger>
-                              <DropdownMenuSubContent>
+                              <DropdownMenuSubContent className="max-h-96 overflow-y-auto">
                                 {models.map((m) => (
                                   <DropdownMenuItem
                                     key={m.id}


### PR DESCRIPTION
## Summary

Fix model provider and model list being clipped when there are many providers/models. Adds `max-h-96 overflow-y-auto` to both the provider dropdown and per-provider model submenu.

## Root Cause

`DropdownMenuContent` and `DropdownMenuSubContent` have `overflow-hidden` with no `max-height`, so items exceeding viewport height are silently clipped.

## Fix

Add `className="max-h-96 overflow-y-auto"` at the usage site (not the base component), following the existing pattern in `ToolsCatalog.tsx`. CSS cascade makes `overflow-y: auto` override only the y-axis from the base `overflow: hidden`, keeping x-axis clipping intact for animation.

## Validation

- `pnpm check` passes (knip failure is pre-existing on main)
- Tested with many model providers

Closes #269