### PR TITLE
fix: replace empty catch in useUpdateCheck with console.error

### DIFF
--- a/packages/desktop/src/renderer/hooks/useUpdateCheck.ts
+++ b/packages/desktop/src/renderer/hooks/useUpdateCheck.ts
@@ -1,21 +1,21 @@
-import { useEffect } from "react";
-import { useUiStore } from "@/stores/uiStore";
+import { useEffect } from 'react';
+import { useUiStore } from '@/stores/uiStore';
 
 export function useUpdateCheck(): void {
-	const setHasUpdate = useUiStore((s) => s.setHasUpdate);
+  const setHasUpdate = useUiStore((s) => s.setHasUpdate);
 
-	useEffect(() => {
-		const timer = setTimeout(async () => {
-			try {
-				const result = await window.clawwork.checkForUpdates();
-				if (result.hasUpdate) {
-					setHasUpdate(true);
-				}
-			} catch (err) {
-				console.error("[useUpdateCheck] check failed:", err);
-			}
-		}, 5000);
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      try {
+        const result = await window.clawwork.checkForUpdates();
+        if (result.hasUpdate) {
+          setHasUpdate(true);
+        }
+      } catch (err) {
+        console.error('[useUpdateCheck] check failed:', err);
+      }
+    }, 5000);
 
-		return () => clearTimeout(timer);
-	}, [setHasUpdate]);
+    return () => clearTimeout(timer);
+  }, [setHasUpdate]);
 }

--- a/packages/desktop/src/renderer/hooks/useUpdateCheck.ts
+++ b/packages/desktop/src/renderer/hooks/useUpdateCheck.ts
@@ -13,6 +13,11 @@ export function useUpdateCheck(): void {
         }
       } catch (err) {
         console.error('[useUpdateCheck] check failed:', err);
+        window.clawwork?.reportDebugEvent?.({
+          domain: 'renderer',
+          event: 'update-check-failed',
+          data: { error: String(err) },
+        });
       }
     }, 5000);
 

--- a/packages/desktop/src/renderer/hooks/useUpdateCheck.ts
+++ b/packages/desktop/src/renderer/hooks/useUpdateCheck.ts
@@ -1,19 +1,21 @@
-import { useEffect } from 'react';
-import { useUiStore } from '@/stores/uiStore';
+import { useEffect } from "react";
+import { useUiStore } from "@/stores/uiStore";
 
 export function useUpdateCheck(): void {
-  const setHasUpdate = useUiStore((s) => s.setHasUpdate);
+	const setHasUpdate = useUiStore((s) => s.setHasUpdate);
 
-  useEffect(() => {
-    const timer = setTimeout(async () => {
-      try {
-        const result = await window.clawwork.checkForUpdates();
-        if (result.hasUpdate) {
-          setHasUpdate(true);
-        }
-      } catch {}
-    }, 5000);
+	useEffect(() => {
+		const timer = setTimeout(async () => {
+			try {
+				const result = await window.clawwork.checkForUpdates();
+				if (result.hasUpdate) {
+					setHasUpdate(true);
+				}
+			} catch (err) {
+				console.error("[useUpdateCheck] check failed:", err);
+			}
+		}, 5000);
 
-    return () => clearTimeout(timer);
-  }, [setHasUpdate]);
+		return () => clearTimeout(timer);
+	}, [setHasUpdate]);
 }


### PR DESCRIPTION
### Problem
`useUpdateCheck.ts` has an empty `catch {}` that silently swallows all errors from the update check IPC call.

### Fix
Replaced `catch {}` with `catch (err) { console.error("[useUpdateCheck] check failed:", err); }` so errors are visible in the console for debugging.

### Verification
- Follows existing error logging patterns in the project
- No behavioral change from user perspective

Fixes #328