### PR TITLE
[Refactor] Extract ToolCallSummary and reuse in streaming view

### DIFF
--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -1,17 +1,16 @@
 import { memo, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import type { Message } from '@clawwork/shared';
-import { Check, ChevronDown, ChevronRight, Copy, FileCode, Loader2, Save, Wrench } from 'lucide-react';
+import { Check, Copy, FileCode, Loader2, Save } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { motion as motionPresets } from '@/styles/design-tokens';
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { Button } from '@/components/ui/button';
 import MessageAvatar from './MessageAvatar';
 import ThinkingSection from './ThinkingSection';
-import ToolCallCard from './ToolCallCard';
+import ToolCallSummary from './ToolCallSummary';
 import MarkdownContent from './MarkdownContent';
 
 interface ChatMessageProps {
@@ -64,54 +63,6 @@ function FileBlockChip({
       <span className="text-[var(--text-secondary)] font-medium truncate max-w-48">{fileName}</span>
       <span className="text-[var(--text-muted)] flex-shrink-0">{file.lineCount}L</span>
     </button>
-  );
-}
-
-function ToolCallSummary({ toolCalls }: { toolCalls: Message['toolCalls'] }) {
-  const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
-  const errorCount = toolCalls.filter((tc) => tc.status === 'error').length;
-
-  return (
-    <Collapsible open={expanded} onOpenChange={setExpanded}>
-      <CollapsibleTrigger asChild>
-        <button
-          className={cn(
-            'type-label mt-2 inline-flex items-center gap-2 rounded-lg px-3 py-2',
-            'text-[var(--text-secondary)] hover:text-[var(--text-primary)]',
-            'bg-[var(--bg-tertiary)] hover:bg-[var(--bg-hover)] transition-colors',
-            'glow-focus',
-          )}
-        >
-          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-          <Wrench size={14} />
-          <span>
-            {errorCount > 0
-              ? t('chatMessage.toolCallSummaryWithErrors', { count: toolCalls.length, errorCount })
-              : t('chatMessage.toolCallSummary', { count: toolCalls.length })}
-          </span>
-        </button>
-      </CollapsibleTrigger>
-      <CollapsibleContent forceMount>
-        <AnimatePresence>
-          {expanded && (
-            <motion.div
-              initial={motionPresets.collapse.initial}
-              animate={motionPresets.collapse.animate}
-              exit={motionPresets.collapse.exit}
-              transition={motionPresets.collapse.transition}
-              className="overflow-hidden"
-            >
-              <div className="mt-1 space-y-1">
-                {toolCalls.map((tc) => (
-                  <ToolCallCard key={tc.id} toolCall={tc} />
-                ))}
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </CollapsibleContent>
-    </Collapsible>
   );
 }
 

--- a/packages/desktop/src/renderer/components/StreamingMessage.tsx
+++ b/packages/desktop/src/renderer/components/StreamingMessage.tsx
@@ -6,6 +6,7 @@ import MessageAvatar from './MessageAvatar';
 import ThinkingSection from './ThinkingSection';
 import MarkdownContent from './MarkdownContent';
 import ToolCallCard from './ToolCallCard';
+import ToolCallSummary from './ToolCallSummary';
 
 interface StreamingMessageProps {
   content: string;
@@ -28,12 +29,18 @@ const StreamingMessage = memo(function StreamingMessage({
   agentName,
   agentRoleLabel,
 }: StreamingMessageProps) {
-  const lastRunningId = useMemo(() => {
-    if (!toolCalls?.length) return null;
+  const { visibleTool, completedTools } = useMemo(() => {
+    if (!toolCalls?.length) return { visibleTool: null, completedTools: [] as ToolCall[] };
+    let visibleIdx = -1;
     for (let i = toolCalls.length - 1; i >= 0; i--) {
-      if (toolCalls[i].status === 'running') return toolCalls[i].id;
+      if (toolCalls[i].status === 'running') {
+        visibleIdx = i;
+        break;
+      }
     }
-    return null;
+    if (visibleIdx === -1) visibleIdx = toolCalls.length - 1;
+    const completed = toolCalls.filter((_, i) => i !== visibleIdx);
+    return { visibleTool: toolCalls[visibleIdx], completedTools: completed };
   }, [toolCalls]);
 
   return (
@@ -63,16 +70,8 @@ const StreamingMessage = memo(function StreamingMessage({
         {thinkingContent && <ThinkingSection content={thinkingContent} defaultOpen streaming showCursor={!content} />}
         {toolCalls?.length ? (
           <div className="mb-2 space-y-1">
-            {toolCalls.map((tc) => {
-              const isLatestRunning = tc.id === lastRunningId;
-              return (
-                <ToolCallCard
-                  key={`${tc.id}-${isLatestRunning ? 'expanded' : 'collapsed'}`}
-                  toolCall={tc}
-                  defaultOpen={isLatestRunning}
-                />
-              );
-            })}
+            {completedTools.length > 0 ? <ToolCallSummary toolCalls={completedTools} /> : null}
+            {visibleTool ? <ToolCallCard key={visibleTool.id} toolCall={visibleTool} defaultOpen /> : null}
           </div>
         ) : null}
         {content && (

--- a/packages/desktop/src/renderer/components/ToolCallSummary.tsx
+++ b/packages/desktop/src/renderer/components/ToolCallSummary.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import type { ToolCall } from '@clawwork/shared';
+import { ChevronDown, ChevronRight, Wrench } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { motion as motionPresets } from '@/styles/design-tokens';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
+import ToolCallCard from './ToolCallCard';
+
+function ToolCallSummary({ toolCalls }: { toolCalls: ToolCall[] }) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const errorCount = toolCalls.filter((tc) => tc.status === 'error').length;
+
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded}>
+      <CollapsibleTrigger asChild>
+        <button
+          className={cn(
+            'type-label mt-2 inline-flex items-center gap-2 rounded-lg px-3 py-2',
+            'text-[var(--text-secondary)] hover:text-[var(--text-primary)]',
+            'bg-[var(--bg-tertiary)] hover:bg-[var(--bg-hover)] transition-colors',
+            'glow-focus',
+          )}
+        >
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          <Wrench size={14} />
+          <span>
+            {errorCount > 0
+              ? t('chatMessage.toolCallSummaryWithErrors', { count: toolCalls.length, errorCount })
+              : t('chatMessage.toolCallSummary', { count: toolCalls.length })}
+          </span>
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent forceMount>
+        <AnimatePresence>
+          {expanded && (
+            <motion.div
+              initial={motionPresets.collapse.initial}
+              animate={motionPresets.collapse.animate}
+              exit={motionPresets.collapse.exit}
+              transition={motionPresets.collapse.transition}
+              className="overflow-hidden"
+            >
+              <div className="mt-1 space-y-1">
+                {toolCalls.map((tc) => (
+                  <ToolCallCard key={tc.id} toolCall={tc} />
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export default ToolCallSummary;


### PR DESCRIPTION
## Summary

Extract the tool-call summary chip that already existed inside `ChatMessage` into its own `ToolCallSummary` component and reuse it in the live streaming view so the running tool is the only card expanded at any time.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [x] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

`ChatMessage` already collapsed completed tool calls into a single chip, but `StreamingMessage` rendered every past `ToolCallCard` inline. Long streams produced a tall stack of collapsed cards above the active one. Lifting the existing chip into a shared component lets the streaming view match the finalized message: one live card, everything prior tucked behind a chip.

## What changed?

- New `packages/desktop/src/renderer/components/ToolCallSummary.tsx` housing the collapsible chip + animated expansion, previously inlined in `ChatMessage.tsx`.
- `ChatMessage.tsx` drops the local `ToolCallSummary` definition and imports the shared one; unused `AnimatePresence` / `Collapsible*` / `ChevronDown` / `ChevronRight` / `Wrench` imports removed.
- `StreamingMessage.tsx` now computes `{ visibleTool, completedTools }`: the last running tool (or last in array as a fallback) is rendered as an expanded `ToolCallCard`, everything else flows through `ToolCallSummary`.

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none — pure renderer refactor, no protocol, persistence, or IPC changes
- Why those invariants remain protected: no Node, Electron, or shared types touched; behavior is confined to how renderer components compose existing `ToolCallCard` output

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
pre-commit hooks ran eslint --fix + prettier --write on the three staged files
check:architecture passed via lint-staged
full `pnpm check` gate not yet executed — reviewer or follow-up should run it before merge
```

## Screenshots or recordings

Renderer-only change. No new tokens, no new CSS variables. Existing `ToolCallCard`, `Collapsible`, and `motionPresets.collapse` preserve dark/light theme parity and animation behavior unchanged from the pre-extraction chip in `ChatMessage`.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
