### PR TITLE
[Docs] Add Teams design journey blog post (v0.0.14 retro)

### DIFF
--- a/website/src/docs/en/2026-03-31-multi-agent-orchestration.md
+++ b/website/src/docs/en/2026-03-31-multi-agent-orchestration.md
@@ -1,0 +1,475 @@
+---
+title: "TaskRoom: ClawWork's Thin Collaboration Layer for Multi-Agent Orchestration"
+description: Extend one Task into 1 Conductor + N Performers using only OpenClaw's native session primitives — no external worker runtime
+date: 2026-03-31
+---
+
+# TaskRoom: ClawWork's Thin Collaboration Layer for Multi-Agent Orchestration
+
+> No external workers. Orchestrate multi-agent collaboration purely with session primitives.
+
+TaskRoom has a simple goal: Task is the product object, a set of sessions is the execution surface, and TaskRoom is the thin collaboration projection in between.
+
+- A normal Task stays `1 Task = 1 session`
+- A new `Ensemble Task` = `1 Conductor + N Performers`
+- Orchestration is built entirely on OpenClaw's native session primitives — no second external worker system
+
+It's a deliberately thin collaboration layer, currently implemented directly on top of native OpenClaw sessions. The core operations are already isolated behind dependency injection, so extracting them into a standalone `RoomAdapter` interface later is cheap — when we swap to a Matrix or another protocol backend, only the Adapter changes. The product model above it stays put.
+
+## Roles
+
+| Role              | English       | What it does                                                                                                                                                                                                                                                 |
+| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Conductor**     | Conductor     | The coordinator. Does not solve problems directly. Analyzes the task, dynamically picks Performers, dispatches messages, aggregates results. Technically the Task's primary session, seeded with scheduling instructions via `sessions.create(message=...)`. |
+| **Performer**     | Performer     | The executor. Runs a concrete task inside an isolated session. Created by the Conductor via `sessions_spawn`, dispatched via `sessions_send`.                                                                                                                |
+| **Ensemble Task** | Ensemble Task | A multi-agent Task. The user explicitly selects this mode when creating a Task. 1 Conductor + N Performers.                                                                                                                                                  |
+
+The role model is intentionally restrained. Multi-agent is not a replacement for ClawWork's existing Task model — it's a new task mode layered on top. Implementation complexity concentrates in Performer discovery and stop logic, which we cover later.
+
+**What we're not doing:**
+
+- Not reinventing the message protocol — reuse the existing `Message` model, just add `sessionKey` and a few related fields
+- Not building a permission system — the Performer whitelist is derived from Conductor spawn relationships, no ACL
+- Not replacing `Task` / `Message` / `Artifact` — these product objects don't move, TaskRoom is only a collaboration projection
+
+## User flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CW as ClawWork Client
+    participant GW as OpenClaw Gateway
+    participant C as Conductor Session
+    participant P1 as Performer A
+    participant P2 as Performer B
+
+    Note over U,CW: Create Ensemble Task
+
+    U->>CW: New Task, select "Ensemble" mode
+    U->>CW: (optional) manually pick agents
+    CW->>CW: Create Task, mark ensemble=true
+
+    Note over CW,GW: Conductor init (atomic step)
+
+    CW->>GW: sessions.create(key, agentId,<br/>message=Conductor dispatch prompt)
+    GW->>C: create session + deliver initial message
+    GW-->>CW: created
+    CW->>CW: conductorReady=true -> unlock user input
+
+    Note over U,CW: Start conversation
+
+    U->>CW: "Refactor the login module and write tests"
+    CW->>GW: chat.send -> Conductor session
+    GW->>C: deliver message
+
+    Note over C: Conductor analyzes task<br/>decides it needs coder + tester
+
+    C->>GW: sessions_spawn(agentId:"coder")
+    GW-->>P1: create Performer A session
+    GW->>CW: event(lifecycle:start, sessionKey=P1)
+
+    C->>GW: sessions_spawn(agentId:"tester")
+    GW-->>P2: create Performer B session
+    GW->>CW: event(lifecycle:start, sessionKey=P2)
+
+    Note over CW: candidate queue -> sessions.list(spawnedBy)<br/>verify -> Performer whitelist
+
+    C->>GW: sessions_send(P1, "refactor login module")
+    Note over CW: UI: Conductor -> Performer A
+    C->>GW: sessions_send(P2, "write tests for login module")
+    Note over CW: UI: Conductor -> Performer B
+
+    Note over P1,P2: Performers execute independently (separate active turns)
+
+    P1->>GW: event(chat, delta/final, sessionKey=P1)
+    GW->>CW: write into P1's active turn -> merge into timeline
+    P2->>GW: event(chat, delta/final, sessionKey=P2)
+    GW->>CW: write into P2's active turn -> merge into timeline
+
+    C->>GW: event(chat, final, sessionKey=Conductor)
+    GW->>CW: Conductor summary -> timeline
+
+    Note over U,CW: Stop conversation
+
+    U->>CW: click "Stop"
+    CW->>CW: room status -> stopping
+    CW->>GW: sessions.list(spawnedBy=conductor)
+    CW->>GW: chat.abort(Conductor)
+    CW->>GW: chat.abort(P1)
+    CW->>GW: chat.abort(P2)
+    CW->>CW: room status -> stopped
+    Note over CW: late discovery events -> compensating abort
+```
+
+## Data structures
+
+```text
+Task
+  |- sessionKey              -> Conductor session
+  |- ensemble: boolean       -> is this an Ensemble Task
+
+TaskRoom
+  |- taskId
+  |- conductorSessionKey     -> = task.sessionKey
+  |- conductorReady          -> boolean
+  |- status                  -> active | stopping | stopped
+  |- performers[]            -> { sessionKey, agentId, agentName, emoji, verifiedAt }
+
+Message
+  |- sessionKey              -> source session
+  |- agentId                 -> source agent
+  |- runId                   -> upstream run id
+```
+
+## Message model upgrade
+
+### Key promoted from taskId to sessionKey
+
+A lot of runtime state is still keyed by `taskId` today. That's fine for single-agent, but with multiple sessions streaming at the same time they step on each other.
+
+The upgraded target:
+
+```text
+activeTurnBySession[sessionKey]     -> each session has its own active turn
+processingBySession.has(sessionKey) -> each session has its own processing flag
+messagesByTask[taskId]              -> read-only aggregated view (merged by timestamp)
+```
+
+Every message must carry:
+
+- `sessionKey`
+- `agentId`
+- `runId`
+
+The timeline still renders by Task, but the real isolation unit must be `sessionKey`.
+
+### SQLite message table upgrade
+
+New columns:
+
+| Column        | Type | Meaning         |
+| ------------- | ---- | --------------- |
+| `session_key` | TEXT | Source session  |
+| `agent_id`    | TEXT | Source agent id |
+| `run_id`      | TEXT | Upstream run id |
+
+Dedup key:
+
+```text
+(task_id, session_key, role, timestamp)
+```
+
+Legacy messages are migrated by backfilling `session_key` to `task.sessionKey`.
+
+Core rule: writes are isolated by `sessionKey`, display aggregates by `taskId`.
+
+## OpenClaw capabilities
+
+### Reusable primitives
+
+| Primitive          | Type                         | What it does                                                   |
+| ------------------ | ---------------------------- | -------------------------------------------------------------- |
+| `sessions_spawn`   | Agent tool                   | Conductor spawns a Performer session                           |
+| `sessions_send`    | Gateway `sessions.send`      | Conductor sends a message to a specific Performer              |
+| `sessions_history` | Agent tool -> `chat.history` | Fetch session message history                                  |
+| `sessions_yield`   | Agent tool                   | Agent yields its current turn                                  |
+| `sessions.list`    | Gateway method               | List sessions, supports `spawnedBy` filter                     |
+| `sessions.create`  | Gateway method               | Create a session, supports `task`/`message` as initial payload |
+| `agents.list`      | Gateway method               | `{ id, name, identity: { name, emoji, avatar } }`              |
+
+> `sessions.create` only landed in OpenClaw 2026.03.18 — mind the version.
+
+### Performer session key format
+
+A session created by `sessions_spawn(agentId:"timi")` gets a key like:
+
+```text
+agent:<agentId>:subagent:<uuid>
+```
+
+For example:
+
+```text
+agent:timi:subagent:d2c7bcdc-37af-4880-ba83-db58c86963da
+```
+
+- the key embeds the Performer's `agentId`
+- the key does not embed `taskId`
+- you cannot route it back to a Task from the key alone
+- ownership must be recovered via `sessions.list(spawnedBy=conductorKey)`
+- config requirement: `subagents.allowAgents: ["*"]`
+
+### Prerequisite: enable subagent spawn
+
+`allowAgents` is a per-agent setting, not under `agents.defaults`. It must be set explicitly on the agent the Conductor runs as.
+
+`~/.openclaw/openclaw.json`:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "subagents": {
+          "allowAgents": ["*"]
+        }
+      }
+    ]
+  }
+}
+```
+
+Without this, `sessions_spawn` from the Conductor comes back with `agentId not allowed`.
+
+### Verified unavailable
+
+- `chat.send` / `sessions.patch` / `sessions.create` do not support system prompt injection
+- There is currently no gateway method that sets a system prompt
+- `sessions.create` without a `message` argument only creates a record — it does not start the agent process
+- `sessions_send` to an empty session does not trigger processing
+
+## Conductor initialization
+
+Conductor init uses:
+
+```text
+sessions.create(key, agentId, message=dispatch prompt)
+```
+
+Flow:
+
+1. `sessions.create(key, agentId, message=dispatch prompt)`
+2. On success, set `conductorReady=true`
+3. Block user input until `conductorReady`
+
+### Dispatch prompt template
+
+The system prompt defines the Conductor role, forbids silent fallback to external orchestration paths, and spells out the serial vs. parallel dispatch modes.
+
+```text
+You are a task coordinator (Conductor). Your responsibilities:
+1. Analyze the user's task and determine if multi-agent collaboration is needed
+2. Select appropriate agents (Performers) from the available list using sessions_spawn
+3. Dispatch tasks to Performers using sessions_send
+4. You do not solve problems directly - you split, dispatch, and summarize
+5. When all Performers complete, summarize results for the user
+
+Hard rules:
+- For delegated work, you MUST use OpenClaw native session tools only: sessions_spawn and sessions_send.
+- Do NOT use coding-agent skills, exec/process background workers, shell-launched copilots, or any external CLI orchestration path.
+- Do NOT switch to another execution method if native subagent delegation is available.
+- If native delegation fails, report the blocker instead of silently falling back to another worker model.
+
+Dispatch modes:
+- Serial: sessions_send(sessionKey, message, timeoutSeconds:30) - blocks until reply
+- Parallel: sessions_send(sessionKey, message, timeoutSeconds:0) - fire-and-forget, result pushed back when done
+Use serial when the next step depends on this result. Use parallel when multiple steps are independent.
+
+Performer sessions are reusable. You can send multiple messages to the same session for iterative work.
+
+Available agents:
+{agentCatalog}
+
+User-selected agents (if any):
+{userSelectedAgents}
+```
+
+The single most important line is the explicit ban on silently falling back to an external orchestration path. Either go through native OpenClaw session orchestration, or surface the blocker. No silent fallback.
+
+> This is the Tier-1 system-level hard constraint, and it's scoped to orchestration strategy. Tier-2 role definitions are also supported and will be covered separately.
+
+## Conductor <-> Performer communication
+
+Coordination happens on the Conductor agent side (inside OpenClaw). The ClawWork client is not part of the scheduling loop.
+
+### Communication modes
+
+| Mode                             | Behavior                                        | Use case                 |
+| -------------------------------- | ----------------------------------------------- | ------------------------ |
+| `sessions_send(timeout:30)`      | Blocks, returns the Performer's reply           | Serial coordination      |
+| `sessions_send(timeout:0)`       | Fire-and-forget, no wait                        | Parallel dispatch        |
+| `sessions_spawn(mode:"run")`     | Non-blocking, result pushed back to Conductor   | One-shot task            |
+| `sessions_spawn(mode:"session")` | Create a persistent session, result pushed back | Reusable multi-turn chat |
+
+- Performer sessions are reusable
+- OpenClaw subagent results are pushed back to the Conductor automatically
+- OpenClaw explicitly reminds you: `Auto-announce is push-based. Do NOT poll.`
+
+### Multi-step collaboration example
+
+```text
+Conductor receives user message: "Refactor the login module and write tests"
+
+-- Serial phase: design first --
+
+1. sessions_send(pm-agent, "Design a refactor plan for login module", timeout:30)
+   -> blocks -> design doc returned
+
+-- Parallel phase: coding and test design can proceed in parallel --
+
+2. sessions_send(code-agent, "Implement per design: {design doc}", timeout:0)
+   sessions_send(test-agent, "Design test cases from: {design doc}", timeout:0)
+   -> two Performers work in parallel
+   -> each result pushed back to Conductor when done
+
+-- Serial phase: need code before review --
+
+3. Conductor receives code-agent result
+   sessions_send(review-agent, "review: {code}", timeout:30)
+   -> blocks -> review notes returned
+
+-- Serial phase: need code before running tests --
+
+4. Conductor has test-agent's test cases + code-agent's code
+   sessions_send(test-agent, "Run these test cases against this code: {code}", timeout:30)
+   -> blocks -> test results returned
+
+-- Iteration phase: loop as needed --
+
+5. Review flagged issues -> sessions_send(code-agent, "Fix: {review notes}", timeout:30)
+   Design flaws -> sessions_send(pm-agent, "Adjust: {issues}", timeout:30)
+   -> sessions are reused, no respawn needed
+
+6. All green -> Conductor summarizes and replies to the user
+```
+
+The example isn't meant as a fixed recipe — it's illustrating a principle: serialize dependency chains, parallelize independent steps, reuse sessions whenever possible.
+
+### User message entry: unicast to Conductor, `@` for direct routing
+
+In an Ensemble Task, multiple agents are online at the same time. If every user message were broadcast to all sessions, it would create a storm of noise — every Performer tries to respond to the same sentence, all talking over each other.
+
+So by default every message goes only to the Conductor, and the Conductor decides whether to dispatch. Users can bypass it with `@` syntax to target a specific session.
+
+| Input         | Target                              | Notes                    |
+| ------------- | ----------------------------------- | ------------------------ |
+| no `@`        | Conductor                           | Default entry point      |
+| `@code-agent` | code-agent session                  | Bypass Conductor, direct |
+| `@code @test` | code + test sessions, one copy each | Concurrent send          |
+| `@all`        | Conductor + all Performers          | Broadcast                |
+
+When the user targets a Performer directly, a notification is also sent to the Conductor so it doesn't lose context — it learns what the user just said to which Performer.
+
+## Performer discovery
+
+The most grounded and most easily underestimated part of the whole scheme.
+
+A Performer key looks like:
+
+```text
+agent:<agentId>:subagent:<uuid>
+```
+
+It has no `taskId`, so the client cannot determine ownership by parsing the key alone. We need a two-step process.
+
+### Passive discovery -> candidate queue
+
+```text
+Gateway event arrives -> parseTaskIdFromSessionKey(sessionKey)
+  |- success (ClawWork-format key) -> normal routing
+  |- failure -> isSubagentSession(sessionKey)?
+       |- yes -> check registered subagentKeyMap
+       |    |- hit -> route by taskId
+       |    |- miss -> buffer event + enqueue to global candidate queue
+       |- no -> drop (non-ClawWork event)
+```
+
+### Authoritative verification -> whitelist
+
+```text
+Candidate arrives -> debounce ->
+  filter active ensemble tasks by gatewayId
+  for each candidate sessionKey:
+    for each active ensemble task on the same gateway:
+      sessions.list(spawnedBy=conductorSessionKey)
+      if candidate sessionKey is in the returned subagent keys:
+        register: subagentKeyMap[candidateKey] = { taskId, agentId }
+        persist to task_room_sessions table
+        if any events arrived early, replay buffered events into message-store
+```
+
+Triggers:
+
+- Debounced verification after a candidate event arrives
+- Full refetch when a Task is opened
+- Re-enumeration after reconnect
+- Immediate compensating abort when a new key shows up during `stopping`
+
+This logic is fiddly, but it buys correctness. Since the Gateway broadcasts all session events, ownership must be verified — there's no shortcut.
+
+## Stop conversation
+
+When multiple sessions need to be managed, the old "stop conversation" flow no longer covers the case. Stop still reuses `chat.abort`, but with an added `stopping` intermediate state.
+
+Normal Task:
+
+```text
+chat.abort(task.sessionKey)
+```
+
+Ensemble Task:
+
+```text
+1. room status -> stopping
+2. sessions.list(spawnedBy=conductor) -> re-enumerate
+3. merge known + newly discovered session keys
+4. chat.abort(each sessionKey) concurrently - Promise.allSettled
+5. room status -> stopped
+```
+
+There's one edge case to handle: **late spawn**.
+
+While in `stopping` or `stopped`, if a new Performer key shows up, we immediately fire another abort for it. Otherwise the user thinks the whole collaboration is stopped, while sessions keep running in the background — which is unacceptable.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenClaw Gateway"
+        GW[Gateway WS :18789]
+        CS[Conductor Session<br/>agent:main:clawwork:deviceId:task:T1]
+        PS1[Performer Session<br/>agent:coder:subagent:uuid1]
+        PS2[Performer Session<br/>agent:tester:subagent:uuid2]
+        CS -.->|sessions_spawn| PS1
+        CS -.->|sessions_spawn| PS2
+        CS -.->|sessions_send| PS1
+        CS -.->|sessions_send| PS2
+        GW -.->|sessions.list<br/>spawnedBy=conductor| CS
+    end
+
+    subgraph "Electron Main Process"
+        Transport[Gateway Transport<br/>single WS connection]
+        DB[(SQLite<br/>tasks + task_room_sessions<br/>+ messages with session_key)]
+        IPC[IPC Handlers]
+        Transport <-->|frames| GW
+        IPC <--> DB
+    end
+
+    subgraph "Core Layer"
+        Dispatcher[gateway-dispatcher<br/>subagent key routing<br/>candidate queue -> whitelist verification]
+        TaskStore[task-store<br/>ensemble flag]
+        RoomStore[room-store<br/>subagentKeyMap<br/>performer whitelist<br/>stopping/stopped state machine]
+        MsgStore[message-store<br/>activeTurn by sessionKey<br/>taskId aggregated view]
+        Sync[session-sync<br/>independent chain per sessionKey]
+
+        Transport -->|session events| Dispatcher
+        Dispatcher -->|by sessionKey| MsgStore
+        Dispatcher -->|candidate performer| RoomStore
+        RoomStore -->|sessions.list verify| Transport
+        RoomStore <-->|persist/hydrate| IPC
+        Sync -->|by sessionKey| MsgStore
+    end
+
+    subgraph "Renderer UI"
+        Timeline[Timeline<br/>agent name+avatar + routing label]
+        Participants[Performer roster]
+        ChatInput[ChatInput<br/>-> Conductor session<br/>conductorReady guard]
+        StopBtn[Stop conversation<br/>stopping -> abort -> stopped]
+
+        MsgStore --> Timeline
+        RoomStore --> Timeline
+        RoomStore --> Participants
+        StopBtn -->|chat.abort x N| Transport
+    end
+```

--- a/website/src/docs/en/2026-04-09-teams-design-journey.md
+++ b/website/src/docs/en/2026-04-09-teams-design-journey.md
@@ -1,0 +1,386 @@
+---
+title: 'Teams: Packaging Multi-Agent Collaboration as an Installable Unit'
+description: v0.0.14 productizes the TaskRoom multi-agent runtime as Team — a pre-configured set of agents and a workflow, packaged for distribution and one-click install
+date: 2026-04-09
+---
+
+# Teams: Packaging Multi-Agent Collaboration as an Installable Unit
+
+> A skill is an atom, an agent is an entity, a team is a pre-configured set of agents plus a workflow.
+
+v0.0.14 has exactly one theme: Teams. 91 commits, 80 PRs across the whole release.
+
+TaskRoom answered "how do multiple agents run." Team answers "how does the user know how many agents to configure, what each one does, and which workflow to follow." The former is a runtime, the latter is a product wrapper.
+
+## Why Team exists
+
+The most common feedback after TaskRoom shipped wasn't "it doesn't run" — it was "I don't know how many agents I'm supposed to configure."
+
+From the user's point of view, wiring up a multi-agent task means answering a pile of questions: How many agents? What role is each one? What system prompt? Which skills to install? Who is the coordinator? How do they collaborate?
+
+These questions aren't hard for someone who already knows how. But they are an **adoption barrier**, not a capability gap. OpenClaw's runtime primitives are strong enough, ClawWork's Ensemble Task already runs, but the missing piece is a "pick one and go" abstraction.
+
+So the Team definition is simple:
+
+> A Team = a pre-configured set of agents + a workflow definition + the required skills and tools, packaged as an installable, shareable unit.
+
+Team is not a new product layer. It's the product wrapper around the Room runtime.
+
+| Team concept               | Room runtime          | OpenClaw layer           |
+| -------------------------- | --------------------- | ------------------------ |
+| Manager (coordinator)      | Conductor             | conductor session        |
+| Specialist agent (worker)  | Performer             | subagent session         |
+| TEAM.md workflow           | Conductor prompt body | `buildConductorPrompt()` |
+| Assigning a task to a Team | Ensemble task         | `task.ensemble = true`   |
+
+The three-layer progression:
+
+```text
+skill  -> single atomic capability
+agent  -> an AI entity with a role, a personality, and skills
+team   -> a pre-configured set of agents + workflow, packaged for distribution
+```
+
+## Team file layout
+
+A Team is a directory, not a JSON config. Git-native.
+
+```text
+<team-name>/
+|- TEAM.md              # metadata + workflow
+|- agents/
+    |- manager/         # required, becomes the Conductor
+    |   |- IDENTITY.md
+    |   |- SOUL.md
+    |   |- skill.json
+    |- developer/       # becomes a Performer
+    |   |- IDENTITY.md
+    |   |- SOUL.md
+    |   |- skill.json
+    `- reviewer/
+    |   |- IDENTITY.md
+    |   |- SOUL.md
+    |   |- skill.json
+```
+
+TEAM.md's frontmatter is metadata; the body is the workflow text.
+
+```yaml
+---
+name: Software Development Team
+description: Full-stack dev team for architecture, implementation, and review.
+version: 1.0.0
+agents:
+  - id: manager
+    name: Tech Lead
+    role: coordinator
+  - id: developer
+    name: Developer
+    role: worker
+  - id: reviewer
+    name: Code Reviewer
+    role: worker
+---
+
+# Workflow
+
+... the collaboration flow written by the Team author ...
+```
+
+Each agent has two files:
+
+- `IDENTITY.md` — the role definition. Its `description` field is distilled into the agent catalog the Conductor sees. Lightweight context for dispatch decisions.
+- `SOUL.md` — personality, communication style, behavioral traits. Injected into the Performer's subagent session as system context.
+
+The Conductor doesn't need the full identity and soul loaded during orchestration. All it needs is "who this agent is and what they're good at." The full content only loads when the Performer session is spawned.
+
+### No full YAML library in the parser
+
+TEAM.md's frontmatter is a stripped-down YAML subset. Reasons we don't pull in a full YAML parser:
+
+- Fewer dependencies is better, especially ones with a history of parser-level attack surface
+- We only need scalars, lists of scalars, and lists of objects — no anchors, aliases, or tags
+- Validation rules in the parser itself are more direct than a schema validator
+
+Hard validation rules:
+
+- must have `name`
+- must have a non-empty `agents` array
+- every agent must have `id` and `role` (`coordinator` or `worker`)
+- **must have exactly 1 coordinator**
+
+The last rule directly determines Conductor role assignment — ambiguity is not allowed.
+
+## Layered Conductor prompt
+
+The system prompt the Conductor sees is two segments concatenated:
+
+```text
+Layer 1: buildConductorPrompt(agentCatalog)   <- runtime hard constraints, not overridable
+Layer 2: TEAM.md body                          <- domain workflow, controlled by Team author
+```
+
+Layer 1 is a hard protocol constraint at the system level. Only a handful of rules, but every one of them is a lesson learned:
+
+- Delegated work **must** go through OpenClaw native subagent sessions (`sessions_spawn` / `sessions_send`)
+- **Forbidden**: falling back to coding-agent skills, exec background processes, shell-launched copilots, or any side-channel orchestration
+- Native delegation failure -> **report the blocker**, do not silently switch to another execution method
+- Subagent completion is push-based — **do not** poll `sessions_list` or sleep-wait on state
+
+The last one is the most critical. OpenClaw subagents automatically push results back to the Conductor when done, but without an explicit ban, the LLM's instinct is to write a sleep-then-check loop. An explicit "Do NOT poll" beats any amount of documentation.
+
+Layer 2 is the domain workflow, fully under the Team author's control. It can spell out team goals, division of labor, collaboration pacing, acceptance criteria. What it **cannot change** is how agents talk to each other.
+
+Why this split matters: community-contributed Teams cannot break runtime correctness. No matter what the TEAM.md body says, the Conductor always routes Performers through the correct protocol path.
+
+## Install: turning a Team into a runnable multi-agent
+
+The install flow is a transactional async generator. Every step yields a progress event, and failures roll back.
+
+```text
+1. Parse TEAM.md
+   |- validate structure
+   `- extract agent list
+
+2. For each agent:
+   |- agents.create         -> create agent in OpenClaw
+   |- agents.files.set      -> write IDENTITY.md
+   |- agents.files.set      -> write SOUL.md
+   `- skills.install x N    -> install each required skill
+
+3. Persist team metadata in ClawWork's local DB
+```
+
+The yield event sequence:
+
+```text
+agent_creating -> agent_created
+-> file_setting -> file_set
+-> skill_installing -> skill_installed
+-> team_persisting -> team_persisted
+-> done
+```
+
+On failure, any already-created agents are rolled back automatically. Either the whole install succeeds or the state returns to the beginning — no intermediate "Team created but skills missing" state is allowed.
+
+### Reinstall safety
+
+`TeamsHub reinstall` reuses existing Gateway agents instead of recreating them. The first cut of this code called `agents.create` on every reinstall, and after some use the user's Gateway ended up littered with orphan agents.
+
+The fix: before install, query `agents.list`. If an agent with the same name exists, just call `agents.files.set` to overwrite its files. Only call `create` when it doesn't exist.
+
+## TeamsHub: Git-native distribution
+
+There's a deliberate stance on distribution: **no centralized API**.
+
+TeamsHub is just a GitHub repository. Each Team is a directory in the repo. ClawWork fetches TEAM.md and agent files via GitHub raw URLs. No registry, no upload review, no API key.
+
+A community registry — `clawwork-ai/teamshub-community` — is built in, and users can add custom GitHub repos as additional registries. Registry ID is the first 12 chars of the URL's SHA256 hash, with path traversal guarded.
+
+Direct wins from Git-native distribution:
+
+- **Zero infrastructure cost** — the registry is a GitHub repo, fork it to run your own
+- **Versioning for free** — Team definitions are Git-managed: diff, revert, PR review
+- **Community-driven** — contributing a Team means opening a PR
+
+Browsing and installing run entirely through the standalone `TeamsHubTab`:
+
+```text
+Teams page -> TeamsHub tab -> pick a Team
+  -> preview structure (agents, roles, required skills)
+  -> assign gateway and model for each agent
+  -> confirm -> install
+```
+
+## AI Builder: create a Team in natural language
+
+Manually creating a Team means going through a three-step wizard: fill in team info -> configure each agent -> review & install. For users unfamiliar with multi-agent orchestration, the bar is still high.
+
+AI Builder turns this into a conversation:
+
+```text
+User: "I want a research team"
+  -> AI breaks down roles, suggests models, generates system prompts
+  -> User reviews and tweaks in the right-side panel
+  -> Hands off to the standard install flow
+```
+
+Implementation-wise it reuses the existing `useSystemSession`. The Agent side already had an AI Builder, so the Team side lines up with the same capability. The AI outputs a `team-config` JSON block that's validated and sanitized into a standard `TeamInfo + AgentDraft[]`, then feeds straight into `useTeamInstall`.
+
+**The AI does not handle skills.** Skills need exact ClawHub slugs, and the LLM's guesses aren't reliable. The next step is to wire up the `skills.search` Gateway RPC and add a debounced search + autocomplete on the right-side panel. Doing nothing beats guessing wrong.
+
+## Performer discovery: the most easily underestimated part
+
+This section is covered in depth in the TaskRoom post. Here I only cover what Teams added.
+
+Performer session key format:
+
+```text
+agent:<agentId>:subagent:<uuid>
+```
+
+No `taskId`. The Gateway broadcasts all session events, so the client has to verify ownership itself. Two steps:
+
+```text
+Gateway event -> parseTaskIdFromSessionKey
+  |- success -> normal routing
+  `- failure -> isSubagentSession?
+       |- yes -> check subagentKeyMap
+       |    |- hit -> route by taskId
+       |    `- miss -> candidate queue -> debounced sessions.list verification
+       `- no -> drop
+```
+
+What Teams added is **#319**: stop discovering Performers by consuming session events, and instead discover them by subscribing to `sessions.changed`. Since the Gateway broadcasts everything, running ownership checks only on the consumption path leaves a window open for cross-Task data leaks. Once discovery moves to a subscription, ownership is determined before routing happens. 325 lines of tests guard this boundary.
+
+## What a Team looks like: Software Development Team
+
+The TeamsHub community registry has a few sample Teams today. The most representative is the Software Development Team:
+
+```text
+agents:
+  - manager: Tech Lead    (coordinator)  -> split work, dispatch, review results
+  - developer: Developer  (worker)       -> implement to the design
+  - reviewer: Code Reviewer (worker)     -> review code
+```
+
+The workflow (Layer 2 body), at its core:
+
+```text
+1. Request arrives -> Tech Lead splits into design and implementation phases
+2. Design phase -> Tech Lead does the architecture design itself
+3. Implementation phase -> sessions_send(developer, design + impl task, serial)
+4. Review phase -> sessions_send(reviewer, code + review criteria, serial)
+5. Iterate: review flags issues -> sessions_send(developer, fix notes, serial) [session reuse]
+6. All green -> summarize result
+```
+
+The Layer 2 body only describes "what to do, in what order, with what acceptance criteria." It does not describe "which tool to use for communication." Communication is enforced by Layer 1.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenClaw Gateway"
+        GW[Gateway WS :18789]
+        CS[Conductor Session]
+        PS1[Performer: Developer]
+        PS2[Performer: Reviewer]
+        CS -.->|sessions_spawn| PS1
+        CS -.->|sessions_spawn| PS2
+        CS -.->|sessions_send| PS1
+        CS -.->|sessions_send| PS2
+    end
+
+    subgraph "Electron Main"
+        Transport[Gateway Transport]
+        DB[(SQLite<br/>teams + team_agents<br/>tasks + messages)]
+        Hub[TeamsHub Registry]
+        Transport <-->|WS| GW
+        Hub -->|raw.githubusercontent| Registry[GitHub Repos]
+    end
+
+    subgraph "Core"
+        TeamStore[team-store]
+        TeamInstaller[team-installer<br/>async generator]
+        TeamParser[team-parser<br/>minimal YAML]
+        RoomStore[room-store<br/>performer whitelist + state machine]
+        Dispatcher[gateway-dispatcher<br/>subagent routing]
+        MsgStore[message-store<br/>isolated by sessionKey]
+        Transport -->|session events| Dispatcher
+        Dispatcher -->|by sessionKey| MsgStore
+        Dispatcher -->|candidate performer| RoomStore
+        TeamParser --> TeamInstaller
+        TeamInstaller --> TeamStore
+    end
+
+    subgraph "Renderer"
+        TeamsPanel[TeamsPanel<br/>browse/create/edit]
+        HubTab[TeamsHub tab<br/>install/update]
+        AIBuilder[AI Builder<br/>natural-language creation]
+        Welcome[WelcomeScreen<br/>Agent/Team tab selection]
+        Bar[EnsembleAgentBar]
+        Timeline[Timeline]
+        RoomStore --> Bar
+        MsgStore --> Timeline
+    end
+```
+
+## Landing cadence: 25 PRs across a week
+
+Bottom-up, each layer stabilized before building the next one on top of it. All dates below are real merge dates.
+
+**Apr 1 (Wed) — TaskRoom prerequisite**
+
+- **#210** Multi-agent runtime lands. Conductor / Performer, candidate queue, whitelist, `stopping` state machine, message isolation by sessionKey — all in one PR. Without it, Teams would be an empty shell.
+
+**Apr 2 (Thu) — UI shell + skill template**
+
+- **#258** TeamsPanel UI shell, left nav entry, card layout, i18n
+- **#259** team-creator skill, a Claude Code-assisted creation skill template
+
+**Apr 3 (Fri) — Data layer**
+
+- **#260** EnsembleAgentBar, the multi-agent avatar bar component
+- **#262** Team data model, SQLite schema, Zustand store, IPC handlers
+
+Two tables: `teams` (team metadata) and `team_agents` (membership, composite primary key `teamId + agentId`). Membership updates run inside a transaction: delete all `team_agents`, re-insert.
+
+**Apr 4–5 (Weekend) — off**
+
+**Apr 6 (Mon) — engine**
+
+- **#266** Wire Team start-chat to the Room runtime, task-store ensemble support
+- **#268** TEAM.md parser + team-installer orchestrator, async generator, rollback
+
+**Apr 7 (Tue) — the burst day, beta.1 tagged**
+
+Nine PRs in one day — TeamsHub end-to-end + Team detail page + a handful of fixes:
+
+- **#270** Multi-step create Wizard, replacing the simple CreateTeamDialog
+- **#282** Team detail view, virtual file tree + inline editor, directly edit IDENTITY.md / SOUL.md
+- **#283** Agent description, a configurable description used for the Conductor's agent catalog
+- **#288** TeamsHub data layer, Git-native registry download, cache, path traversal guard
+- **#290** TeamsHub browse UI, TeamsHubTab, RegistryManageDialog
+- **#294** TeamsHub install flow, TeamHubDetailView, useTeamHubInstall
+- **#295** Defer Task creation — Team chat only creates a Task on the first message sent
+- **#296** Team detail view layout unification
+- **#299** Reinstall safety — TeamsHub reinstall reuses existing Gateway agents
+
+**v0.0.14-beta.1** was tagged at the end of this day.
+
+**Apr 8 (Wed) — AI Builder + runtime hardening**
+
+- **#303** AI Builder dialog, two-pane layout: left AI chat + right live config preview
+- **#304** WelcomeScreen refactor, tab-based Agent / Team / orchestrate mode selection
+- **#310 / #311** Ensemble flag persistence, keeping WelcomeScreen tab switching and Task switching consistent
+- **#313** Terminology unification — repo-wide switch to coordinator / worker, replacing the earlier mixed manager / specialist usage
+- **#319** Subagent event routing via `sessions.changed` subscription, preventing cross-Task data leaks
+- **#320** Extract WelcomeScreen gateway selector hook
+- **#321** Teams panel button visual hierarchy fix
+
+**Apr 9 (Thu) — v0.0.14 shipped**
+
+## Unfinished work
+
+**RoomAdapter abstraction.** OpenClaw operations are already isolated behind dependency injection, but spread across three deps interfaces. The plan is to extract a unified `RoomAdapter` interface:
+
+```typescript
+interface RoomAdapter {
+  createConductorSession(gatewayId, params);
+  sendToSession(gatewayId, sessionKey, content);
+  abortSession(gatewayId, sessionKey);
+  listPerformerSessions(gatewayId, conductorSessionKey);
+  isPerformerSession(sessionKey): boolean;
+  parseSessionKey(sessionKey): { agentId?; taskId?; isSubagent };
+  buildConductorPrompt(agentCatalog): string;
+}
+```
+
+Cost is low (~200 lines), zero business change. The point isn't to switch protocol backends now — it's so that when we eventually wire up Matrix or another protocol, the orchestration layer doesn't need to be rewritten.
+
+**Observability.** Multi-agent debugging is a real pain point. The plan is a single `traceId` threaded through the Conductor and all Performers, IPC-level start/success/failure logs, and renderer-side state transition tracing.
+
+**Skills search.** AI Builder doesn't touch skills today. Once `skills.search` Gateway RPC is wired up, add debounced search + autocomplete in the UI.
+
+**Team versioning.** The `version` field in TEAM.md already exists, but there's no upgrade flow yet. Next step: TeamsHub detects a new version -> prompts the user -> runs diff preview -> reinstall.

--- a/website/src/docs/zh/2026-04-09-teams-design-journey.md
+++ b/website/src/docs/zh/2026-04-09-teams-design-journey.md
@@ -1,0 +1,386 @@
+---
+title: Teams：把多 Agent 协作打包成可安装单元
+description: v0.0.14 把 TaskRoom 的多 Agent 运行时产品化为 Team，一组预配置好的 agents 和工作流，打包分发，一键安装
+date: 2026-04-09
+---
+
+# Teams：把多 Agent 协作打包成可安装单元
+
+> skill 是原子，agent 是实体，team 是一组预配置好的 agents 加工作流。
+
+v0.0.14 的主题只有一个词：Teams。整个版本 91 个 commit、80 个 PR。
+
+TaskRoom 解决的是"多 Agent 怎么跑"。Team 解决的是"用户怎么知道该配几个 Agent、分别干什么、按什么工作流协作"。前者是运行时，后者是产品封装。
+
+## 为什么要有 Team
+
+TaskRoom 上线之后，最直接的反馈不是"跑不起来"，而是"我不知道该配几个 Agent"。
+
+从用户视角看，配一个多 Agent 任务要回答一堆问题：要几个 agent？分别什么角色？用什么 system prompt？装哪些 skill？谁是 coordinator？怎么协作？
+
+这些问题对会用的人不难，但它们是**采纳障碍**，不是能力问题。OpenClaw 的运行时原语已经够强了，ClawWork 的 Ensemble Task 也能跑，缺的是一个"选一下就能用"的抽象。
+
+所以 Team 的定位很明确：
+
+> 一个 Team = 一组预配置好的 agents + 一份工作流定义 + 必要的 skills 和 tools，打包为一个可安装、可分享的单元。
+
+Team 不是新的产品层。它是 Room 运行时的产品化封装。
+
+| Team 概念            | Room 运行时           | OpenClaw 层              |
+| -------------------- | --------------------- | ------------------------ |
+| Manager（协调者）    | Conductor             | conductor session        |
+| 专业 Agent（执行者） | Performer             | subagent session         |
+| TEAM.md 工作流       | Conductor prompt body | `buildConductorPrompt()` |
+| 把任务分配给 Team    | Ensemble task         | `task.ensemble = true`   |
+
+三层递进：
+
+```text
+skill  -> 单一原子能力
+agent  -> 有角色、性格、技能的 AI 实体
+team   -> 一组预配置 agents + 工作流，打包分发
+```
+
+## Team 的文件结构
+
+Team 是一个目录，不是一个 JSON 配置。Git 原生。
+
+```text
+<team-name>/
+|- TEAM.md              # 元数据 + 工作流
+|- agents/
+    |- manager/         # 必需，成为 Conductor
+    |   |- IDENTITY.md
+    |   |- SOUL.md
+    |   |- skill.json
+    |- developer/       # 成为 Performer
+    |   |- IDENTITY.md
+    |   |- SOUL.md
+    |   |- skill.json
+    `- reviewer/
+    |   |- IDENTITY.md
+    |   |- SOUL.md
+    |   |- skill.json
+```
+
+TEAM.md 的 frontmatter 是元数据，body 是工作流文本。
+
+```yaml
+---
+name: Software Development Team
+description: Full-stack dev team for architecture, implementation, and review.
+version: 1.0.0
+agents:
+  - id: manager
+    name: Tech Lead
+    role: coordinator
+  - id: developer
+    name: Developer
+    role: worker
+  - id: reviewer
+    name: Code Reviewer
+    role: worker
+---
+
+# Workflow
+
+... Team 作者写的协作流程 ...
+```
+
+每个 agent 有两个文件：
+
+- `IDENTITY.md` - 角色定义。其 `description` 字段会被提炼进 Conductor 看到的 agent catalog，轻量上下文用于分派决策
+- `SOUL.md` - 性格、沟通风格、行为特征。注入 performer 的 subagent session 作为系统上下文
+
+Conductor 不需要在编排时加载完整 identity 和 soul，它只需要知道"这个 Agent 是谁、擅长什么"就够了。完整内容只有当 performer session 被 spawn 时才会加载进去。
+
+### parser 不引入完整 YAML 库
+
+TEAM.md 的 frontmatter 是一个精简的 YAML 子集，不用完整 YAML parser 是因为：
+
+- 依赖越少越好，尤其是 parser 这种有历史攻击面的东西
+- 只需要支持 scalar、list of scalar、list of object，不需要 anchor / alias / tag
+- 校验规则写在 parser 里，比用 schema validator 更直接
+
+校验硬约束：
+
+- 必须有 `name`
+- 必须有非空 `agents` 数组
+- 每个 agent 必须有 `id` 和 `role`（`coordinator` 或 `worker`）
+- **必须恰好 1 个 coordinator**
+
+最后一条直接决定了 Conductor 的角色归属，不允许模糊。
+
+## Conductor 的 prompt 分层
+
+Conductor 收到的 system prompt 是两段拼起来的：
+
+```text
+Layer 1: buildConductorPrompt(agentCatalog)   <- 运行时硬约束，不可覆盖
+Layer 2: TEAM.md body                          <- 领域工作流，Team 作者控制
+```
+
+Layer 1 是系统层的硬性协议约束。核心规则只有几条，但每条都是踩过的坑：
+
+- 委派工作 **必须** 走 OpenClaw 原生 subagent session（`sessions_spawn` / `sessions_send`）
+- **禁止** 降级到 coding-agent skills、exec 后台进程、shell 启动的 copilot、或任何旁路编排
+- 原生委派失败 -> **报告阻塞**，而不是静默切换到其他执行方式
+- 子任务完成是 push-based，**禁止** 轮询 `sessions_list` 或 sleep 等状态
+
+最后一条最关键。OpenClaw subagent 完成后会自动把结果推送回 Conductor，但不显式禁止，LLM 的本能是写 sleep-then-check 循环。加一条明确的 "Do NOT poll" 胜过任何文档。
+
+Layer 2 是 Team 作者完全控制的领域工作流。可以写团队目标、分工策略、协作节奏、验收标准。但它**不能改变** agents 之间的通信方式。
+
+这种分层的好处：社区贡献的 Team 无法破坏运行时的正确性。无论 TEAM.md body 怎么写，Conductor 始终通过正确的协议路径编排 Performer。
+
+## 安装：把一个 Team 变成可运行的多 Agent
+
+安装流程是一个事务性 async generator，每一步 yield 进度事件，失败回滚。
+
+```text
+1. 解析 TEAM.md
+   |- 校验结构
+   `- 提取 agent 列表
+
+2. 对每个 agent：
+   |- agents.create         -> 在 OpenClaw 创建 agent
+   |- agents.files.set      -> 写入 IDENTITY.md
+   |- agents.files.set      -> 写入 SOUL.md
+   `- skills.install x N    -> 安装所需的每个 skill
+
+3. 在 ClawWork 本地 DB 存储 team 元数据
+```
+
+yield 的事件序列：
+
+```text
+agent_creating -> agent_created
+-> file_setting -> file_set
+-> skill_installing -> skill_installed
+-> team_persisting -> team_persisted
+-> done
+```
+
+失败时自动回滚已创建的 agents。要么全部成功，要么回到初始状态——不允许"Team 创建了但没装 skill"这种中间态。
+
+### 重装安全
+
+`TeamsHub reinstall` 时复用已有的 Gateway agent，不重复创建。一开始的实现是每次 reinstall 都重新 `agents.create`，结果用户用了一段时间之后 Gateway 上挂着一堆孤儿 agent。
+
+改成：安装前先查 `agents.list`，如果同名 agent 已存在，直接 `agents.files.set` 覆盖文件即可，只有不存在时才 `create`。
+
+## TeamsHub：Git 原生分发
+
+分发方式上有一个明确的立场：**不做中心化 API**。
+
+TeamsHub 就是一个 GitHub 仓库。每个 Team 是仓库里的一个目录。ClawWork 通过 GitHub raw URL 拉 TEAM.md 和 agent 文件。没有注册中心、没有上传审核、没有 API key。
+
+内置了一个社区注册表 `clawwork-ai/teamshub-community`，用户也可以添加自定义 GitHub 仓库作为注册表。注册表 ID 是 URL 的 SHA256 哈希前 12 位，做了路径遍历防护。
+
+Git 原生分发的直接收益：
+
+- **零基础设施成本** - 注册表就是 GitHub repo，fork 即可自建
+- **版本控制天然** - Team 定义是 Git 管理的，可以 diff、revert、PR review
+- **社区驱动** - 贡献一个 Team 就是提一个 PR
+
+浏览和安装流程在 UI 上走完全独立的 `TeamsHubTab`：
+
+```text
+Teams 页 -> TeamsHub tab -> 选一个 Team
+  -> 预览结构（agents、角色、所需 skills）
+  -> 为每个 Agent 分配 gateway 和 model
+  -> 确认 -> 安装
+```
+
+## AI Builder：自然语言创建 Team
+
+手动创建 Team 要走三步 wizard：填团队信息 -> 逐个配 Agent -> review & install。对不熟悉多 Agent 编排的用户来说，门槛还是高。
+
+AI Builder 把这个问题转化为对话：
+
+```text
+用户: "我想要一个做研究的团队"
+  -> AI 拆解角色分工、建议 model、生成 system prompt
+  -> 用户在右面板 review 和微调
+  -> 对接标准安装流程
+```
+
+实现上复用了已有的 `useSystemSession`。Agent 侧已经有 AI Builder，Team 侧对齐这套能力。AI 输出 `team-config` JSON 块，经过校验和 sanitize 转为标准的 TeamInfo + AgentDraft[]，直接走 `useTeamInstall`。
+
+**AI 不处理 skills**。Skills 需要精确的 ClawHub slug，LLM 猜不靠谱。下一步计划接入 `skills.search` Gateway RPC，在右面板做 debounced 搜索 + autocomplete。不做比乱猜好。
+
+## Performer 发现：最容易被忽略的一环
+
+这部分在 TaskRoom 那篇文章里展开过，这里只讲 Teams 给它加了什么。
+
+Performer session key 格式：
+
+```text
+agent:<agentId>:subagent:<uuid>
+```
+
+没有 `taskId`。Gateway 广播所有 session 事件，客户端必须自己做归属验证。两步走：
+
+```text
+Gateway 事件 -> parseTaskIdFromSessionKey
+  |- 成功 -> 正常路由
+  `- 失败 -> isSubagentSession?
+       |- 是 -> 检查 subagentKeyMap
+       |    |- 命中 -> 按 taskId 路由
+       |    `- 未命中 -> 候选队列 -> debounced sessions.list 验证
+       `- 否 -> 丢弃
+```
+
+Teams 带来的改动是 **#319**：不再靠消费 session 事件时发现 performer，改成订阅 `sessions.changed` 主动发现。Gateway 广播所有事件，如果只在消费路径做归属判断，跨 Task 数据泄漏的窗口无法关闭。改成订阅拉取之后，归属关系的确定被前置到路由之前，325 行测试守着这个边界。
+
+## 一个 Team 长什么样：Software Development Team
+
+TeamsHub 社区注册表里目前有几个示例 Team，最典型的一个是 Software Development Team：
+
+```text
+agents:
+  - manager: Tech Lead    (coordinator)  -> 拆任务、分派、review 结果
+  - developer: Developer  (worker)       -> 按设计编码
+  - reviewer: Code Reviewer (worker)     -> review 代码
+```
+
+工作流（Layer 2 body）的核心是：
+
+```text
+1. 收到需求 -> Tech Lead 拆分为设计和实现两个阶段
+2. 设计阶段 -> Tech Lead 自己完成架构设计
+3. 实现阶段 -> sessions_send(developer, 设计 + 实现任务, serial)
+4. Review 阶段 -> sessions_send(reviewer, 代码 + review 标准, serial)
+5. 迭代: review 有问题 -> sessions_send(developer, 修复意见, serial) [session 复用]
+6. 全部通过 -> 汇总结果
+```
+
+Layer 2 body 只描述"做什么、什么顺序、什么验收标准"，不描述"用哪个工具通信"。通信方式由 Layer 1 强制。
+
+## 架构
+
+```mermaid
+graph TB
+    subgraph "OpenClaw Gateway"
+        GW[Gateway WS :18789]
+        CS[Conductor Session]
+        PS1[Performer: Developer]
+        PS2[Performer: Reviewer]
+        CS -.->|sessions_spawn| PS1
+        CS -.->|sessions_spawn| PS2
+        CS -.->|sessions_send| PS1
+        CS -.->|sessions_send| PS2
+    end
+
+    subgraph "Electron Main"
+        Transport[Gateway Transport]
+        DB[(SQLite<br/>teams + team_agents<br/>tasks + messages)]
+        Hub[TeamsHub Registry]
+        Transport <-->|WS| GW
+        Hub -->|raw.githubusercontent| Registry[GitHub Repos]
+    end
+
+    subgraph "Core"
+        TeamStore[team-store]
+        TeamInstaller[team-installer<br/>async generator]
+        TeamParser[team-parser<br/>minimal YAML]
+        RoomStore[room-store<br/>performer 白名单 + 状态机]
+        Dispatcher[gateway-dispatcher<br/>subagent 路由]
+        MsgStore[message-store<br/>按 sessionKey 隔离]
+        Transport -->|session 事件| Dispatcher
+        Dispatcher -->|按 sessionKey| MsgStore
+        Dispatcher -->|候选 performer| RoomStore
+        TeamParser --> TeamInstaller
+        TeamInstaller --> TeamStore
+    end
+
+    subgraph "Renderer"
+        TeamsPanel[TeamsPanel<br/>浏览/创建/编辑]
+        HubTab[TeamsHub tab<br/>安装/更新]
+        AIBuilder[AI Builder<br/>自然语言创建]
+        Welcome[WelcomeScreen<br/>Agent/Team tab 选择]
+        Bar[EnsembleAgentBar]
+        Timeline[Timeline]
+        RoomStore --> Bar
+        MsgStore --> Timeline
+    end
+```
+
+## 25 个 PR 的落地节奏
+
+自底向上，每一层稳了再做上一层。工作日期全部是真实 merge 日期。
+
+**Apr 1（周三）- TaskRoom 前置**
+
+- **#210** 多 Agent 运行时落地。Conductor / Performer、候选队列、白名单、`stopping` 状态机、消息按 sessionKey 隔离——全在这一个 PR 里。没有它，后面的 Teams 都是空壳
+
+**Apr 2（周四）- UI shell + skill 模板**
+
+- **#258** TeamsPanel UI shell，左导航入口、卡片布局、i18n
+- **#259** team-creator skill，Claude Code 辅助创建的 skill 模板
+
+**Apr 3（周五）- 数据层**
+
+- **#260** EnsembleAgentBar，多 Agent 头像栏组件
+- **#262** Team 数据模型，SQLite schema、Zustand store、IPC handlers
+
+两张表：`teams`（团队元数据）和 `team_agents`（成员关系，复合主键 `teamId + agentId`）。成员变更事务内做：删除所有 team_agents，重新插入。
+
+**Apr 4-5（周末）- 休**
+
+**Apr 6（周一）- 引擎**
+
+- **#266** 连接 Team start-chat 到 Room 运行时，task-store ensemble 支持
+- **#268** TEAM.md parser + team-installer 编排器，async generator、rollback
+
+**Apr 7（周二）- 爆发日，beta.1 打 tag**
+
+一天 9 个 PR，TeamsHub 全链路 + Team 详情页 + 多个 fix：
+
+- **#270** Multi-step 创建 Wizard，替换简单的 CreateTeamDialog
+- **#282** Team detail view，虚拟文件树 + 内联编辑器，直接改 IDENTITY.md / SOUL.md
+- **#283** Agent description，可配置的 agent 描述用于 Conductor agent catalog
+- **#288** TeamsHub 数据层，Git-native registry 下载、缓存、路径遍历防护
+- **#290** TeamsHub 浏览 UI，TeamsHubTab、RegistryManageDialog
+- **#294** TeamsHub 安装流程，TeamHubDetailView、useTeamHubInstall
+- **#295** 延迟 Task 创建，Team chat 等第一条消息发送才创建 Task
+- **#296** Team detail view 布局统一
+- **#299** 重装安全，TeamsHub reinstall 复用已有 Gateway agent
+
+**v0.0.14-beta.1** 在这天收工后打 tag。
+
+**Apr 8（周三）- AI Builder + 运行时加固**
+
+- **#303** AI Builder dialog，双面板：左 AI 对话 + 右实时 config 预览
+- **#304** WelcomeScreen 重构，tab-based Agent / Team / 编排模式选择
+- **#310 / #311** Ensemble flag 持久化，WelcomeScreen tab 切换和 Task 切换状态一致
+- **#313** 术语统一，全仓库统一为 coordinator / worker，取代之前混用的 manager / specialist
+- **#319** Subagent 事件路由，通过 `sessions.changed` 订阅发现 performer，防止跨 Task 数据泄漏
+- **#320** WelcomeScreen gateway selector hook 提取
+- **#321** Teams 面板 button 视觉层次修正
+
+**Apr 9（周四）- v0.0.14 发布**
+
+## 未完成的事
+
+**RoomAdapter 抽象**。当前 OpenClaw 操作已通过 deps 注入隔离，但分散在三个 deps interface 里。计划抽取统一的 `RoomAdapter` 接口：
+
+```typescript
+interface RoomAdapter {
+  createConductorSession(gatewayId, params);
+  sendToSession(gatewayId, sessionKey, content);
+  abortSession(gatewayId, sessionKey);
+  listPerformerSessions(gatewayId, conductorSessionKey);
+  isPerformerSession(sessionKey): boolean;
+  parseSessionKey(sessionKey): { agentId?; taskId?; isSubagent };
+  buildConductorPrompt(agentCatalog): string;
+}
+```
+
+成本很低（~200 行），零业务变化。目的不是现在要换协议后端，是为了未来接 Matrix 或其他协议时不用重写编排层。
+
+**可观测性**。多 Agent 调试是一个真实痛点。计划单一 `traceId` 贯穿 Conductor + 所有 Performer，IPC 级 start/success/failure 日志，renderer 侧状态转换追踪。
+
+**Skills 搜索**。AI Builder 现在不处理 skills，接入 `skills.search` Gateway RPC 之后，在 UI 做 debounced 搜索 + autocomplete。
+
+**Team 版本管理**。TEAM.md 的 `version` 字段已经有了，但还没接 upgrade 流程。下一步是 TeamsHub 发现新版本 -> 提示用户 -> 走 diff 预览 -> 重装。


### PR DESCRIPTION
## Summary

Add a zh-locale blog post documenting the design journey of the Teams feature that shipped in v0.0.14. The post walks through the gap between OpenClaw's multi-agent runtime primitives and ClawWork's single-Task product model, and how Teams bridges that gap by packaging pre-configured agents + workflow into an installable, shareable unit.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [x] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

v0.0.14 was the biggest release so far (91 commits, 80 PRs), and Teams was the headline feature. There was no public write-up explaining:

- why `skill -> agent -> team` exists as a layered abstraction
- how the two-layer Conductor prompt (runtime rules vs TEAM.md workflow body) keeps community-contributed teams from breaking protocol guarantees
- how TeamsHub uses a GitHub repo as the registry instead of a centralized API
- why the subagent event routing had to switch to `sessions.changed` subscription in #319
- the actual chronology of the 25 Teams-related PRs that landed between Apr 2 and Apr 9

This post fills that gap, in the same format and voice as the TaskRoom design post that shipped on Mar 31 (#221).

## What changed?

- New file: `website/src/docs/zh/2026-04-09-teams-design-journey.md`
- Front-matter `date: 2026-04-09` slots it after the existing 2026-03-31 TaskRoom post
- Mermaid architecture diagram covering Gateway / Electron main / Core / Renderer layers
- Real merge-date timeline for Teams PRs: #210 (Apr 1 TaskRoom) -> #258..#321 (Apr 2 - Apr 8) -> v0.0.14 (Apr 9)
- Sections: why Team exists, TEAM.md structure, Layer 1 / Layer 2 Conductor prompt split, transactional install generator, Git-native TeamsHub distribution, AI Builder constraints, Performer discovery delta from TaskRoom (#319), a concrete Software Development Team example, and an "unfinished work" section (RoomAdapter, observability, skills.search, Team versioning)

## Architecture impact

- **Owning layer**: website only (docs)
- **Cross-layer impact**: none
- **Invariants touched from `docs/architecture-invariants.md`**: none
- **Why those invariants remain protected**: this PR only adds a markdown file under `website/src/docs/zh/`; no source code, no protocol, no schema change, no session key handling touched, no persistence path modified

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
Docs-only change to website/src/docs/zh/. The website dev server
auto-discovers new markdown files via the docs index, so no build
step is required for the post to appear at /blogs/teams-design-journey.

Commit counts and PR numbers in the post were cross-checked against
`git log v0.0.13..v0.0.14 --max-count=500` before writing:
  - 91 commits, 80 PRs in the v0.0.14 range
  - 25 Teams-related PRs (filtered by team/ensemble/conductor/
    performer/welcome/subagent keyword)
  - Timeline: Apr 1 #210 -> Apr 2..Apr 8 Teams work -> Apr 9 ship
```

## Screenshots or recordings

No UI change. Content is a markdown blog post rendered by the existing website pipeline under `/blogs/teams-design-journey`.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Docs]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified (none)
- [x] The release note block is accurate
