### PR TITLE
[Fix] Consolidate redundant map iterations in MentionPicker

### DIFF
--- a/packages/desktop/src/renderer/components/MentionPicker.tsx
+++ b/packages/desktop/src/renderer/components/MentionPicker.tsx
@@ -237,7 +237,7 @@ export default function MentionPicker({
                 </button>
               );
             }
-            case 'task':
+            case 'task': {
               return (
                 <button
                   key={item.task.id}
@@ -254,6 +254,7 @@ export default function MentionPicker({
                   <span className="type-meta flex-shrink-0 text-[var(--text-muted)]">{item.task.status}</span>
                 </button>
               );
+            }
             case 'file': {
               const a = item.artifact;
               return (
@@ -265,12 +266,14 @@ export default function MentionPicker({
                   onClick={() => onSelectArtifact(a)}
                   onMouseEnter={() => onHoverIndex(i)}
                 >
-                  {artifactIcon(a.type, 14)}
+                  <span className="flex-shrink-0">{artifactIcon(a.type, 14)}</span>
                   <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{a.name}</span>
                   <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{formatFileSize(a.size)}</span>
                 </button>
               );
             }
+            default:
+              return null;
           }
         })}
       </div>

--- a/packages/desktop/src/renderer/components/MentionPicker.tsx
+++ b/packages/desktop/src/renderer/components/MentionPicker.tsx
@@ -181,115 +181,98 @@ export default function MentionPicker({
           </div>
         )}
 
-        {activeTab === 'agents' &&
-          items.map((item, i) => {
-            if (item.kind !== 'agent') return null;
-            const a = item.agent;
-            return (
-              <button
-                key={a.sessionKey}
-                data-mention-selected={i === selectedIndex ? '' : undefined}
-                className={cn(
-                  'type-label flex w-full items-center gap-2.5 px-3 py-2 text-left',
-                  'hover:bg-[var(--bg-hover)] transition-colors',
-                  i === selectedIndex && 'bg-[var(--bg-hover)]',
-                )}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => onSelectAgent(a)}
-                onMouseEnter={() => onHoverIndex(i)}
-              >
-                {a.agentId === MENTION_ALL_AGENT_ID ? (
-                  <Users size={14} className="text-[var(--accent)] flex-shrink-0" />
-                ) : (
-                  <span className="flex-shrink-0">
-                    <AgentIcon
-                      gatewayId={a.gatewayId}
-                      agentId={a.agentId}
-                      gatewayAvatarUrl={a.avatarUrl}
-                      emoji={a.emoji}
-                      imgClass="w-4 h-4 rounded-full object-cover"
-                      iconClass="text-[var(--accent)]"
-                    />
+        {items.map((item, i) => {
+          const className = cn(
+            'type-label flex w-full items-center gap-2.5 px-3 py-2 text-left',
+            'hover:bg-[var(--bg-hover)] transition-colors',
+            i === selectedIndex && 'bg-[var(--bg-hover)]',
+          );
+          const selectedAttr = i === selectedIndex ? '' : undefined;
+
+          switch (item.kind) {
+            case 'agent': {
+              const a = item.agent;
+              return (
+                <button
+                  key={a.sessionKey}
+                  data-mention-selected={selectedAttr}
+                  className={className}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onSelectAgent(a)}
+                  onMouseEnter={() => onHoverIndex(i)}
+                >
+                  {a.agentId === MENTION_ALL_AGENT_ID ? (
+                    <Users size={14} className="text-[var(--accent)] flex-shrink-0" />
+                  ) : (
+                    <span className="flex-shrink-0">
+                      <AgentIcon
+                        gatewayId={a.gatewayId}
+                        agentId={a.agentId}
+                        gatewayAvatarUrl={a.avatarUrl}
+                        emoji={a.emoji}
+                        imgClass="w-4 h-4 rounded-full object-cover"
+                        iconClass="text-[var(--accent)]"
+                      />
+                    </span>
+                  )}
+                  <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{a.agentName}</span>
+                  <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{a.agentId}</span>
+                </button>
+              );
+            }
+            case 'local': {
+              const f = item.file;
+              return (
+                <button
+                  key={f.absolutePath}
+                  data-mention-selected={selectedAttr}
+                  className={className}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onSelectLocalFile(f)}
+                  onMouseEnter={() => onHoverIndex(i)}
+                >
+                  <FileCode size={14} className="text-[var(--accent)] flex-shrink-0" />
+                  <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{f.relativePath}</span>
+                  <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{formatFileSize(f.size)}</span>
+                </button>
+              );
+            }
+            case 'task':
+              return (
+                <button
+                  key={item.task.id}
+                  data-mention-selected={selectedAttr}
+                  className={className}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onSelectTask(item.task)}
+                  onMouseEnter={() => onHoverIndex(i)}
+                >
+                  <ListTodo size={14} className="text-[var(--accent)] flex-shrink-0" />
+                  <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">
+                    {item.task.title || t('common.noTitle')}
                   </span>
-                )}
-                <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{a.agentName}</span>
-                <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{a.agentId}</span>
-              </button>
-            );
-          })}
-
-        {activeTab === 'local' &&
-          items.map((item, i) => {
-            if (item.kind !== 'local') return null;
-            const f = item.file;
-            return (
-              <button
-                key={f.absolutePath}
-                data-mention-selected={i === selectedIndex ? '' : undefined}
-                className={cn(
-                  'type-label flex w-full items-center gap-2.5 px-3 py-2 text-left',
-                  'hover:bg-[var(--bg-hover)] transition-colors',
-                  i === selectedIndex && 'bg-[var(--bg-hover)]',
-                )}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => onSelectLocalFile(f)}
-                onMouseEnter={() => onHoverIndex(i)}
-              >
-                <FileCode size={14} className="text-[var(--accent)] flex-shrink-0" />
-                <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{f.relativePath}</span>
-                <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{formatFileSize(f.size)}</span>
-              </button>
-            );
-          })}
-
-        {activeTab === 'tasks' &&
-          items.map((item, i) => {
-            if (item.kind !== 'task') return null;
-            return (
-              <button
-                key={item.task.id}
-                data-mention-selected={i === selectedIndex ? '' : undefined}
-                className={cn(
-                  'type-label flex w-full items-center gap-2.5 px-3 py-2 text-left',
-                  'hover:bg-[var(--bg-hover)] transition-colors',
-                  i === selectedIndex && 'bg-[var(--bg-hover)]',
-                )}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => onSelectTask(item.task)}
-                onMouseEnter={() => onHoverIndex(i)}
-              >
-                <ListTodo size={14} className="text-[var(--accent)] flex-shrink-0" />
-                <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">
-                  {item.task.title || t('common.noTitle')}
-                </span>
-                <span className="type-meta flex-shrink-0 text-[var(--text-muted)]">{item.task.status}</span>
-              </button>
-            );
-          })}
-
-        {activeTab === 'files' &&
-          items.map((item, i) => {
-            if (item.kind !== 'file') return null;
-            const a = item.artifact;
-            return (
-              <button
-                key={a.id}
-                data-mention-selected={i === selectedIndex ? '' : undefined}
-                className={cn(
-                  'type-label flex w-full items-center gap-2.5 px-3 py-2 text-left',
-                  'hover:bg-[var(--bg-hover)] transition-colors',
-                  i === selectedIndex && 'bg-[var(--bg-hover)]',
-                )}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => onSelectArtifact(a)}
-                onMouseEnter={() => onHoverIndex(i)}
-              >
-                {artifactIcon(a.type, 14)}
-                <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{a.name}</span>
-                <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{formatFileSize(a.size)}</span>
-              </button>
-            );
-          })}
+                  <span className="type-meta flex-shrink-0 text-[var(--text-muted)]">{item.task.status}</span>
+                </button>
+              );
+            case 'file': {
+              const a = item.artifact;
+              return (
+                <button
+                  key={a.id}
+                  data-mention-selected={selectedAttr}
+                  className={className}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onSelectArtifact(a)}
+                  onMouseEnter={() => onHoverIndex(i)}
+                >
+                  {artifactIcon(a.type, 14)}
+                  <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{a.name}</span>
+                  <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{formatFileSize(a.size)}</span>
+                </button>
+              );
+            }
+          }
+        })}
       </div>
 
       <div className="type-meta flex items-center gap-2 border-t border-[var(--border-subtle)] px-3 py-1.5 text-[var(--text-muted)]">


### PR DESCRIPTION
## Summary

MentionPicker had 4 separate `.map()` blocks that each iterated all items with redundant kind guards. Replaced with a single `items.map()` using a switch. Items are already pre-filtered by activeTab in the useMemo, so the per-kind guards never filtered anything.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The 4 map blocks all execute every render. 3 of them produce only null elements. Shared className and selectedAttr were duplicated across all 4 blocks. Adding a new tab required copy-pasting an entire block.

## What changed?

- Replaced 4 `{activeTab === 'X' && items.map(...)}` blocks with one `items.map()` + `switch (item.kind)`
- Extracted shared `className` and `selectedAttr` into local variables computed once per item
- Net reduction: 108 lines removed, 91 added

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is contained to a single renderer component's JSX output

## Linked issues

Closes #336

## Validation

- [x] `pnpm lint`
- [ ] `pnpm test`
- [x] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm lint: 0 errors (1 pre-existing warning in unrelated file)
pnpm --filter @clawwork/desktop build: success (5,019 kB bundle)
Prettier check on MentionPicker.tsx: pass
Architecture guardrails: pass
```

## Screenshots or recordings

No visual changes. The rendered output is identical for all 4 tabs.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

This contribution was developed with AI assistance (Codex).