### PR TITLE
refactor(core): unify ChatContentBlock with RawContentBlock

### DIFF
--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -1,15 +1,5 @@
 import type { ToolCall } from '@clawwork/shared';
 
-export interface ChatContentBlock {
-  type: string;
-  text?: string;
-  thinking?: string;
-  id?: string;
-  name?: string;
-  arguments?: Record<string, unknown> | string;
-  result?: unknown;
-}
-
 export interface ChatMessage {
   role?: string;
   content?: ChatContentBlock[];
@@ -36,6 +26,10 @@ export interface RawContentBlock {
   arguments?: Record<string, unknown> | string;
   result?: unknown;
 }
+
+export type ChatContentBlock = RawContentBlock & {
+  thinking?: string;
+};
 
 export interface RawHistoryMessage {
   role: string;


### PR DESCRIPTION
## What

Closes #224.

`ChatContentBlock` and `RawContentBlock` in `packages/core/src/protocol/types.ts` carried the same field set; the only delta was `ChatContentBlock.thinking`. Two near-identical shapes invite silent drift.

## How

Option A from the issue:
- Keep `RawContentBlock` as the base shape.
- Re-declare `ChatContentBlock` as a type alias: `RawContentBlock & { thinking?: string }`.
- No other files need changes - every existing import keeps working.

## Verification

- `pnpm --filter @clawwork/core exec tsc -b` - clean
- `pnpm typecheck` (shared, core, pwa, desktop, website) - clean
- `pnpm --filter @clawwork/core test` - 73 tests pass
- `pnpm lint` - no new warnings
- `prettier --check packages/core/src/protocol/types.ts` - formatted

## Scope

One file, net -6 lines.