### PR TITLE
[Fix] Clean up orphan artifact files when DB insert fails

### DIFF
--- a/packages/desktop/src/main/artifact/save.ts
+++ b/packages/desktop/src/main/artifact/save.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, statSync, writeFileSync } from 'fs';
+import { copyFileSync, statSync, unlinkSync, writeFileSync } from 'fs';
 import { basename, extname, resolve, sep } from 'path';
 import { randomUUID } from 'crypto';
 import type { Artifact } from '@clawwork/shared';
@@ -94,20 +94,29 @@ export async function saveArtifact(params: SaveArtifactParams): Promise<Artifact
   };
 
   const db = getDb();
-  db.insert(artifacts)
-    .values({
-      id: artifact.id,
-      taskId: artifact.taskId,
-      messageId: artifact.messageId,
-      type: artifact.type,
-      name: artifact.name,
-      filePath: artifact.filePath,
-      localPath: artifact.localPath,
-      mimeType: artifact.mimeType,
-      size: artifact.size,
-      createdAt: artifact.createdAt,
-    })
-    .run();
+  try {
+    db.insert(artifacts)
+      .values({
+        id: artifact.id,
+        taskId: artifact.taskId,
+        messageId: artifact.messageId,
+        type: artifact.type,
+        name: artifact.name,
+        filePath: artifact.filePath,
+        localPath: artifact.localPath,
+        mimeType: artifact.mimeType,
+        size: artifact.size,
+        createdAt: artifact.createdAt,
+      })
+      .run();
+  } catch (err) {
+    try {
+      unlinkSync(destPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw err;
+  }
 
   return artifact;
 }
@@ -150,21 +159,30 @@ export async function saveArtifactFromBuffer(params: SaveArtifactFromBufferParam
   };
 
   const db = getDb();
-  db.insert(artifacts)
-    .values({
-      id: artifact.id,
-      taskId: artifact.taskId,
-      messageId: artifact.messageId,
-      type: artifact.type,
-      name: artifact.name,
-      filePath: artifact.filePath,
-      localPath: artifact.localPath,
-      mimeType: artifact.mimeType,
-      size: artifact.size,
-      createdAt: artifact.createdAt,
-      contentText: contentText ?? '',
-    })
-    .run();
+  try {
+    db.insert(artifacts)
+      .values({
+        id: artifact.id,
+        taskId: artifact.taskId,
+        messageId: artifact.messageId,
+        type: artifact.type,
+        name: artifact.name,
+        filePath: artifact.filePath,
+        localPath: artifact.localPath,
+        mimeType: artifact.mimeType,
+        size: artifact.size,
+        createdAt: artifact.createdAt,
+        contentText: contentText ?? '',
+      })
+      .run();
+  } catch (err) {
+    try {
+      unlinkSync(destPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw err;
+  }
 
   return artifact;
 }

--- a/packages/desktop/test/artifact-save.test.ts
+++ b/packages/desktop/test/artifact-save.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  copyFileSync: vi.fn(),
+  statSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('crypto', () => ({
+  randomUUID: vi.fn(() => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+}));
+
+vi.mock('../src/main/db/index.js', () => ({
+  getDb: vi.fn(),
+}));
+
+vi.mock('../src/main/db/schema.js', () => ({
+  artifacts: Symbol('artifacts'),
+}));
+
+vi.mock('../src/main/workspace/init.js', () => ({
+  ensureTaskDir: vi.fn(() => '/workspace/tasks/task-1'),
+}));
+
+import { saveArtifact, saveArtifactFromBuffer } from '../src/main/artifact/save.js';
+import { copyFileSync, statSync, unlinkSync, writeFileSync } from 'fs';
+import { getDb } from '../src/main/db/index.js';
+
+const mockCopyFileSync = vi.mocked(copyFileSync);
+const mockStatSync = vi.mocked(statSync);
+const mockUnlinkSync = vi.mocked(unlinkSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockGetDb = vi.mocked(getDb);
+
+const DB_ERROR = new Error('UNIQUE constraint failed');
+
+function mockDbSuccess() {
+  const run = vi.fn();
+  const values = vi.fn(() => ({ run }));
+  const insert = vi.fn(() => ({ values }));
+  mockGetDb.mockReturnValue({ insert } as unknown as ReturnType<typeof getDb>);
+  return { insert, values, run };
+}
+
+function mockDbFailure() {
+  const run = vi.fn(() => {
+    throw DB_ERROR;
+  });
+  const values = vi.fn(() => ({ run }));
+  const insert = vi.fn(() => ({ values }));
+  mockGetDb.mockReturnValue({ insert } as unknown as ReturnType<typeof getDb>);
+  return { insert, values, run };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStatSync.mockReturnValue({ size: 1024 } as ReturnType<typeof statSync>);
+});
+
+describe('saveArtifact', () => {
+  const params = {
+    workspacePath: '/workspace',
+    taskId: 'task-1',
+    messageId: 'msg-1',
+    sourcePath: '/tmp/upload.png',
+  };
+
+  it('returns artifact on success', async () => {
+    mockDbSuccess();
+    const result = await saveArtifact(params);
+
+    expect(result.taskId).toBe('task-1');
+    expect(result.messageId).toBe('msg-1');
+    expect(result.mimeType).toBe('image/png');
+    expect(mockCopyFileSync).toHaveBeenCalledTimes(1);
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('removes copied file when DB insert fails', async () => {
+    mockDbFailure();
+
+    await expect(saveArtifact(params)).rejects.toThrow(DB_ERROR);
+
+    expect(mockCopyFileSync).toHaveBeenCalledTimes(1);
+    expect(mockUnlinkSync).toHaveBeenCalledTimes(1);
+    const destPath = mockUnlinkSync.mock.calls[0][0];
+    expect(String(destPath)).toContain('task-1');
+  });
+
+  it('still throws DB error when unlink also fails', async () => {
+    mockDbFailure();
+    mockUnlinkSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    await expect(saveArtifact(params)).rejects.toThrow(DB_ERROR);
+  });
+});
+
+describe('saveArtifactFromBuffer', () => {
+  const params = {
+    workspacePath: '/workspace',
+    taskId: 'task-1',
+    messageId: 'msg-1',
+    fileName: 'output.json',
+    buffer: Buffer.from('{"ok":true}'),
+    artifactType: 'file' as const,
+  };
+
+  it('returns artifact on success', async () => {
+    mockDbSuccess();
+    const result = await saveArtifactFromBuffer(params);
+
+    expect(result.taskId).toBe('task-1');
+    expect(result.mimeType).toBe('application/json');
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('removes written file when DB insert fails', async () => {
+    mockDbFailure();
+
+    await expect(saveArtifactFromBuffer(params)).rejects.toThrow(DB_ERROR);
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    expect(mockUnlinkSync).toHaveBeenCalledTimes(1);
+    const destPath = mockUnlinkSync.mock.calls[0][0];
+    expect(String(destPath)).toContain('task-1');
+  });
+
+  it('still throws DB error when unlink also fails', async () => {
+    mockDbFailure();
+    mockUnlinkSync.mockImplementation(() => {
+      throw new Error('EPERM');
+    });
+
+    await expect(saveArtifactFromBuffer(params)).rejects.toThrow(DB_ERROR);
+  });
+});


### PR DESCRIPTION
## Summary

Both `saveArtifact` and `saveArtifactFromBuffer` write files to disk before inserting metadata into SQLite. If the insert throws, the file remains on disk with no database row — orphan files accumulate over time.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

Users cannot reclaim orphaned files through the UI since no database row references them. Over time this silently wastes disk space in the task directory, especially under repeated save failures (e.g. constraint violations, disk-full during insert).

## What changed?

- Wrapped `db.insert().run()` in `try/catch` for both `saveArtifact` and `saveArtifactFromBuffer`
- On insert failure, `unlinkSync(destPath)` removes the orphan file before re-throwing
- The unlink itself is guarded with a bare `catch` so a cleanup failure cannot mask the original DB error
- Added `unlinkSync` to the existing `fs` import — no new dependencies

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is internal to `save.ts` — no new IPC surface, no schema change, no cross-layer imports

## Linked issues

Closes #386

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm check:ui-contract`
- [x] `pnpm check` (full gate — 2 pre-existing failures in `gateway-auth`/`gateway-tls` from missing Electron binary, unrelated)

New test file: `packages/desktop/test/artifact-save.test.ts` (6 tests)
- saveArtifact returns artifact on success
- saveArtifact removes copied file when DB insert fails
- saveArtifact still throws DB error when unlink also fails
- saveArtifactFromBuffer returns artifact on success
- saveArtifactFromBuffer removes written file when DB insert fails
- saveArtifactFromBuffer still throws DB error when unlink also fails

## Screenshots or recordings

No UI change.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

---

Drafted with AI assistance. Reviewed, tested, and verified by me.