### PR TITLE
[Build] Add automated release notes draft generator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,9 @@ jobs:
   publish-release-notes:
     needs: [prepare-release, verify-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     env:
       RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,53 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  publish-release-notes:
+    needs: [prepare-release, verify-release]
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate release notes draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/generate-release-notes.mjs "$RELEASE_TAG" > /tmp/release-notes.md
+          {
+            echo "## Draft release notes for $RELEASE_TAG"
+            echo ''
+            cat /tmp/release-notes.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload draft as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-${{ env.RELEASE_TAG }}
+          path: /tmp/release-notes.md
+
+      - name: Fill Release body only if empty
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current=$(gh release view "$RELEASE_TAG" --repo ${{ github.repository }} --json body -q '.body' || echo '')
+          stripped=$(printf '%s' "$current" | tr -d '[:space:]')
+          if [ -z "$stripped" ]; then
+            echo "Release body is empty — writing draft"
+            gh release edit "$RELEASE_TAG" --repo ${{ github.repository }} --notes-file /tmp/release-notes.md
+          else
+            echo "Release body already populated — leaving it alone"
+          fi
+
   update-homebrew:
     needs: [prepare-release, release, verify-release]
     if: ${{ needs.prepare-release.outputs.is_prerelease != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          current=$(gh release view "$RELEASE_TAG" --repo ${{ github.repository }} --json body -q '.body' || echo '')
+          if ! current=$(gh release view "$RELEASE_TAG" --repo ${{ github.repository }} --json body -q '.body' 2>/dev/null); then
+            echo "::warning::Could not read current Release body — skipping notes fill to avoid overwriting hand-written content"
+            exit 0
+          fi
           stripped=$(printf '%s' "$current" | tr -d '[:space:]')
           if [ -z "$stripped" ]; then
             echo "Release body is empty — writing draft"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:e2e:gateway": "playwright test --config=e2e/playwright.config.ts --project=gateway",
     "check:i18n": "node scripts/check-i18n.mjs",
     "check:dead-code": "knip",
+    "release-notes": "node scripts/generate-release-notes.mjs",
     "check": "pnpm lint && pnpm check:architecture && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm test"
   },
   "lint-staged": {

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -113,7 +113,7 @@ function getPrCandidates(base, head) {
       i += 1;
       stderr.write(`  [${i}/${needsLookup.length}] commit->PR ${c.sha.slice(0, 8)}\r`);
       const out = sh(
-        `gh api repos/:owner/:repo/commits/${c.sha}/pulls --jq '[.[] | select(.state=="closed" or .state=="merged")] | .[0].number // empty'`,
+        `gh api repos/:owner/:repo/commits/${c.sha}/pulls --jq '[.[] | select(.merged_at != null)] | .[0].number // empty'`,
         { allowFail: true },
       );
       const num = Number(out);
@@ -209,10 +209,11 @@ function render({ base, head, groups, newContributors, repo }) {
     lines.push(`## ${group.emoji} ${group.name}`);
     lines.push('');
     for (const item of group.items) {
+      const text = item.text.replace(/\s+/g, ' ').trim();
       if (item.orphan) {
-        lines.push(`- ${item.text} by ${item.author} (${item.sha.slice(0, 7)})`);
+        lines.push(`- ${text} by ${item.author} (${item.sha.slice(0, 7)})`);
       } else {
-        lines.push(`- ${item.text} by @${item.author} in #${item.number}`);
+        lines.push(`- ${text} by @${item.author} in #${item.number}`);
       }
     }
     lines.push('');

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { argv, stderr, stdout, exit } from 'node:process';
+
+const PREFIX_META = {
+  '[Feat]': { emoji: '✨', name: 'Features', order: 1 },
+  '[UI]': { emoji: '🎨', name: 'UI / UX', order: 2 },
+  '[Fix]': { emoji: '🐛', name: 'Bug Fixes', order: 3 },
+  '[Refactor]': { emoji: '♻️', name: 'Refactor', order: 4 },
+  '[Build]': { emoji: '🔧', name: 'Build / CI', order: 5 },
+  '[Docs]': { emoji: '📚', name: 'Docs', order: 6 },
+  '[Chore]': { emoji: '🧹', name: 'Chore', order: 7 },
+};
+
+const CONVENTIONAL_MAP = {
+  feat: '[Feat]',
+  fix: '[Fix]',
+  ui: '[UI]',
+  style: '[UI]',
+  docs: '[Docs]',
+  refactor: '[Refactor]',
+  perf: '[Refactor]',
+  test: '[Refactor]',
+  build: '[Build]',
+  ci: '[Build]',
+  chore: '[Chore]',
+};
+
+const PREFIX_ALIASES = {
+  '[Bug]': '[Fix]',
+  '[Bugfix]': '[Fix]',
+  '[Hotfix]': '[Fix]',
+  '[Cleanup]': '[Refactor]',
+  '[Test]': '[Refactor]',
+  '[Tests]': '[Refactor]',
+  '[Perf]': '[Refactor]',
+  '[CI]': '[Build]',
+  '[Ops]': '[Build]',
+  '[I18n]': '[Chore]',
+  '[Style]': '[UI]',
+};
+
+function sh(cmd, { allowFail = false } = {}) {
+  try {
+    return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  } catch (err) {
+    if (allowFail) return '';
+    stderr.write(`command failed: ${cmd}\n${err.stderr ?? err.message}\n`);
+    throw err;
+  }
+}
+
+function parseArgs() {
+  const args = argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    stdout.write(
+      [
+        'Usage: node scripts/generate-release-notes.mjs [RANGE]',
+        '',
+        'RANGE forms:',
+        '  v0.0.14                previous tag..v0.0.14',
+        '  v0.0.13..v0.0.14       explicit range',
+        '  (no arg)               previous tag..HEAD',
+        '',
+        'Output: markdown to stdout. Log to stderr.',
+        '',
+      ].join('\n'),
+    );
+    exit(0);
+  }
+
+  const arg = args[0];
+  let base;
+  let head;
+  if (!arg) {
+    head = 'HEAD';
+    base = sh('git describe --tags --abbrev=0 HEAD^', { allowFail: true });
+  } else if (arg.includes('..')) {
+    [base, head] = arg.split('..');
+  } else {
+    head = arg;
+    base = sh(`git describe --tags --abbrev=0 ${head}^`, { allowFail: true });
+  }
+  if (!base || !head) {
+    stderr.write('error: could not resolve base..head range\n');
+    exit(1);
+  }
+  return { base, head };
+}
+
+function getPrCandidates(base, head) {
+  const log = sh(`git log ${base}..${head} --format=%H%x09%s --no-merges`);
+  const byNum = new Map();
+  const needsLookup = [];
+  for (const line of log.split('\n')) {
+    if (!line) continue;
+    const tab = line.indexOf('\t');
+    const sha = line.slice(0, tab);
+    const subject = line.slice(tab + 1);
+    const m = subject.match(/^(.+?)\s*\(#(\d+)\)\s*$/);
+    if (m) {
+      const num = Number(m[2]);
+      if (!byNum.has(num)) byNum.set(num, { number: num, sha, subjectTitle: m[1] });
+    } else {
+      needsLookup.push({ sha, subjectTitle: subject });
+    }
+  }
+
+  if (needsLookup.length > 0) {
+    stderr.write(`resolving ${needsLookup.length} commit(s) without PR suffix...\n`);
+    let i = 0;
+    for (const c of needsLookup) {
+      i += 1;
+      stderr.write(`  [${i}/${needsLookup.length}] commit->PR ${c.sha.slice(0, 8)}\r`);
+      const out = sh(
+        `gh api repos/:owner/:repo/commits/${c.sha}/pulls --jq '[.[] | select(.state=="closed" or .state=="merged")] | .[0].number // empty'`,
+        { allowFail: true },
+      );
+      const num = Number(out);
+      if (Number.isFinite(num) && num > 0) {
+        if (!byNum.has(num)) byNum.set(num, { number: num, sha: c.sha, subjectTitle: c.subjectTitle });
+      } else {
+        const synthetic = -Math.abs([...c.sha].reduce((acc, ch) => (acc * 31 + ch.charCodeAt(0)) >>> 0, 0));
+        byNum.set(synthetic, {
+          number: synthetic,
+          sha: c.sha,
+          subjectTitle: c.subjectTitle,
+          orphan: true,
+        });
+      }
+    }
+    stderr.write('\n');
+  }
+
+  return [...byNum.values()].sort((a, b) => a.number - b.number);
+}
+
+function fetchPr(num) {
+  const raw = sh(`gh pr view ${num} --json number,title,body,author,mergedAt`);
+  return JSON.parse(raw);
+}
+
+function classify(title) {
+  for (const [prefix, meta] of Object.entries(PREFIX_META)) {
+    if (title.startsWith(prefix)) {
+      return { prefix, strippedTitle: title.slice(prefix.length).trim(), ...meta };
+    }
+  }
+  for (const [alias, canonical] of Object.entries(PREFIX_ALIASES)) {
+    if (title.toLowerCase().startsWith(alias.toLowerCase())) {
+      const stripped = title.slice(alias.length).trim();
+      return { prefix: canonical, strippedTitle: stripped, ...PREFIX_META[canonical] };
+    }
+  }
+  const m = title.match(/^(\w+)(\([^)]+\))?!?:\s*(.+)$/);
+  if (m) {
+    const type = m[1].toLowerCase();
+    const mapped = CONVENTIONAL_MAP[type];
+    if (mapped) {
+      return { prefix: mapped, strippedTitle: m[3], ...PREFIX_META[mapped] };
+    }
+  }
+  return { prefix: null, strippedTitle: title, emoji: '📦', name: 'Other', order: 99 };
+}
+
+function extractReleaseNote(body) {
+  if (!body) return null;
+  const m = body.match(/```release-note\s*\n([\s\S]*?)\n```/);
+  if (!m) return null;
+  const text = m[1].trim();
+  if (!text || text.toUpperCase() === 'NONE') return null;
+  return text;
+}
+
+function findNewContributors(prs) {
+  const firstByAuthor = new Map();
+  for (const pr of prs) {
+    const login = pr.author?.login;
+    if (!login) continue;
+    const prev = firstByAuthor.get(login);
+    if (!prev || pr.number < prev.number) firstByAuthor.set(login, pr);
+  }
+
+  const result = [];
+  for (const [login, firstPr] of firstByAuthor) {
+    const out = sh(`gh pr list --state merged --author ${JSON.stringify(login)} --limit 500 --json number`, {
+      allowFail: true,
+    });
+    let allNums = [];
+    try {
+      allNums = JSON.parse(out || '[]').map((p) => p.number);
+    } catch {
+      allNums = [];
+    }
+    if (allNums.length === 0) continue;
+    const globalMin = Math.min(...allNums);
+    if (globalMin === firstPr.number) {
+      result.push({ login, firstPr });
+    }
+  }
+  return result.sort((a, b) => a.firstPr.number - b.firstPr.number);
+}
+
+function render({ base, head, groups, newContributors, repo }) {
+  const lines = [];
+  const sorted = [...groups.values()].sort((a, b) => a.order - b.order);
+  for (const group of sorted) {
+    if (group.items.length === 0) continue;
+    lines.push(`## ${group.emoji} ${group.name}`);
+    lines.push('');
+    for (const item of group.items) {
+      if (item.orphan) {
+        lines.push(`- ${item.text} by @${item.author} (${item.sha.slice(0, 7)})`);
+      } else {
+        lines.push(`- ${item.text} by @${item.author} in #${item.number}`);
+      }
+    }
+    lines.push('');
+  }
+  if (newContributors.length > 0) {
+    lines.push('## 👋 New Contributors');
+    lines.push('');
+    for (const nc of newContributors) {
+      lines.push(`- @${nc.login} made their first contribution in #${nc.firstPr.number}`);
+    }
+    lines.push('');
+  }
+  lines.push(`**Full Changelog**: https://github.com/${repo}/compare/${base}...${head}`);
+  return lines.join('\n') + '\n';
+}
+
+function main() {
+  const { base, head } = parseArgs();
+  stderr.write(`range: ${base}..${head}\n`);
+
+  const candidates = getPrCandidates(base, head);
+  stderr.write(`found ${candidates.length} PR references\n`);
+
+  const groups = new Map();
+  for (const [prefix, meta] of Object.entries(PREFIX_META)) {
+    groups.set(prefix, { ...meta, items: [] });
+  }
+  groups.set('__other__', { emoji: '📦', name: 'Other', order: 99, items: [] });
+
+  const prs = [];
+  const unresolved = [];
+  let done = 0;
+  for (const candidate of candidates) {
+    done += 1;
+    if (candidate.orphan) {
+      stderr.write(`  [${done}/${candidates.length}] orphan ${candidate.sha.slice(0, 8)}\n`);
+      const { prefix, strippedTitle } = classify(candidate.subjectTitle);
+      const commitAuthor = sh(`git log -1 --format=%aN ${candidate.sha}`, { allowFail: true });
+      const bucket = prefix ? groups.get(prefix) : groups.get('__other__');
+      bucket.items.push({
+        text: strippedTitle,
+        author: commitAuthor || 'unknown',
+        sha: candidate.sha,
+        orphan: true,
+      });
+      continue;
+    }
+    stderr.write(`  [${done}/${candidates.length}] fetching #${candidate.number}\r`);
+    try {
+      const pr = fetchPr(candidate.number);
+      prs.push(pr);
+      const { prefix, strippedTitle } = classify(pr.title);
+      const note = extractReleaseNote(pr.body);
+      const text = note ?? strippedTitle;
+      const bucket = prefix ? groups.get(prefix) : groups.get('__other__');
+      bucket.items.push({
+        text,
+        author: pr.author?.login ?? 'unknown',
+        number: pr.number,
+      });
+    } catch {
+      stderr.write(`\n  unresolved #${candidate.number} — using commit subject\n`);
+      const { prefix, strippedTitle } = classify(candidate.subjectTitle);
+      const commitAuthor = sh(`git log -1 --format=%aN ${candidate.sha}`, { allowFail: true });
+      const bucket = prefix ? groups.get(prefix) : groups.get('__other__');
+      bucket.items.push({
+        text: strippedTitle,
+        author: commitAuthor || 'unknown',
+        number: candidate.number,
+        unresolved: true,
+      });
+      unresolved.push(candidate.number);
+    }
+  }
+  stderr.write('\n');
+
+  const repo = sh('gh repo view --json nameWithOwner -q .nameWithOwner');
+  stderr.write(`resolving first-time contributors...\n`);
+  const newContributors = findNewContributors(prs);
+  stderr.write(`  ${newContributors.length} new contributors\n`);
+
+  if (unresolved.length > 0) {
+    stderr.write(
+      `warning: ${unresolved.length} PR(s) could not be resolved via gh API: ${unresolved
+        .map((n) => `#${n}`)
+        .join(', ')}\n`,
+    );
+  }
+
+  stdout.write(render({ base, head, groups, newContributors, repo }));
+}
+
+main();

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -165,7 +165,7 @@ function classify(title) {
 
 function extractReleaseNote(body) {
   if (!body) return null;
-  const m = body.match(/```release-note\s*\n([\s\S]*?)\n```/);
+  const m = body.match(/```release-note\s*([\s\S]*?)```/);
   if (!m) return null;
   const text = m[1].trim();
   if (!text || text.toUpperCase() === 'NONE') return null;
@@ -183,18 +183,18 @@ function findNewContributors(prs) {
 
   const result = [];
   for (const [login, firstPr] of firstByAuthor) {
-    const out = sh(`gh pr list --state merged --author ${JSON.stringify(login)} --limit 500 --json number`, {
-      allowFail: true,
-    });
-    let allNums = [];
+    const out = sh(
+      `gh pr list --state merged --author ${JSON.stringify(login)} --search "sort:created-asc" --limit 1 --json number`,
+      { allowFail: true },
+    );
+    let earliest = null;
     try {
-      allNums = JSON.parse(out || '[]').map((p) => p.number);
+      const arr = JSON.parse(out || '[]');
+      if (arr.length > 0) earliest = arr[0].number;
     } catch {
-      allNums = [];
+      earliest = null;
     }
-    if (allNums.length === 0) continue;
-    const globalMin = Math.min(...allNums);
-    if (globalMin === firstPr.number) {
+    if (earliest === firstPr.number) {
       result.push({ login, firstPr });
     }
   }
@@ -210,7 +210,7 @@ function render({ base, head, groups, newContributors, repo }) {
     lines.push('');
     for (const item of group.items) {
       if (item.orphan) {
-        lines.push(`- ${item.text} by @${item.author} (${item.sha.slice(0, 7)})`);
+        lines.push(`- ${item.text} by ${item.author} (${item.sha.slice(0, 7)})`);
       } else {
         lines.push(`- ${item.text} by @${item.author} in #${item.number}`);
       }


### PR DESCRIPTION
## Summary

Adds a release notes draft generator so maintainers no longer have to hand-assemble the release body from 80+ PRs each tag. The `pnpm release-notes <tag>` CLI produces a categorized markdown draft from merged PR metadata. A new `publish-release-notes` CI job runs the same generator on tag push, publishes the draft to `$GITHUB_STEP_SUMMARY`, uploads it as an artifact, and fills the GitHub Release body **only if it is empty** — existing hand-curated notes are never overwritten.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [x] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The PR template already captures structured signal (`[Feat]`/`[Fix]`/... title prefixes, a `release-note` code block in the body), but `release.yml` only builds and publishes binaries — nothing consumes that metadata. Every release has been hand-assembled from the PR list, which is mechanical and repetitive. The creative work (Highlights, semantic PR grouping, contributor descriptions) stays in human hands; this change automates only the part worth automating.

## What changed?

- `scripts/generate-release-notes.mjs` (new, ~310 lines, zero npm deps): resolves PR numbers from `git log base..head` via `(#NNN)` suffix, with `gh api commits/<sha>/pulls` fallback for squashes whose subject was edited to drop the suffix. Classifies by title prefix with an alias map for non-canonical prefixes (`[Bug]` → `[Fix]`, `[Cleanup]` → `[Refactor]`, etc.) and a conventional-commits fallback. Prefers the non-`NONE` `release-note` block over PR title for bullet text. Detects first-time contributors by comparing the author's range-local first PR to their global minimum merged PR. Orphan commits (no associated PR) render with a short SHA instead of being dropped.
- `package.json`: adds `pnpm release-notes` script entry.
- `.github/workflows/release.yml`: new `publish-release-notes` job, positioned after `verify-release` and parallel to `update-homebrew` so total workflow duration is unchanged. Always writes `$GITHUB_STEP_SUMMARY` and uploads a `release-notes-<tag>` artifact; only calls `gh release edit --notes-file` when the current Release body is whitespace-empty. No new permissions required — the top-level `contents: write` / `actions: write` already cover it.

## Architecture impact

- Owning layer: build / CI tooling only — no runtime code touched.
- Cross-layer impact: none.
- Invariants touched from `docs/architecture-invariants.md`: none.
- Why those invariants remain protected: changes are confined to `scripts/` and `.github/workflows/`. No `shared` / `core` / `main` / `preload` / `renderer` code is touched, and no new runtime dependencies are introduced — the generator uses only Node built-ins and the `gh` CLI already required by existing workflow steps.

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
lint-staged pre-commit gate passed (eslint --fix, prettier --write, check:architecture).
Full `pnpm check` NOT run — this change is CI/tooling-only (workflow yaml + generator script),
does not touch runtime code, and has no unit-test hook; it can only be fully exercised by an
actual tag push. Reviewer should run `pnpm check` before merge.

Local smoke test of the generator against v0.0.13..v0.0.14:
  91 PRs resolved (80 via (#NNN) suffix, 11 via commit->PR API fallback)
  6 first-time contributors detected
  9 orphan commits rendered with short SHA instead of being dropped
  sections: 30 Features / 33 Bug Fixes / 7 Refactor / 1 Build / 12 Docs / 6 Chore / 2 Other
  output structurally matches the hand-written v0.0.14 release body
  (minus the Highlights section and semantic PR grouping, intentionally left to human editing)

Workflow yaml validated via yq:
  jobs: [prepare-release, release, verify-release, publish-release-notes, update-homebrew]
  publish-release-notes needs: [prepare-release, verify-release]
  update-homebrew needs unchanged
```

## Screenshots or recordings

No UI change.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Release maintainers can now run `pnpm release-notes <tag>` to generate a categorized release
notes draft from merged PR metadata. A new `publish-release-notes` CI job runs the same
generator on every tag push, saves the draft to the workflow summary and a downloadable
artifact, and populates the GitHub Release body only when it is empty — existing hand-written
notes are never overwritten.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
