### PR TITLE
fix: add .catch() handlers to IPC calls in Settings sections

### DIFF
--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -502,6 +502,7 @@
     "quickLaunchEnabled": "Schnellstart aktiviert",
     "quickLaunchShortcut": "Tastenkuerzel",
     "quickLaunchShortcutConflict": "Tastenkuerzel koennte mit einer anderen App kollidieren",
+    "quickLaunchUpdateFailed": "Quick Launch-Konfiguration konnte nicht aktualisiert werden",
     "readyToInstall": "Neustart fuer Update",
     "remove": "Entfernen",
     "rightPanelShortcut": "Kontextbereich ein-/ausblenden",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -502,6 +502,7 @@
     "quickLaunchEnabled": "Quick Launch enabled",
     "quickLaunchShortcut": "Shortcut",
     "quickLaunchShortcutConflict": "Shortcut may conflict with another app",
+    "quickLaunchUpdateFailed": "Failed to update Quick Launch config",
     "readyToInstall": "Restart to Update",
     "remove": "Remove",
     "rightPanelShortcut": "Toggle context panel",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -502,6 +502,7 @@
     "quickLaunchEnabled": "Inicio rápido activado",
     "quickLaunchShortcut": "Atajo",
     "quickLaunchShortcutConflict": "El atajo podría entrar en conflicto con otra aplicación",
+    "quickLaunchUpdateFailed": "Error al actualizar la configuración de Quick Launch",
     "readyToInstall": "Reiniciar para actualizar",
     "remove": "Eliminar",
     "rightPanelShortcut": "Alternar panel de contexto",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -502,6 +502,7 @@
     "quickLaunchEnabled": "クイック起動を有効にしました",
     "quickLaunchShortcut": "ショートカット",
     "quickLaunchShortcutConflict": "ショートカットが他のアプリと競合する可能性があります",
+    "quickLaunchUpdateFailed": "クイック起動の設定を更新できませんでした",
     "readyToInstall": "再起動してアップデート",
     "remove": "削除",
     "rightPanelShortcut": "コンテキストパネルの切替",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -502,6 +502,7 @@
     "quickLaunchEnabled": "빠른 실행이 활성화되었습니다",
     "quickLaunchShortcut": "단축키",
     "quickLaunchShortcutConflict": "다른 앱과 단축키가 충돌할 수 있습니다",
+    "quickLaunchUpdateFailed": "빠른 실행 설정을 업데이트하지 못했습니다",
     "readyToInstall": "재시작하여 업데이트",
     "remove": "제거",
     "rightPanelShortcut": "컨텍스트 패널 전환",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -502,6 +502,7 @@
     "quickLaunchEnabled": "Acesso Rápido ativado",
     "quickLaunchShortcut": "Atalho",
     "quickLaunchShortcutConflict": "O atalho pode conflitar com outro aplicativo",
+    "quickLaunchUpdateFailed": "Falha ao atualizar a configuração do Quick Launch",
     "readyToInstall": "Reiniciar para Atualizar",
     "remove": "Remover",
     "rightPanelShortcut": "Alternar painel de contexto",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -502,6 +502,7 @@
     "quickLaunchEnabled": "快速啟動已啟用",
     "quickLaunchShortcut": "快捷鍵",
     "quickLaunchShortcutConflict": "快捷鍵可能與其他應用程式衝突",
+    "quickLaunchUpdateFailed": "無法更新快速啟動設定",
     "readyToInstall": "重新啟動以更新",
     "remove": "移除",
     "rightPanelShortcut": "切換上下文面板",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -502,6 +502,7 @@
     "quickLaunchEnabled": "快速启动已开启",
     "quickLaunchShortcut": "快捷键",
     "quickLaunchShortcutConflict": "快捷键可能与其他应用冲突",
+    "quickLaunchUpdateFailed": "无法更新快速启动配置",
     "readyToInstall": "重启以更新",
     "remove": "移除",
     "rightPanelShortcut": "切换上下文面板",

--- a/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
@@ -85,15 +85,18 @@ export default function GeneralSection() {
   });
 
   useEffect(() => {
-    window.clawwork.getSettings().then((settings) => {
-      if (!settings?.notifications) return;
-      const n = settings.notifications;
-      setNotifyState((prev) => ({
-        taskComplete: n.taskComplete ?? prev.taskComplete,
-        approvalRequest: n.approvalRequest ?? prev.approvalRequest,
-        gatewayDisconnect: n.gatewayDisconnect ?? prev.gatewayDisconnect,
-      }));
-    }).catch((err) => console.error('[GeneralSection] getSettings failed:', err));;
+    window.clawwork
+      .getSettings()
+      .then((settings) => {
+        if (!settings?.notifications) return;
+        const n = settings.notifications;
+        setNotifyState((prev) => ({
+          taskComplete: n.taskComplete ?? prev.taskComplete,
+          approvalRequest: n.approvalRequest ?? prev.approvalRequest,
+          gatewayDisconnect: n.gatewayDisconnect ?? prev.gatewayDisconnect,
+        }));
+      })
+      .catch((err) => console.error('[GeneralSection] getSettings failed:', err));
   }, []);
 
   const handleNotificationToggle = useCallback(

--- a/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
@@ -93,7 +93,7 @@ export default function GeneralSection() {
         approvalRequest: n.approvalRequest ?? prev.approvalRequest,
         gatewayDisconnect: n.gatewayDisconnect ?? prev.gatewayDisconnect,
       }));
-    });
+    }).catch((err) => console.error('[GeneralSection] getSettings failed:', err));;
   }, []);
 
   const handleNotificationToggle = useCallback(

--- a/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
@@ -18,17 +18,23 @@ export default function SystemSection() {
   const [changingWorkspace, setChangingWorkspace] = useState(false);
 
   useEffect(() => {
-    window.clawwork.getQuickLaunchConfig().then((config) => {
-      setQuickLaunchEnabled(config.enabled);
-      setQuickLaunchShortcut(config.shortcut);
-    }).catch((err) => console.error('[SystemSection] getQuickLaunchConfig failed:', err));;
-    window.clawwork.getTrayEnabled()
-    .then(setTrayEnabled)
-    .catch((err) => console.error('[SystemSection] getTrayEnabled failed:', err));;
-    window.clawwork.getSettings().then((settings) => {
-      if (settings) setWorkspacePath(settings.workspacePath || t('common.notConfigured'));
-    })
-    .catch((err) => console.error('[SystemSection] getSettings failed:', err));;
+    window.clawwork
+      .getQuickLaunchConfig()
+      .then((config) => {
+        setQuickLaunchEnabled(config.enabled);
+        setQuickLaunchShortcut(config.shortcut);
+      })
+      .catch((err) => console.error('[SystemSection] getQuickLaunchConfig failed:', err));
+    window.clawwork
+      .getTrayEnabled()
+      .then(setTrayEnabled)
+      .catch((err) => console.error('[SystemSection] getTrayEnabled failed:', err));
+    window.clawwork
+      .getSettings()
+      .then((settings) => {
+        if (settings) setWorkspacePath(settings.workspacePath || t('common.notConfigured'));
+      })
+      .catch((err) => console.error('[SystemSection] getSettings failed:', err));
   }, [t]);
 
   const handleTrayToggle = useCallback(
@@ -101,15 +107,17 @@ export default function SystemSection() {
       const shortcut = parts.join('+');
       setRecordingShortcut(false);
 
-      window.clawwork.updateQuickLaunchConfig(quickLaunchEnabled, shortcut).then((ok) => {
-        if (ok) {
-          setQuickLaunchShortcut(shortcut);
-          toast.success(t('settings.shortcutUpdated'));
-        } else {
-          toast.error(t('settings.quickLaunchShortcutConflict'));
-        }
-      })
-      .catch(() => toast.error(t('settings.quickLaunchUpdateFailed')));
+      window.clawwork
+        .updateQuickLaunchConfig(quickLaunchEnabled, shortcut)
+        .then((ok) => {
+          if (ok) {
+            setQuickLaunchShortcut(shortcut);
+            toast.success(t('settings.shortcutUpdated'));
+          } else {
+            toast.error(t('settings.quickLaunchShortcutConflict'));
+          }
+        })
+        .catch(() => toast.error(t('settings.quickLaunchUpdateFailed')));
     },
     [quickLaunchEnabled, t],
   );

--- a/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
@@ -21,11 +21,14 @@ export default function SystemSection() {
     window.clawwork.getQuickLaunchConfig().then((config) => {
       setQuickLaunchEnabled(config.enabled);
       setQuickLaunchShortcut(config.shortcut);
-    });
-    window.clawwork.getTrayEnabled().then(setTrayEnabled);
+    }).catch((err) => console.error('[SystemSection] getQuickLaunchConfig failed:', err));;
+    window.clawwork.getTrayEnabled()
+    .then(setTrayEnabled)
+    .catch((err) => console.error('[SystemSection] getTrayEnabled failed:', err));;
     window.clawwork.getSettings().then((settings) => {
       if (settings) setWorkspacePath(settings.workspacePath || t('common.notConfigured'));
-    });
+    })
+    .catch((err) => console.error('[SystemSection] getSettings failed:', err));;
   }, [t]);
 
   const handleTrayToggle = useCallback(
@@ -105,7 +108,8 @@ export default function SystemSection() {
         } else {
           toast.error(t('settings.quickLaunchShortcutConflict'));
         }
-      });
+      })
+      .catch(() => toast.error(t('settings.quickLaunchUpdateFailed')));
     },
     [quickLaunchEnabled, t],
   );

--- a/packages/desktop/src/renderer/layouts/Setup/index.tsx
+++ b/packages/desktop/src/renderer/layouts/Setup/index.tsx
@@ -66,9 +66,10 @@ export default function Setup({ onSetupComplete, initialStep = 'workspace' }: Se
   };
 
   useEffect(() => {
-    window.clawwork.getDefaultWorkspacePath()
-    .then(setPath)
-    .catch((err) => console.error('[Setup] getDefaultWorkspacePath failed:', err));
+    window.clawwork
+      .getDefaultWorkspacePath()
+      .then(setPath)
+      .catch((err) => console.error('[Setup] getDefaultWorkspacePath failed:', err));
   }, []);
 
   const handleBrowse = async (): Promise<void> => {

--- a/packages/desktop/src/renderer/layouts/Setup/index.tsx
+++ b/packages/desktop/src/renderer/layouts/Setup/index.tsx
@@ -66,7 +66,9 @@ export default function Setup({ onSetupComplete, initialStep = 'workspace' }: Se
   };
 
   useEffect(() => {
-    window.clawwork.getDefaultWorkspacePath().then(setPath);
+    window.clawwork.getDefaultWorkspacePath()
+    .then(setPath)
+    .catch((err) => console.error('[Setup] getDefaultWorkspacePath failed:', err));
   }, []);
 
   const handleBrowse = async (): Promise<void> => {


### PR DESCRIPTION
## Summary
Adds `.catch()` handlers to six IPC calls across three Settings section files that were missing error handling. Without these, a rejected promise would leave the Settings page silently broken with no user feedback, and cause unhandled promise rejection warnings in the console.

## Type of change
- [x] `[Fix]` bug fix

## Why is this needed?
If any of the IPC calls (getSettings, getTrayEnabled, getQuickLaunchConfig, updateQuickLaunchConfig, getDefaultWorkspacePath) reject, the Settings UI would show incomplete or broken state with no indication to the user that something went wrong. Adding .catch() ensures errors are logged or surfaced via toast.

## What changed?
- `GeneralSection.tsx` — added `.catch()` to `getSettings()`
- `SystemSection.tsx` — added `.catch()` to `getQuickLaunchConfig()`, `getTrayEnabled()`, `getSettings()`, and `updateQuickLaunchConfig()` (with `toast.error()` for the mutation call)
- `Setup/index.tsx` — added `.catch()` to `getDefaultWorkspacePath()`
- Added `settings.quickLaunchUpdateFailed` i18n key to all 8 locale files (en, de, es, ja, ko, pt, zh-TW, zh)

## Architecture impact
- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is limited to adding error handlers on existing IPC calls, no new IPC channels or cross-layer dependencies introduced

## Linked issues
Closes #332

## Validation
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [ ] `pnpm build`
- [x] Not run (partially)

```text
check:dead-code (knip) crashes with RangeError: Array buffer allocation failed 
on Windows due to a memory limitation in oxc-parser. Unrelated to this change.
All other checks pass.
```

## Screenshots or recordings
No UI change — error handling only.

## Release note
- [x] No user-facing change. Release note is `NONE`.
```release-note
NONE
```

## Checklist
- [ ] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate