### PR TITLE
[Refactor] Extract TeamCardShell from TeamCard and TeamHubCard

### DIFF
--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamCard.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamCard.tsx
@@ -1,9 +1,6 @@
-import { motion } from 'framer-motion';
-import { MessageSquare, MoreHorizontal, Pencil, Trash2, Users } from 'lucide-react';
+import { MessageSquare, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Team } from '@clawwork/shared';
-import { cn } from '@/lib/utils';
-import { motion as motionPresets } from '@/styles/design-tokens';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -11,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { TeamCardShell } from './TeamCardShell';
 
 interface TeamCardProps {
   team: Team;
@@ -24,22 +22,13 @@ export default function TeamCard({ team, onSelect, onStartChat, onEdit, onDelete
   const { t } = useTranslation();
 
   return (
-    <motion.div
-      {...motionPresets.listItem}
+    <TeamCardShell
+      emoji={team.emoji}
+      name={team.name}
+      description={team.description}
+      memberCount={team.agents.length}
       onClick={onSelect}
-      className={cn(
-        'surface-card flex w-full cursor-pointer flex-col items-start gap-3 rounded-xl p-5',
-        'border border-[var(--border)] transition-colors',
-        'hover:border-[var(--border-hover)] hover:bg-[var(--bg-hover)]',
-      )}
-    >
-      <div className="flex w-full items-center justify-between">
-        <div className="flex items-center gap-3 min-w-0">
-          <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)]">
-            <span className="emoji-lg">{team.emoji}</span>
-          </span>
-          <h3 className="type-section-title text-[var(--text-primary)] truncate">{team.name}</h3>
-        </div>
+      topRight={
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
@@ -60,13 +49,8 @@ export default function TeamCard({ team, onSelect, onStartChat, onEdit, onDelete
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-      </div>
-      {team.description && <p className="type-body text-[var(--text-secondary)] line-clamp-2">{team.description}</p>}
-      <div className="flex w-full items-center justify-between">
-        <div className="type-meta flex items-center gap-1.5 text-[var(--text-muted)]">
-          <Users size={13} className="opacity-60" />
-          <span>{t('teams.memberCount', { count: team.agents.length })}</span>
-        </div>
+      }
+      actions={
         <Button
           size="sm"
           variant="soft"
@@ -78,7 +62,7 @@ export default function TeamCard({ team, onSelect, onStartChat, onEdit, onDelete
           <MessageSquare size={14} />
           {t('teams.startChat')}
         </Button>
-      </div>
-    </motion.div>
+      }
+    />
   );
 }

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamCardShell.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamCardShell.tsx
@@ -1,0 +1,62 @@
+import { type ReactNode } from 'react';
+import { motion } from 'framer-motion';
+import { Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { motion as motionPresets } from '@/styles/design-tokens';
+
+interface TeamCardShellProps {
+  emoji: string;
+  name: string;
+  subtitle?: ReactNode;
+  description?: string;
+  memberCount: number;
+  actions: ReactNode;
+  topRight?: ReactNode;
+  onClick: () => void;
+}
+
+export function TeamCardShell({
+  emoji,
+  name,
+  subtitle,
+  description,
+  memberCount,
+  actions,
+  topRight,
+  onClick,
+}: TeamCardShellProps) {
+  const { t } = useTranslation();
+  return (
+    <motion.div
+      {...motionPresets.listItem}
+      onClick={onClick}
+      className={cn(
+        'surface-card flex w-full cursor-pointer flex-col items-start gap-3 rounded-xl p-5',
+        'border border-[var(--border)] transition-colors',
+        'hover:border-[var(--border-hover)] hover:bg-[var(--bg-hover)]',
+      )}
+    >
+      <div className="flex w-full items-center justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)]">
+            <span className="emoji-lg">{emoji}</span>
+          </span>
+          <div className="min-w-0">
+            <h3 className="type-section-title truncate text-[var(--text-primary)]">{name}</h3>
+            {subtitle}
+          </div>
+        </div>
+        {topRight}
+      </div>
+      {description && <p className="type-body line-clamp-2 text-[var(--text-secondary)]">{description}</p>}
+      <div className="flex w-full items-center justify-between">
+        <div className="type-meta flex items-center gap-1.5 text-[var(--text-muted)]">
+          <Users size={13} className="opacity-60" />
+          <span>{t('teams.memberCount', { count: memberCount })}</span>
+        </div>
+        {actions}
+      </div>
+    </motion.div>
+  );
+}

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamHubCard.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamHubCard.tsx
@@ -1,10 +1,8 @@
-import { motion } from 'framer-motion';
-import { Download, Check, Users } from 'lucide-react';
+import { Download, Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { TeamHubEntry } from '@clawwork/shared';
-import { cn } from '@/lib/utils';
-import { motion as motionPresets } from '@/styles/design-tokens';
 import { Button } from '@/components/ui/button';
+import { TeamCardShell } from './TeamCardShell';
 
 interface TeamHubCardProps {
   entry: TeamHubEntry;
@@ -17,31 +15,17 @@ export default function TeamHubCard({ entry, installed, onSelect, onInstall }: T
   const { t } = useTranslation();
 
   return (
-    <motion.div
-      {...motionPresets.listItem}
+    <TeamCardShell
+      emoji={entry.emoji}
+      name={entry.name}
+      description={entry.description}
+      memberCount={entry.agentCount}
       onClick={onSelect}
-      className={cn(
-        'surface-card flex w-full cursor-pointer flex-col items-start gap-3 rounded-xl p-5',
-        'border border-[var(--border)] transition-colors',
-        'hover:border-[var(--border-hover)] hover:bg-[var(--bg-hover)]',
-      )}
-    >
-      <div className="flex w-full items-center gap-3 min-w-0">
-        <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)]">
-          <span className="emoji-lg">{entry.emoji}</span>
-        </span>
-        <div className="min-w-0 flex-1">
-          <h3 className="type-section-title text-[var(--text-primary)] truncate">{entry.name}</h3>
-          {entry.category && <span className="type-meta text-[var(--text-muted)]">{entry.category}</span>}
-        </div>
-      </div>
-      {entry.description && <p className="type-body text-[var(--text-secondary)] line-clamp-2">{entry.description}</p>}
-      <div className="flex w-full items-center justify-between">
-        <div className="type-meta flex items-center gap-1.5 text-[var(--text-muted)]">
-          <Users size={13} className="opacity-60" />
-          <span>{t('teams.memberCount', { count: entry.agentCount })}</span>
-        </div>
-        {installed ? (
+      subtitle={
+        entry.category ? <span className="type-meta text-[var(--text-muted)]">{entry.category}</span> : undefined
+      }
+      actions={
+        installed ? (
           <span className="type-meta flex items-center gap-1 text-[var(--accent)]">
             <Check size={13} />
             {t('teamshub.installed')}
@@ -58,8 +42,8 @@ export default function TeamHubCard({ entry, installed, onSelect, onInstall }: T
             <Download size={14} />
             {t('teamshub.install')}
           </Button>
-        )}
-      </div>
-    </motion.div>
+        )
+      }
+    />
   );
 }


### PR DESCRIPTION
## Summary
Closes #341

Extracted shared card structure from `TeamCard` and `TeamHubCard` into a 
new reusable `TeamCardShell` component. Both cards had nearly identical 
layout — same motion wrapper, same className, same emoji icon, same 
description and member count row. Only the action buttons differed.

## Type of change
- [x] `[Refactor]` internal cleanup

## Why is this needed?
Eliminates duplicated layout code across two components. Future visual 
changes to the card structure now only need to be made in one place.

## What changed?
- Created `TeamCardShell.tsx` — shared card layout component
- Refactored `TeamCard.tsx` — now a thin wrapper (~50 lines, was 84)
- Refactored `TeamHubCard.tsx` — now a thin wrapper (~45 lines, was 65)

## Architecture impact
- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched: none
- Why protected: pure renderer refactor, no new IPC or cross-layer dependencies

## Linked issues
Closes #341

## Validation
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check:renderer-copy`
- [x] `pnpm check:i18n`
- [x] Not run (partially)

```text
check:dead-code (knip) crashes with RangeError: Array buffer allocation 
failed on Windows — pre-existing environment issue, unrelated to this change.

file-reader.test.ts — 7 tests failing with "path outside allowed context 
folders" — pre-existing failure unrelated to this change.
```

## Screenshots or recordings
No visual change — card appearance is identical. Internal code restructure only.

## Release note
- [x] No user-facing change. Release note is `NONE`.
```release-note
NONE
```

## Checklist
- [x] All commits are signed off (`git commit -s`)
- [x] PR title uses approved prefix `[Refactor]`
- [x] Summary explains what changed and why
- [x] Validation reflects commands actually run
- [x] Architecture impact described
- [x] Release note block is accurate