### PR TITLE
fix(core): log persistence errors instead of silently swallowing (#216)

### DIFF
--- a/packages/core/src/stores/room-store.ts
+++ b/packages/core/src/stores/room-store.ts
@@ -106,7 +106,9 @@ export function createRoomStore(deps: RoomStoreDeps) {
         }
 
         updateRoom(taskId, { conductorReady: true }, set);
-        deps.persistRoom({ taskId, status: 'active', conductorReady: true }).catch(() => {});
+        deps.persistRoom({ taskId, status: 'active', conductorReady: true }).catch((err) => {
+          console.warn('[room-store] persistRoom failed:', err);
+        });
         return true;
       } catch (err) {
         console.warn('[room-store] initConductor failed:', err);
@@ -151,7 +153,9 @@ export function createRoomStore(deps: RoomStoreDeps) {
       updateRoom(taskId, { status }, set);
       const room = get().rooms[taskId];
       if (room) {
-        deps.persistRoom({ taskId, status, conductorReady: room.conductorReady }).catch(() => {});
+        deps.persistRoom({ taskId, status, conductorReady: room.conductorReady }).catch((err) => {
+          console.warn('[room-store] persistRoom failed:', err);
+        });
       }
     },
 
@@ -181,7 +185,9 @@ export function createRoomStore(deps: RoomStoreDeps) {
           subagentKeyMap: { ...s.subagentKeyMap, [subagentKey]: taskId },
         };
       });
-      deps.persistPerformer({ taskId, ...performer }).catch(() => {});
+      deps.persistPerformer({ taskId, ...performer }).catch((err) => {
+        console.warn('[room-store] persistPerformer failed:', err);
+      });
     },
 
     verifyCandidates: async (taskId, gatewayId) => {


### PR DESCRIPTION
Replace .catch(() => {}) with console.warn logging in room-store for persistRoom and persistPerformer calls so failures are visible in logs.

## Summary

Describe the change and the problem it solves.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Explain the user problem, engineering problem, or follow-up this PR addresses.

## What changed?

-

## Architecture impact

- Owning layer: shared / main / preload / renderer
- Cross-layer impact: none / yes (explain)
- Invariants touched from `docs/architecture-invariants.md`:
- Why those invariants remain protected:

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text

```

## Screenshots or recordings

If the change affects the UI, add screenshots or a short recording.

If the change touches renderer styles, layout, spacing, component states, or interaction polish, explain which tokens, variables, states, or `pnpm check:ui-contract` rules were intentionally preserved or changed.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [ ] All commits are signed off (`git commit -s`)
- [ ] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [ ] The summary explains both what changed and why
- [ ] Validation reflects the commands actually run for this PR
- [ ] Architecture impact is described and references any touched invariants
- [ ] Cross-layer changes are explicitly justified
- [ ] The release note block is accurate
