### PR TITLE
fix(main): allowlist http(s) schemes in shell.openExternal to prevent…

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -153,7 +153,12 @@ function createWindow(): BrowserWindow {
   });
 
   win.webContents.setWindowOpenHandler((details) => {
-    shell.openExternal(details.url);
+    try {
+      const parsed = new URL(details.url);
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        shell.openExternal(details.url);
+      }
+    } catch {}
     return { action: 'deny' };
   });
 

--- a/packages/desktop/src/renderer/components/MarkdownContent.tsx
+++ b/packages/desktop/src/renderer/components/MarkdownContent.tsx
@@ -169,8 +169,8 @@ export default function MarkdownContent({
                 <a
                   href={href}
                   onClick={(e) => {
+                    e.preventDefault();
                     if (href && /^https?:\/\//.test(href)) {
-                      e.preventDefault();
                       window.open(href, '_blank');
                     }
                   }}


### PR DESCRIPTION
… protocol handler abuse

## Summary

Describe the change and the problem it solves.

- `setWindowOpenHandler` was passing any URL to `shell.openExternal()` without
    validating the scheme, allowing file://, ms-settings:, vscode://, and other
    OS protocol handlers to be invoked via a crafted link in a chat message.
- Add an http(s)-only allowlist in `main/index.ts` before calling
  `shell.openExternal()`.
- Move `e.preventDefault()` to run unconditionally in `MarkdownContent.tsx` so
    non-http links cannot cause native renderer navigation either
  (defense-in-depth).

  Closes #131.


## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Explain the user problem, engineering problem, or follow-up this PR addresses.

## What changed?

-

## Architecture impact

- Owning layer: shared / main / preload / renderer
- Cross-layer impact: none / yes (explain)
- Invariants touched from `docs/architecture-invariants.md`:
- Why those invariants remain protected:

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text

```

## Screenshots or recordings

If the change affects the UI, add screenshots or a short recording.

If the change touches renderer styles, layout, spacing, component states, or interaction polish, explain which tokens, variables, states, or `pnpm check:ui-contract` rules were intentionally preserved or changed.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [ ] Architecture impact is described and references any touched invariants
- [ ] Cross-layer changes are explicitly justified
- [ ] The release note block is accurate
