### PR TITLE
[Fix] Hard-code renderer domain in debug:renderer-event handler

### DIFF
--- a/packages/desktop/src/main/ipc/debug-handlers.ts
+++ b/packages/desktop/src/main/ipc/debug-handlers.ts
@@ -11,7 +11,6 @@ export function registerDebugHandlers(): void {
     (
       _event,
       payload: {
-        domain: string;
         event: string;
         traceId?: string;
         feature?: string;
@@ -20,7 +19,7 @@ export function registerDebugHandlers(): void {
     ) => {
       const logger = getDebugLogger();
       logger.info({
-        domain: (payload.domain || 'renderer') as 'renderer',
+        domain: 'renderer',
         event: payload.event,
         traceId: payload.traceId,
         feature: payload.feature,

--- a/packages/desktop/test/debug-handlers-domain.test.ts
+++ b/packages/desktop/test/debug-handlers-domain.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const onMap = new Map<string, (...args: unknown[]) => void>();
+const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  ipcMain: {
+    on: vi.fn((channel: string, handler: (...args: unknown[]) => void) => {
+      onMap.set(channel, handler);
+    }),
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handleMap.set(channel, handler);
+    }),
+  },
+}));
+
+const infoMock = vi.fn();
+vi.mock('../src/main/debug/index.js', () => ({
+  getDebugLogger: vi.fn(() => ({ info: infoMock })),
+}));
+
+vi.mock('../src/main/ws/index.js', () => ({
+  getAllGatewayClients: vi.fn(() => new Map()),
+}));
+
+vi.mock('../src/main/workspace/config.js', () => ({
+  readConfig: vi.fn(() => null),
+}));
+
+vi.mock('../src/main/debug/export.js', () => ({
+  exportDebugBundle: vi.fn(() => ({ bundlePath: '/tmp/b.zip', events: [] })),
+}));
+
+import { registerDebugHandlers } from '../src/main/ipc/debug-handlers.js';
+
+beforeEach(() => {
+  onMap.clear();
+  handleMap.clear();
+  infoMock.mockClear();
+  registerDebugHandlers();
+});
+
+describe('debug:renderer-event domain enforcement', () => {
+  it('always logs domain as renderer regardless of payload', () => {
+    const handler = onMap.get('debug:renderer-event');
+    expect(handler).toBeDefined();
+
+    handler!({}, { event: 'test.click', data: { x: 1 } });
+
+    expect(infoMock).toHaveBeenCalledWith(expect.objectContaining({ domain: 'renderer', event: 'test.click' }));
+  });
+
+  it('ignores payload.domain even when set to a different value', () => {
+    const handler = onMap.get('debug:renderer-event')!;
+
+    handler!({}, { domain: 'db', event: 'spoofed.event' });
+
+    expect(infoMock).toHaveBeenCalledWith(expect.objectContaining({ domain: 'renderer' }));
+    expect(infoMock).not.toHaveBeenCalledWith(expect.objectContaining({ domain: 'db' }));
+  });
+});


### PR DESCRIPTION
## Summary

The `debug:renderer-event` IPC handler accepted an untrusted `domain` field from the renderer and cast it with `as 'renderer'`, letting the renderer log events under any domain name (`'db'`, `'gateway'`, etc.). Hard-coded `domain` to `'renderer'` since the IPC channel already identifies the source.

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

A renderer can inject events into any debug domain, polluting `getRecentEvents({ domain })` results and making it harder to debug real issues in those subsystems. The `as 'renderer'` cast masked the runtime contract violation.

## What changed?

- Removed `domain: string` from the payload type — the handler no longer reads it
- Changed `domain: (payload.domain || 'renderer') as 'renderer'` to `domain: 'renderer'`
- Added test file verifying the domain is always `'renderer'` regardless of payload

## Architecture impact

- Owning layer: main
- Cross-layer impact: none — renderers that sent `domain` will have it ignored silently
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: no new IPC surface, no schema change

## Linked issues

Closes #409

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (artifact-save and debug-handlers-domain tests all pass)

New test file: `packages/desktop/test/debug-handlers-domain.test.ts` (2 tests)
- Logs domain as `'renderer'` for normal payloads
- Ignores `payload.domain` when set to a spoofed value like `'db'`

## Screenshots or recordings

No UI change.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

---

Drafted with AI assistance. Reviewed, tested, and verified by me.