### PR TITLE
[Fix] Race condition in FileBrowser search: stale results from out-of-order responses

### DIFF
--- a/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
+++ b/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
@@ -75,7 +75,7 @@ export default function FileBrowser() {
   const setHighlightedMessage = useMessageStore((s) => s.setHighlightedMessage);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const requestIdRef = useRef(0);
+  const searchRequestIdRef = useRef(0);
 
   const [fileMenu, setFileMenu] = useState<FileMenuState>(null);
 
@@ -150,12 +150,12 @@ export default function FileBrowser() {
       return;
     }
     setIsSearching(true);
-    const requestId = ++requestIdRef.current;
+    const requestId = ++searchRequestIdRef.current;
     debounceRef.current = setTimeout(() => {
       window.clawwork
         .searchArtifacts(searchQuery)
         .then((res) => {
-          if (requestIdRef.current !== requestId) return;
+          if (searchRequestIdRef.current !== requestId) return;
           setIsSearching(false);
           if (res.ok && res.result) {
             setSearchResults(res.result as unknown as ArtifactSearchResult[]);
@@ -164,7 +164,7 @@ export default function FileBrowser() {
           }
         })
         .catch(() => {
-          if (requestIdRef.current !== requestId) return;
+          if (searchRequestIdRef.current !== requestId) return;
           setIsSearching(false);
           setSearchResults([]);
         });


### PR DESCRIPTION
Refactor-only: upstream already landed the request-counter race fix for search responses after this PR was opened. The remaining change is a clarity rename of `requestIdRef` to `searchRequestIdRef` in `FileBrowser/index.tsx` so the ref is unambiguous if other request-tracking patterns get added in the same component later.

The `listArtifacts` unmount guard is unchanged (the earlier push that removed it was accidental and has been restored).

Closes #330.