### PR TITLE
fix(ipc): add payload size cap + per-event rate limiting to debug:renderer-event

### DIFF
--- a/packages/desktop/src/main/ipc/debug-handlers.ts
+++ b/packages/desktop/src/main/ipc/debug-handlers.ts
@@ -33,28 +33,7 @@ export function registerDebugHandlers(): void {
   ipcMain.on('debug:renderer-event', (_event, payload: unknown) => {
     if (!isRecord(payload)) return;
 
-    const payloadSize = getSerializedPayloadSize(payload);
-    if (payloadSize === null) return;
-
     const event = typeof payload.event === 'string' && payload.event ? payload.event : UNKNOWN_EVENT;
-    const traceId = typeof payload.traceId === 'string' ? payload.traceId : undefined;
-    const feature = typeof payload.feature === 'string' ? payload.feature : undefined;
-    const data = isRecord(payload.data) ? payload.data : undefined;
-
-    if (payloadSize > MAX_PAYLOAD_BYTES) {
-      const logger = getDebugLogger();
-      logger.warn({
-        domain: RENDERER_DOMAIN,
-        event: 'renderer.payload-oversize',
-        data: {
-          payloadSize,
-          maxBytes: MAX_PAYLOAD_BYTES,
-          event,
-        },
-      });
-      return;
-    }
-
     const result = debugRateLimiter.check(RENDERER_DOMAIN, event);
     if (result.evictedKey) {
       const logger = getDebugLogger();
@@ -71,6 +50,27 @@ export function registerDebugHandlers(): void {
     if (!result.allowed) {
       return;
     }
+
+    const payloadSize = getSerializedPayloadSize(payload);
+    if (payloadSize === null) return;
+
+    if (payloadSize > MAX_PAYLOAD_BYTES) {
+      const logger = getDebugLogger();
+      logger.warn({
+        domain: RENDERER_DOMAIN,
+        event: 'renderer.payload-oversize',
+        data: {
+          payloadSize,
+          maxBytes: MAX_PAYLOAD_BYTES,
+          event,
+        },
+      });
+      return;
+    }
+
+    const traceId = typeof payload.traceId === 'string' ? payload.traceId : undefined;
+    const feature = typeof payload.feature === 'string' ? payload.feature : undefined;
+    const data = isRecord(payload.data) ? payload.data : undefined;
 
     const logger = getDebugLogger();
     logger.info({

--- a/packages/desktop/src/main/ipc/debug-handlers.ts
+++ b/packages/desktop/src/main/ipc/debug-handlers.ts
@@ -6,82 +6,81 @@ import { getAllGatewayClients } from '../ws/index.js';
 import { readConfig } from '../workspace/config.js';
 import { createRateLimiter } from './debug-rate-limiter.js';
 
-// ---------------------------------------------------------------------------
-// Constants for debug:renderer-event hardening (issue #413)
-// ---------------------------------------------------------------------------
+const MAX_PAYLOAD_BYTES = 16 * 1024;
+const RENDERER_DOMAIN = 'renderer' as const;
+const UNKNOWN_EVENT = 'unknown';
 
-/** Max serialized payload size in bytes — reject oversized events before processing */
-const MAX_PAYLOAD_BYTES = 16 * 1024; // 16 KB
-
-/** Per-(domain, event) rate limiter: 100 events/sec */
 const debugRateLimiter = createRateLimiter({
   maxEventsPerWindow: 100,
   windowMs: 1000,
   maxTrackedKeys: 256,
 });
 
-// ---------------------------------------------------------------------------
-// IPC handler registration
-// ---------------------------------------------------------------------------
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getSerializedPayloadSize(payload: unknown): number | null {
+  try {
+    const serialized = JSON.stringify(payload);
+    return typeof serialized === 'string' ? serialized.length : 0;
+  } catch {
+    return null;
+  }
+}
 
 export function registerDebugHandlers(): void {
-  ipcMain.on(
-    'debug:renderer-event',
-    (
-      _event,
-      payload: {
-        event: string;
-        traceId?: string;
-        feature?: string;
-        data?: Record<string, unknown>;
-      },
-    ) => {
-      // 1. Payload size guard — reject oversized payloads before any processing
-      const payloadSize = JSON.stringify(payload).length;
-      if (payloadSize > MAX_PAYLOAD_BYTES) {
-        const logger = getDebugLogger();
-        logger.warn({
-          domain: 'renderer' as 'renderer',
-          event: 'renderer.payload-oversize',
-          data: {
-            payloadSize,
-            maxBytes: MAX_PAYLOAD_BYTES,
-            domain: payload?.domain,
-            event: payload?.event,
-          },
-        });
-        return;
-      }
+  ipcMain.on('debug:renderer-event', (_event, payload: unknown) => {
+    if (!isRecord(payload)) return;
 
-      // 2. Rate limit per (domain, event) tuple
-      const result = debugRateLimiter.check(payload.domain, payload.event);
-      if (result.evictedKey) {
-        const logger = getDebugLogger();
-        logger.warn({
-          domain: 'renderer' as 'renderer',
-          event: 'renderer.throttled',
-          data: {
-            key: result.evictedKey,
-            dropped: result.evictedDrops,
-            reason: 'rate-limit',
-          },
-        });
-      }
-      if (!result.allowed) {
-        return; // dropped — counted and will be summarized on next window flip
-      }
+    const payloadSize = getSerializedPayloadSize(payload);
+    if (payloadSize === null) return;
 
-      // 3. Normal logging path
+    const event = typeof payload.event === 'string' && payload.event ? payload.event : UNKNOWN_EVENT;
+    const traceId = typeof payload.traceId === 'string' ? payload.traceId : undefined;
+    const feature = typeof payload.feature === 'string' ? payload.feature : undefined;
+    const data = isRecord(payload.data) ? payload.data : undefined;
+
+    if (payloadSize > MAX_PAYLOAD_BYTES) {
       const logger = getDebugLogger();
-      logger.info({
-        domain: 'renderer',
-        event: payload.event,
-        traceId: payload.traceId,
-        feature: payload.feature,
-        data: payload.data,
+      logger.warn({
+        domain: RENDERER_DOMAIN,
+        event: 'renderer.payload-oversize',
+        data: {
+          payloadSize,
+          maxBytes: MAX_PAYLOAD_BYTES,
+          event,
+        },
       });
-    },
-  );
+      return;
+    }
+
+    const result = debugRateLimiter.check(RENDERER_DOMAIN, event);
+    if (result.evictedKey) {
+      const logger = getDebugLogger();
+      logger.warn({
+        domain: RENDERER_DOMAIN,
+        event: 'renderer.throttled',
+        data: {
+          key: result.evictedKey,
+          dropped: result.evictedDrops,
+          reason: 'rate-limit',
+        },
+      });
+    }
+    if (!result.allowed) {
+      return;
+    }
+
+    const logger = getDebugLogger();
+    logger.info({
+      domain: RENDERER_DOMAIN,
+      event,
+      traceId,
+      feature,
+      data,
+    });
+  });
 
   ipcMain.handle(
     'debug:export-bundle',

--- a/packages/desktop/src/main/ipc/debug-handlers.ts
+++ b/packages/desktop/src/main/ipc/debug-handlers.ts
@@ -4,6 +4,25 @@ import { exportDebugBundle } from '../debug/export.js';
 import { getDebugLogger } from '../debug/index.js';
 import { getAllGatewayClients } from '../ws/index.js';
 import { readConfig } from '../workspace/config.js';
+import { createRateLimiter } from './debug-rate-limiter.js';
+
+// ---------------------------------------------------------------------------
+// Constants for debug:renderer-event hardening (issue #413)
+// ---------------------------------------------------------------------------
+
+/** Max serialized payload size in bytes — reject oversized events before processing */
+const MAX_PAYLOAD_BYTES = 16 * 1024; // 16 KB
+
+/** Per-(domain, event) rate limiter: 100 events/sec */
+const debugRateLimiter = createRateLimiter({
+  maxEventsPerWindow: 100,
+  windowMs: 1000,
+  maxTrackedKeys: 256,
+});
+
+// ---------------------------------------------------------------------------
+// IPC handler registration
+// ---------------------------------------------------------------------------
 
 export function registerDebugHandlers(): void {
   ipcMain.on(
@@ -17,6 +36,42 @@ export function registerDebugHandlers(): void {
         data?: Record<string, unknown>;
       },
     ) => {
+      // 1. Payload size guard — reject oversized payloads before any processing
+      const payloadSize = JSON.stringify(payload).length;
+      if (payloadSize > MAX_PAYLOAD_BYTES) {
+        const logger = getDebugLogger();
+        logger.warn({
+          domain: 'renderer' as 'renderer',
+          event: 'renderer.payload-oversize',
+          data: {
+            payloadSize,
+            maxBytes: MAX_PAYLOAD_BYTES,
+            domain: payload?.domain,
+            event: payload?.event,
+          },
+        });
+        return;
+      }
+
+      // 2. Rate limit per (domain, event) tuple
+      const result = debugRateLimiter.check(payload.domain, payload.event);
+      if (result.evictedKey) {
+        const logger = getDebugLogger();
+        logger.warn({
+          domain: 'renderer' as 'renderer',
+          event: 'renderer.throttled',
+          data: {
+            key: result.evictedKey,
+            dropped: result.evictedDrops,
+            reason: 'rate-limit',
+          },
+        });
+      }
+      if (!result.allowed) {
+        return; // dropped — counted and will be summarized on next window flip
+      }
+
+      // 3. Normal logging path
       const logger = getDebugLogger();
       logger.info({
         domain: 'renderer',

--- a/packages/desktop/src/main/ipc/debug-rate-limiter.ts
+++ b/packages/desktop/src/main/ipc/debug-rate-limiter.ts
@@ -1,17 +1,6 @@
-/**
- * Per-(domain, event) sliding-window rate limiter for IPC handlers.
- *
- * Prevents a buggy or malicious renderer from:
- * - flooding the logger with thousands of events per second
- * - growing the limiter's memory indefinitely (bounded to MAX_TRACKED_KEYS)
- */
-
-export interface RateLimiterConfig {
-  /** Max events allowed per window per key. Default: 100 */
+interface RateLimiterConfig {
   maxEventsPerWindow?: number;
-  /** Window duration in ms. Default: 1000 */
   windowMs?: number;
-  /** Max unique (domain:event) keys tracked. Oldest evicted when full. Default: 256 */
   maxTrackedKeys?: number;
 }
 
@@ -21,10 +10,8 @@ interface WindowEntry {
   dropped: number;
 }
 
-export interface RateLimitResult {
-  /** true = allowed, false = dropped */
+interface RateLimitResult {
   allowed: boolean;
-  /** If an evicted key had drops, returns it for summary logging */
   evictedKey?: string;
   evictedDrops?: number;
 }
@@ -36,16 +23,11 @@ export function createRateLimiter(config: RateLimiterConfig = {}) {
 
   const map = new Map<string, WindowEntry>();
 
-  /**
-   * Check whether an event for (domain, event) should be allowed.
-   * Returns a result indicating if the event passes and any evicted summary info.
-   */
   function check(domain: string, event: string, now: number = Date.now()): RateLimitResult {
     const key = `${domain}:${event}`;
     let evictedKey: string | undefined;
     let evictedDrops: number | undefined;
 
-    // Evict oldest key if we've hit the cap
     if (!map.has(key) && map.size >= maxKeys) {
       const oldestKey = map.keys().next().value;
       if (oldestKey) {
@@ -60,7 +42,6 @@ export function createRateLimiter(config: RateLimiterConfig = {}) {
 
     let entry = map.get(key);
 
-    // New or expired window
     if (!entry || now - entry.windowStart >= windowMs) {
       const prevDrops = entry?.dropped ?? 0;
       entry = { count: 1, windowStart: now, dropped: 0 };
@@ -72,23 +53,19 @@ export function createRateLimiter(config: RateLimiterConfig = {}) {
       };
     }
 
-    // Within the same window
     if (entry.count < maxEvents) {
       entry.count++;
       return { allowed: true, evictedKey, evictedDrops };
     }
 
-    // Over limit
     entry.dropped++;
     return { allowed: false, evictedKey, evictedDrops };
   }
 
-  /** Reset all state (for testing) */
   function reset(): void {
     map.clear();
   }
 
-  /** Get current tracked key count (for testing) */
   function size(): number {
     return map.size;
   }

--- a/packages/desktop/src/main/ipc/debug-rate-limiter.ts
+++ b/packages/desktop/src/main/ipc/debug-rate-limiter.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-(domain, event) sliding-window rate limiter for IPC handlers.
+ *
+ * Prevents a buggy or malicious renderer from:
+ * - flooding the logger with thousands of events per second
+ * - growing the limiter's memory indefinitely (bounded to MAX_TRACKED_KEYS)
+ */
+
+export interface RateLimiterConfig {
+  /** Max events allowed per window per key. Default: 100 */
+  maxEventsPerWindow?: number;
+  /** Window duration in ms. Default: 1000 */
+  windowMs?: number;
+  /** Max unique (domain:event) keys tracked. Oldest evicted when full. Default: 256 */
+  maxTrackedKeys?: number;
+}
+
+interface WindowEntry {
+  count: number;
+  windowStart: number;
+  dropped: number;
+}
+
+export interface RateLimitResult {
+  /** true = allowed, false = dropped */
+  allowed: boolean;
+  /** If an evicted key had drops, returns it for summary logging */
+  evictedKey?: string;
+  evictedDrops?: number;
+}
+
+export function createRateLimiter(config: RateLimiterConfig = {}) {
+  const maxEvents = config.maxEventsPerWindow ?? 100;
+  const windowMs = config.windowMs ?? 1000;
+  const maxKeys = config.maxTrackedKeys ?? 256;
+
+  const map = new Map<string, WindowEntry>();
+
+  /**
+   * Check whether an event for (domain, event) should be allowed.
+   * Returns a result indicating if the event passes and any evicted summary info.
+   */
+  function check(domain: string, event: string, now: number = Date.now()): RateLimitResult {
+    const key = `${domain}:${event}`;
+    let evictedKey: string | undefined;
+    let evictedDrops: number | undefined;
+
+    // Evict oldest key if we've hit the cap
+    if (!map.has(key) && map.size >= maxKeys) {
+      const oldestKey = map.keys().next().value;
+      if (oldestKey) {
+        const evicted = map.get(oldestKey);
+        if (evicted && evicted.dropped > 0) {
+          evictedKey = oldestKey;
+          evictedDrops = evicted.dropped;
+        }
+        map.delete(oldestKey);
+      }
+    }
+
+    let entry = map.get(key);
+
+    // New or expired window
+    if (!entry || now - entry.windowStart >= windowMs) {
+      const prevDrops = entry?.dropped ?? 0;
+      entry = { count: 1, windowStart: now, dropped: 0 };
+      map.set(key, entry);
+      return {
+        allowed: true,
+        evictedKey: prevDrops > 0 ? key : evictedKey,
+        evictedDrops: prevDrops > 0 ? prevDrops : evictedDrops,
+      };
+    }
+
+    // Within the same window
+    if (entry.count < maxEvents) {
+      entry.count++;
+      return { allowed: true, evictedKey, evictedDrops };
+    }
+
+    // Over limit
+    entry.dropped++;
+    return { allowed: false, evictedKey, evictedDrops };
+  }
+
+  /** Reset all state (for testing) */
+  function reset(): void {
+    map.clear();
+  }
+
+  /** Get current tracked key count (for testing) */
+  function size(): number {
+    return map.size;
+  }
+
+  return { check, reset, size };
+}

--- a/packages/desktop/test/debug-handlers.test.ts
+++ b/packages/desktop/test/debug-handlers.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const onMap = new Map<string, (...args: unknown[]) => unknown>();
+const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+const infoMock = vi.fn();
+const warnMock = vi.fn();
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/mock-userData' },
+  ipcMain: {
+    on: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      onMap.set(channel, handler);
+    }),
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handleMap.set(channel, handler);
+    }),
+  },
+}));
+
+vi.mock('../src/main/debug/export.js', () => ({
+  exportDebugBundle: vi.fn(() => ({ bundlePath: '/tmp/debug-bundle', events: [] })),
+}));
+
+vi.mock('../src/main/debug/index.js', () => ({
+  getDebugLogger: () => ({
+    info: infoMock,
+    warn: warnMock,
+    error: vi.fn(),
+    debug: vi.fn(),
+    log: vi.fn(),
+    getRecentEvents: vi.fn(() => []),
+    currentFilePath: vi.fn(() => ''),
+  }),
+}));
+
+vi.mock('../src/main/ws/index.js', () => ({
+  getAllGatewayClients: vi.fn(() => new Map()),
+}));
+
+vi.mock('../src/main/workspace/config.js', () => ({
+  readConfig: vi.fn(() => null),
+}));
+
+describe('registerDebugHandlers', () => {
+  beforeEach(async () => {
+    onMap.clear();
+    handleMap.clear();
+    vi.clearAllMocks();
+
+    const mod = await import('../src/main/ipc/debug-handlers.js');
+    mod.registerDebugHandlers();
+  });
+
+  it('ignores missing payloads without crashing the main process', () => {
+    const handler = onMap.get('debug:renderer-event');
+    expect(handler).toBeTypeOf('function');
+
+    expect(() => handler?.({}, undefined)).not.toThrow();
+    expect(infoMock).not.toHaveBeenCalled();
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores circular payloads without crashing the main process', () => {
+    const handler = onMap.get('debug:renderer-event');
+    expect(handler).toBeTypeOf('function');
+
+    const payload: Record<string, unknown> = { event: 'renderer.loop' };
+    payload.self = payload;
+
+    expect(() => handler?.({}, payload)).not.toThrow();
+    expect(infoMock).not.toHaveBeenCalled();
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an unknown event name for malformed payloads', () => {
+    const handler = onMap.get('debug:renderer-event');
+    expect(handler).toBeTypeOf('function');
+
+    handler?.({}, { event: 42, traceId: 'trace-1', feature: 'debug', data: { ok: true } });
+
+    expect(infoMock).toHaveBeenCalledWith({
+      domain: 'renderer',
+      event: 'unknown',
+      traceId: 'trace-1',
+      feature: 'debug',
+      data: { ok: true },
+    });
+  });
+});

--- a/packages/desktop/test/debug-handlers.test.ts
+++ b/packages/desktop/test/debug-handlers.test.ts
@@ -4,6 +4,7 @@ const onMap = new Map<string, (...args: unknown[]) => unknown>();
 const handleMap = new Map<string, (...args: unknown[]) => unknown>();
 const infoMock = vi.fn();
 const warnMock = vi.fn();
+const rateLimiterCheckMock = vi.fn();
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/mock-userData' },
@@ -33,6 +34,14 @@ vi.mock('../src/main/debug/index.js', () => ({
   }),
 }));
 
+vi.mock('../src/main/ipc/debug-rate-limiter.js', () => ({
+  createRateLimiter: () => ({
+    check: (...args: unknown[]) => rateLimiterCheckMock(...args),
+    reset: vi.fn(),
+    size: vi.fn(() => 0),
+  }),
+}));
+
 vi.mock('../src/main/ws/index.js', () => ({
   getAllGatewayClients: vi.fn(() => new Map()),
 }));
@@ -45,7 +54,10 @@ describe('registerDebugHandlers', () => {
   beforeEach(async () => {
     onMap.clear();
     handleMap.clear();
+    vi.resetModules();
     vi.clearAllMocks();
+    rateLimiterCheckMock.mockReset();
+    rateLimiterCheckMock.mockReturnValue({ allowed: true });
 
     const mod = await import('../src/main/ipc/debug-handlers.js');
     mod.registerDebugHandlers();
@@ -66,6 +78,24 @@ describe('registerDebugHandlers', () => {
 
     const payload: Record<string, unknown> = { event: 'renderer.loop' };
     payload.self = payload;
+
+    expect(() => handler?.({}, payload)).not.toThrow();
+    expect(infoMock).not.toHaveBeenCalled();
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('drops throttled payloads before attempting serialization', () => {
+    const handler = onMap.get('debug:renderer-event');
+    expect(handler).toBeTypeOf('function');
+
+    rateLimiterCheckMock.mockReturnValueOnce({ allowed: false });
+
+    const payload = {
+      event: 'renderer.loop',
+      toJSON() {
+        throw new Error('should not stringify throttled payload');
+      },
+    };
 
     expect(() => handler?.({}, payload)).not.toThrow();
     expect(infoMock).not.toHaveBeenCalled();

--- a/packages/desktop/test/debug-rate-limiter.test.ts
+++ b/packages/desktop/test/debug-rate-limiter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createRateLimiter } from '../src/main/ipc/debug-rate-limiter';
+
+describe('debug rate limiter', () => {
+  let limiter: ReturnType<typeof createRateLimiter>;
+  const t = (seconds: number) => 1_000_000_000 + seconds * 1000;
+
+  beforeEach(() => {
+    limiter = createRateLimiter({
+      maxEventsPerWindow: 5,
+      windowMs: 1000,
+      maxTrackedKeys: 4,
+    });
+  });
+
+  it('allows events within the rate limit', () => {
+    for (let i = 0; i < 5; i++) {
+      const r = limiter.check('renderer', 'test.event', t(0));
+      expect(r.allowed).toBe(true);
+    }
+  });
+
+  it('drops events exceeding the rate limit', () => {
+    for (let i = 0; i < 5; i++) {
+      limiter.check('renderer', 'test.event', t(0));
+    }
+    const r = limiter.check('renderer', 'test.event', t(0));
+    expect(r.allowed).toBe(false);
+  });
+
+  it('resets the window after the configured duration', () => {
+    for (let i = 0; i < 5; i++) {
+      limiter.check('renderer', 'test.event', t(0));
+    }
+    // next window
+    const r = limiter.check('renderer', 'test.event', t(1));
+    expect(r.allowed).toBe(true);
+    expect(r.evictedKey).toBe('renderer:test.event'); // previous window had drops
+  });
+
+  it('tracks different (domain, event) tuples independently', () => {
+    for (let i = 0; i < 5; i++) {
+      limiter.check('renderer', 'event-a', t(0));
+    }
+    // event-a is now rate-limited
+    expect(limiter.check('renderer', 'event-a', t(0)).allowed).toBe(false);
+    // event-b is still fine
+    expect(limiter.check('renderer', 'event-b', t(0)).allowed).toBe(true);
+  });
+
+  it('evicts the oldest key when max tracked keys is reached', () => {
+    // Fill 4 keys (maxTrackedKeys = 4)
+    limiter.check('renderer', 'e1', t(0));
+    limiter.check('renderer', 'e2', t(0));
+    limiter.check('renderer', 'e3', t(0));
+    limiter.check('renderer', 'e4', t(0));
+    expect(limiter.size()).toBe(4);
+
+    // Adding a 5th key should evict the oldest
+    limiter.check('renderer', 'e5', t(0));
+    expect(limiter.size()).toBe(4);
+  });
+
+  it('reports evicted drops in the result', () => {
+    // Fill up to limit, then drop some
+    for (let i = 0; i < 5; i++) {
+      limiter.check('renderer', 'spam', t(0));
+    }
+    limiter.check('renderer', 'spam', t(0)); // dropped
+    limiter.check('renderer', 'spam', t(0)); // dropped
+
+    // Fill the map so eviction triggers
+    limiter.check('renderer', 'a', t(0));
+    limiter.check('renderer', 'b', t(0));
+    limiter.check('renderer', 'c', t(0));
+    limiter.check('renderer', 'd', t(0));
+
+    // This will evict the oldest key
+    const r = limiter.check('renderer', 'e', t(0));
+    // The evicted key should be renderer:spam (first inserted)
+    expect(r.evictedKey).toBe('renderer:spam');
+    expect(r.evictedDrops).toBe(2);
+  });
+
+  it('resets state with reset()', () => {
+    limiter.check('renderer', 'test', t(0));
+    expect(limiter.size()).toBe(1);
+    limiter.reset();
+    expect(limiter.size()).toBe(0);
+  });
+});

--- a/packages/desktop/test/debug-rate-limiter.test.ts
+++ b/packages/desktop/test/debug-rate-limiter.test.ts
@@ -28,56 +28,59 @@ describe('debug rate limiter', () => {
     expect(r.allowed).toBe(false);
   });
 
-  it('resets the window after the configured duration', () => {
+  it('starts a new window without emitting a summary when nothing was dropped', () => {
     for (let i = 0; i < 5; i++) {
       limiter.check('renderer', 'test.event', t(0));
     }
-    // next window
     const r = limiter.check('renderer', 'test.event', t(1));
     expect(r.allowed).toBe(true);
-    expect(r.evictedKey).toBe('renderer:test.event'); // previous window had drops
+    expect(r.evictedKey).toBeUndefined();
+  });
+
+  it('reports dropped events when a throttled window rolls over', () => {
+    for (let i = 0; i < 5; i++) {
+      limiter.check('renderer', 'test.event', t(0));
+    }
+    limiter.check('renderer', 'test.event', t(0));
+    limiter.check('renderer', 'test.event', t(0));
+
+    const r = limiter.check('renderer', 'test.event', t(1));
+    expect(r.allowed).toBe(true);
+    expect(r.evictedKey).toBe('renderer:test.event');
+    expect(r.evictedDrops).toBe(2);
   });
 
   it('tracks different (domain, event) tuples independently', () => {
     for (let i = 0; i < 5; i++) {
       limiter.check('renderer', 'event-a', t(0));
     }
-    // event-a is now rate-limited
     expect(limiter.check('renderer', 'event-a', t(0)).allowed).toBe(false);
-    // event-b is still fine
     expect(limiter.check('renderer', 'event-b', t(0)).allowed).toBe(true);
   });
 
   it('evicts the oldest key when max tracked keys is reached', () => {
-    // Fill 4 keys (maxTrackedKeys = 4)
     limiter.check('renderer', 'e1', t(0));
     limiter.check('renderer', 'e2', t(0));
     limiter.check('renderer', 'e3', t(0));
     limiter.check('renderer', 'e4', t(0));
     expect(limiter.size()).toBe(4);
 
-    // Adding a 5th key should evict the oldest
     limiter.check('renderer', 'e5', t(0));
     expect(limiter.size()).toBe(4);
   });
 
   it('reports evicted drops in the result', () => {
-    // Fill up to limit, then drop some
     for (let i = 0; i < 5; i++) {
       limiter.check('renderer', 'spam', t(0));
     }
-    limiter.check('renderer', 'spam', t(0)); // dropped
-    limiter.check('renderer', 'spam', t(0)); // dropped
+    limiter.check('renderer', 'spam', t(0));
+    limiter.check('renderer', 'spam', t(0));
 
-    // Fill the map so eviction triggers
     limiter.check('renderer', 'a', t(0));
     limiter.check('renderer', 'b', t(0));
     limiter.check('renderer', 'c', t(0));
-    limiter.check('renderer', 'd', t(0));
 
-    // This will evict the oldest key
-    const r = limiter.check('renderer', 'e', t(0));
-    // The evicted key should be renderer:spam (first inserted)
+    const r = limiter.check('renderer', 'd', t(0));
     expect(r.evictedKey).toBe('renderer:spam');
     expect(r.evictedDrops).toBe(2);
   });


### PR DESCRIPTION
Fixes #413

## Problem
The `debug:renderer-event` IPC handler has no input validation or rate limiting, creating a renderer-to-main DoS vector:
1. **No payload size limit** — a renderer can send arbitrarily large payloads (e.g. 10 MB), exhausting disk via `appendFileSync`
2. **No rate limiting** — a renderer can spam thousands of events/sec, each triggering a synchronous disk write

## Changes

| File | Change |
|---|---|
| `packages/desktop/src/main/ipc/debug-rate-limiter.ts` | **New** — standalone sliding-window rate limiter |
| `packages/desktop/src/main/ipc/debug-handlers.ts` | **Modified** — added size cap + rate limit checks |
| `packages/desktop/test/debug-rate-limiter.test.ts` | **New** — unit tests for rate limiter |

## Design

- **16 KB payload cap** — rejects oversized events, logs `renderer.payload-oversize` warning
- **100 events/sec per (domain, event)** — generous for normal use, catches tight-loop bugs
- **256 max tracked keys** — bounded memory prevents rate-limiter itself from being an attack surface
- **Window-flip summaries** — dropped events are counted; when a window resets, a single `renderer.throttled` warning reports the count (no silent data loss)
- **Separated into testable module** — rate limiter has no Electron dependency, easy to unit test

## Verification

1. `pnpm check` must pass
2. `pnpm vitest packages/desktop/test/debug-rate-limiter.test.ts`
3. Manual: in devtools, send IPC events in a tight loop — verify dropping and throttled warnings in debug log