### PR TITLE
[Fix] Fall back to team agent list when gateway catalog is not yet loaded

### DIFF
--- a/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
@@ -194,7 +194,7 @@ export function useChatSend(opts: UseChatSendOpts) {
           if (agents.length === 0 && !catalogEntryAll && team) {
             agents = team.agents
               .filter((ta) => ta.agentId !== task.agentId)
-              .map((ta) => ({ id: ta.agentId } satisfies AgentInfo));
+              .map((ta) => ({ id: ta.agentId }) satisfies AgentInfo);
           }
         } else {
           agents = allAgents.filter((a) => a.id !== 'main');

--- a/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
@@ -189,6 +189,13 @@ export function useChatSend(opts: UseChatSendOpts) {
           const teamAgentIds = new Set(team?.agents.map((a) => a.agentId) ?? []);
           teamAgentMap = new Map(team?.agents.map((a) => [a.agentId, a]));
           agents = allAgents.filter((a) => teamAgentIds.has(a.id) && a.id !== task.agentId);
+          // Fallback: if gateway agent catalog has not been fetched yet,
+          // build minimal AgentInfo objects from the team definition itself.
+          if (agents.length === 0 && !catalogEntryAll && team) {
+            agents = team.agents
+              .filter((ta) => ta.agentId !== task.agentId)
+              .map((ta) => ({ id: ta.agentId } satisfies AgentInfo));
+          }
         } else {
           agents = allAgents.filter((a) => a.id !== 'main');
         }

--- a/packages/desktop/test/conductor-catalog-fallback.test.tsx
+++ b/packages/desktop/test/conductor-catalog-fallback.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import { act, useRef, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Task, Team } from '@clawwork/shared';
+
+/* ---------- hoisted mocks ---------- */
+const mocks = vi.hoisted(() => {
+  const ensembleTask: Task = {
+    id: 'task-ensemble',
+    sessionKey: 'agent:main:clawwork:task:task-ensemble',
+    sessionId: '',
+    title: 'Team Task',
+    status: 'active',
+    createdAt: '2026-04-10T00:00:00.000Z',
+    updatedAt: '2026-04-10T00:00:00.000Z',
+    tags: [],
+    artifactDir: '',
+    gatewayId: 'gw-1',
+    agentId: 'manager-agent',
+    ensemble: true,
+    teamId: 'team-1',
+  };
+
+  const teamData: Team = {
+    id: 'team-1',
+    name: 'Test Team',
+    emoji: '',
+    description: 'A test team',
+    gatewayId: 'gw-1',
+    source: 'local',
+    version: '1',
+    agents: [
+      { agentId: 'manager-agent', role: 'manager', isManager: true },
+      { agentId: 'worker-a', role: 'coder', isManager: false },
+      { agentId: 'worker-b', role: 'reviewer', isManager: false },
+    ],
+    createdAt: '2026-04-10T00:00:00.000Z',
+    updatedAt: '2026-04-10T00:00:00.000Z',
+  };
+
+  return {
+    ensembleTask,
+    teamData,
+    initConductor: vi.fn(async () => true),
+    composerSend: vi.fn(async () => {}),
+    taskState: {
+      tasks: [ensembleTask],
+      activeTaskId: 'task-ensemble',
+      pendingNewTask: null,
+      commitPendingTask: vi.fn(),
+      updateTaskMetadata: vi.fn(),
+    },
+    messageState: {
+      addMessage: vi.fn(),
+      setProcessing: vi.fn(),
+      processingBySession: new Set<string>(),
+      activeTurnBySession: {},
+    },
+    uiState: {
+      gatewayStatusMap: { 'gw-1': 'connected' } as Record<string, string>,
+      modelCatalogByGateway: {} as Record<string, unknown>,
+      toolsCatalogByGateway: {} as Record<string, unknown>,
+      agentCatalogByGateway: {} as Record<string, unknown>,
+      setMainView: vi.fn(),
+    },
+    roomState: {
+      rooms: {} as Record<string, unknown>,
+      initConductor: vi.fn(async () => true),
+    },
+    teamState: {
+      teams: {} as Record<string, Team>,
+    },
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@clawwork/core', () => ({
+  extractDescription: (content: string) => content.slice(0, 50),
+}));
+
+/* Build mock store functions that support both hook calls and .getState() */
+function makeStoreMock<T extends object>(stateRef: T) {
+  const fn = <U,>(selector?: (state: T) => U) => (selector ? selector(stateRef) : stateRef);
+  fn.getState = () => stateRef;
+  fn.setState = () => {};
+  fn.subscribe = () => () => {};
+  return fn;
+}
+
+vi.mock('../src/renderer/platform', () => ({
+  composer: {
+    send: mocks.composerSend,
+    abort: vi.fn(async () => {}),
+  },
+  useTaskStore: makeStoreMock(mocks.taskState),
+  useMessageStore: makeStoreMock(mocks.messageState),
+  useUiStore: makeStoreMock(mocks.uiState),
+  useRoomStore: makeStoreMock(mocks.roomState),
+  useTeamStore: makeStoreMock(mocks.teamState),
+}));
+
+import { toast } from 'sonner';
+import { useChatSend } from '../src/renderer/components/ChatInput/useChatSend';
+
+/* ---------- helpers ---------- */
+function render(ui: ReactElement): { container: HTMLDivElement; unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+let capturedHandleSend: (() => Promise<void>) | null = null;
+
+function Harness() {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const chat = useChatSend({
+    textareaRef,
+    pendingImages: [],
+    setPendingImages: vi.fn(),
+    selectedTasks: [],
+    setSelectedTasks: vi.fn(),
+    selectedArtifacts: [],
+    setSelectedArtifacts: vi.fn(),
+    selectedLocalFiles: [],
+    setSelectedLocalFiles: vi.fn(),
+    selectedAgents: [],
+    setSelectedAgents: vi.fn(),
+    contextFolders: [],
+    stopVoiceInput: vi.fn(),
+  });
+  capturedHandleSend = chat.handleSend;
+  return <textarea ref={textareaRef} defaultValue="hello team" />;
+}
+
+/* ---------- tests ---------- */
+describe('conductor initialization - catalog fallback', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    capturedHandleSend = null;
+    vi.clearAllMocks();
+
+    // Stub IPC call used to fetch agent IDENTITY.md
+    (globalThis as Record<string, unknown>).window = globalThis;
+    (globalThis as Record<string, unknown> & { clawwork?: Record<string, unknown> }).clawwork = {
+      getAgentFile: vi.fn(async () => ({ ok: false })),
+    };
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to team agents when gateway catalog is not yet loaded', async () => {
+    // --- Setup: gateway catalog is empty (not yet fetched), but team data is available ---
+    mocks.uiState.agentCatalogByGateway = {};
+    mocks.teamState.teams = { 'team-1': mocks.teamData };
+    mocks.roomState.rooms = {};
+    mocks.roomState.initConductor.mockResolvedValue(true);
+
+    const { unmount } = render(<Harness />);
+    expect(capturedHandleSend).not.toBeNull();
+
+    await act(async () => {
+      await capturedHandleSend!();
+    });
+
+    // The conductor should have been initialized (not the error toast).
+    expect(toast.error).not.toHaveBeenCalledWith('errors.conductorInitFailed');
+    expect(mocks.roomState.initConductor).toHaveBeenCalledTimes(1);
+
+    // Verify the agentCatalogStr passed to initConductor contains the two worker agents.
+    const catalogArg = mocks.roomState.initConductor.mock.calls[0][3] as string;
+    expect(catalogArg).toContain('worker-a');
+    expect(catalogArg).toContain('worker-b');
+    // Manager agent should be excluded (it equals task.agentId).
+    expect(catalogArg).not.toContain('manager-agent');
+
+    unmount();
+  });
+
+  it('shows error toast when gateway catalog is empty AND no team data exists', async () => {
+    // --- Setup: gateway catalog empty, no team data ---
+    mocks.uiState.agentCatalogByGateway = {};
+    mocks.teamState.teams = {};
+    mocks.roomState.rooms = {};
+
+    const { unmount } = render(<Harness />);
+    expect(capturedHandleSend).not.toBeNull();
+
+    await act(async () => {
+      await capturedHandleSend!();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('errors.conductorInitFailed');
+    expect(mocks.roomState.initConductor).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('uses gateway catalog agents when catalog IS loaded (no fallback needed)', async () => {
+    // --- Setup: gateway catalog is populated ---
+    mocks.uiState.agentCatalogByGateway = {
+      'gw-1': {
+        defaultId: 'main',
+        agents: [
+          { id: 'manager-agent', name: 'Manager' },
+          { id: 'worker-a', name: 'Worker A', identity: { emoji: '🔧' } },
+          { id: 'worker-b', name: 'Worker B' },
+          { id: 'unrelated-agent', name: 'Other' },
+        ],
+      },
+    };
+    mocks.teamState.teams = { 'team-1': mocks.teamData };
+    mocks.roomState.rooms = {};
+    mocks.roomState.initConductor.mockResolvedValue(true);
+
+    const { unmount } = render(<Harness />);
+
+    await act(async () => {
+      await capturedHandleSend!();
+    });
+
+    expect(toast.error).not.toHaveBeenCalledWith('errors.conductorInitFailed');
+    expect(mocks.roomState.initConductor).toHaveBeenCalledTimes(1);
+
+    // When catalog IS loaded, agent names from the catalog should appear.
+    const catalogArg = mocks.roomState.initConductor.mock.calls[0][3] as string;
+    expect(catalogArg).toContain('Worker A');
+    expect(catalogArg).toContain('Worker B');
+    // unrelated-agent is not in the team, should not appear.
+    expect(catalogArg).not.toContain('unrelated-agent');
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary

When a user sends a message in a newly created team, the conductor initialization fails with "Failed to initialize team coordinator" because the gateway agent catalog hasn't been fetched yet (async race condition in `useGatewayBootstrap.ts`). This PR adds a fallback that builds the worker list from the team's own agent definitions stored in the team store.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

When a team is newly created and the user immediately sends a message, the gateway agent catalog may not have completed its async fetch yet. The conductor initialization code in `useChatSend.ts` looks up agents from `agentCatalogByGateway[task.gatewayId]`, which returns `undefined` when the catalog hasn't loaded. This causes `allAgents` to be `[]`, the filter returns `[]`, and the user sees the error toast "Failed to initialize team coordinator" — even though the team definition itself already has the required agent information.

## What changed?

- In `useChatSend.ts`, after the existing agent filter (line 191), added a fallback: when `agents.length === 0` AND `catalogEntryAll` is undefined (catalog not yet loaded) AND the team definition is available, build minimal `AgentInfo` objects from the team's own agent list (excluding the manager/task agent).
- Added a new test file `conductor-catalog-fallback.test.tsx` with three test cases covering: (1) successful fallback to team agents, (2) error when both catalog and team data are missing, and (3) normal path when catalog is loaded.

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none — the change is a local fallback within the existing conductor initialization flow in the renderer layer.
- Why those invariants remain protected: The fix only adds a fallback data source (team store) that is already imported and used in the same function. No new cross-layer calls are introduced.

## Linked issues

Closes #417

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm lint — 0 errors, 1 pre-existing warning (unrelated)
pnpm typecheck — passes
pnpm test — 214 passed, 2 pre-existing failures (electron binary not installed for gateway-auth/gateway-tls tests)
New test: packages/desktop/test/conductor-catalog-fallback.test.tsx — 3 tests, all pass
```

## Screenshots or recordings

No UI changes. The fix is in the data-fetching/initialization logic only.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fixed a bug where sending messages in a newly created team could fail with "Failed to initialize team coordinator" when the gateway agent catalog had not finished loading.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

---

Drafted with AI assistance. Reviewed, tested, and verified by me.