### PR TITLE
fix(i18n): replace hardcoded English strings in useTraySync with i18n…

### DIFF
--- a/packages/desktop/src/renderer/hooks/useTraySync.ts
+++ b/packages/desktop/src/renderer/hooks/useTraySync.ts
@@ -2,13 +2,14 @@ import { useEffect, useRef } from 'react';
 import { useTaskStore } from '../stores/taskStore';
 import { useUiStore } from '../stores/uiStore';
 import { useMessageStore } from '../stores/messageStore';
+import i18n from '../i18n';
 
 function formatDuration(updatedAt: string): string {
   const ms = Date.now() - new Date(updatedAt).getTime();
   const min = Math.floor(ms / 60000);
-  if (min < 1) return 'just now';
-  if (min === 1) return '1 min ago';
-  return `${min} min ago`;
+  if (min < 1) return i18n.t('common.justNow');
+  if (min === 1) return i18n.t('common.minAgo', { count: 1 });
+  return i18n.t('common.minAgo', { count: min });
 }
 
 export function useTraySync(): void {
@@ -38,12 +39,12 @@ export function useTraySync(): void {
 
     const activeTurnBySession = useMessageStore.getState().activeTurnBySession;
     const activeTasks = activeIds.map((id) => {
-      const t = tasks.find((task) => task.id === id)!;
+      const task = tasks.find((t) => t.id === id)!;
       return {
         taskId: id,
-        title: t.title || 'Untitled',
-        snippet: (activeTurnBySession[t.sessionKey]?.streamingText ?? '').slice(0, 60),
-        duration: formatDuration(t.updatedAt),
+        title: task.title || i18n.t('common.noTitle'),
+        snippet: (activeTurnBySession[task.sessionKey]?.streamingText ?? '').slice(0, 60),
+        duration: formatDuration(task.updatedAt),
       };
     });
 

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -75,6 +75,7 @@
     "gateway": "Gateway",
     "justNow": "gerade eben",
     "light": "Hell",
+    "minAgo": "vor {{count}} Min.",
     "missing": "Fehlt",
     "navigate": "Navigieren",
     "newTask": "Neue Aufgabe",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -75,6 +75,7 @@
     "gateway": "Gateway",
     "justNow": "just now",
     "light": "Light",
+    "minAgo": "{{count}} min ago",
     "missing": "Missing",
     "navigate": "navigate",
     "newTask": "New Task",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -75,6 +75,7 @@
     "gateway": "Gateway",
     "justNow": "justo ahora",
     "light": "Claro",
+    "minAgo": "hace {{count}} min",
     "missing": "Faltante",
     "navigate": "navegar",
     "newTask": "Nueva tarea",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -75,6 +75,7 @@
     "gateway": "ゲートウェイ",
     "justNow": "たった今",
     "light": "ライト",
+    "minAgo": "{{count}} 分前",
     "missing": "不明",
     "navigate": "移動",
     "newTask": "新規タスク",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -75,6 +75,7 @@
     "gateway": "게이트웨이",
     "justNow": "방금",
     "light": "라이트",
+    "minAgo": "{{count}}분 전",
     "missing": "누락",
     "navigate": "이동",
     "newTask": "새 작업",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -75,6 +75,7 @@
     "gateway": "Gateway",
     "justNow": "agora mesmo",
     "light": "Claro",
+    "minAgo": "{{count}} min atrás",
     "missing": "Ausente",
     "navigate": "navegar",
     "newTask": "Nova Tarefa",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -75,6 +75,7 @@
     "gateway": "Gateway",
     "justNow": "剛剛",
     "light": "淺色",
+    "minAgo": "{{count}} 分鐘前",
     "missing": "缺少",
     "navigate": "導覽",
     "newTask": "新任務",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -75,6 +75,7 @@
     "gateway": "网关",
     "justNow": "刚刚",
     "light": "浅色",
+    "minAgo": "{{count}} 分钟前",
     "missing": "缺失",
     "navigate": "导航",
     "newTask": "新任务",


### PR DESCRIPTION
… calls

- Import i18n singleton and use i18n.t() for tray duration strings

- Add common.minAgo key to all 8 locale files

- Reuse existing common.justNow and common.noTitle keys

- Rename loop variable t to task to avoid confusion with i18n t function

Closes #334

## Summary

Describe the change and the problem it solves.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Explain the user problem, engineering problem, or follow-up this PR addresses.

## What changed?

-

## Architecture impact

- Owning layer: shared / main / preload / renderer
- Cross-layer impact: none / yes (explain)
- Invariants touched from `docs/architecture-invariants.md`:
- Why those invariants remain protected:

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text

```

## Screenshots or recordings

If the change affects the UI, add screenshots or a short recording.

If the change touches renderer styles, layout, spacing, component states, or interaction polish, explain which tokens, variables, states, or `pnpm check:ui-contract` rules were intentionally preserved or changed.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [ ] All commits are signed off (`git commit -s`)
- [ ] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [ ] The summary explains both what changed and why
- [ ] Validation reflects the commands actually run for this PR
- [ ] Architecture impact is described and references any touched invariants
- [ ] Cross-layer changes are explicitly justified
- [ ] The release note block is accurate
