### PR TITLE
[Build] Add aggregation gate for CI required status checks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -175,3 +175,20 @@ jobs:
           name: e2e-gateway-report
           path: playwright-report/
           retention-days: 7
+
+  e2e-passed:
+    needs: [changes, smoke, gateway]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify aggregate status
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS"
+          failed=$(jq -r '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key] | join(", ")' <<< "$NEEDS")
+          if [ -n "$failed" ]; then
+            echo "::error::Required gates failed or cancelled: $failed"
+            exit 1
+          fi
+          echo "All required gates passed or skipped cleanly."

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -241,3 +241,20 @@ jobs:
 
       - name: Package Linux smoke build
         run: pnpm --filter @clawwork/desktop exec electron-builder --linux --x64 --publish never
+
+  ci-passed:
+    needs: [changes, quality, test, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify aggregate status
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS"
+          failed=$(jq -r '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key] | join(", ")' <<< "$NEEDS")
+          if [ -n "$failed" ]; then
+            echo "::error::Required gates failed or cancelled: $failed"
+            exit 1
+          fi
+          echo "All required gates passed or skipped cleanly."


### PR DESCRIPTION
## Why

Today the `main` branch ruleset has **no required status checks**. PRs can technically merge with CI red; everything relies on manual gatekeeping. Making a set of existing jobs `required` directly is brittle — every new/removed job means a ruleset edit, and individual `if`-gated jobs can be `skipped` in ways the ruleset treats as neutral.

## What

Two new aggregation jobs:

- `ci-passed` in `pr-check.yml` — fans in `changes`, `quality`, `test`, `build`
- `e2e-passed` in `e2e.yml`   — fans in `changes`, `smoke`, `gateway`

Each runs with `if: always()` and inspects `needs.*.result` via `jq`. The rule:

| Upstream result | Treated as |
|---|---|
| `success`   | pass |
| `skipped`   | pass (path-filter bypass is legitimate for docs-only PRs) |
| `failure`   | fail |
| `cancelled` | fail |

Verified against 6 scenarios locally (all success / each of quality/test failing / all skipped / changes failing / a cancelled job) — all behave correctly.

## Follow-up (admin, after this merges)

Update the repo ruleset [`main`](https://github.com/clawwork-ai/ClawWork/rules/13866130) to require:

- `ci-passed`
- `e2e-passed`

After this is in place, adding/removing underlying CI jobs requires **no ruleset edit** — just update the `needs:` array of the aggregation job.

## Out of scope

- Switching the ruleset itself (manual admin step — needs to observe a few green runs first)
- Fixing the other CI gaps surfaced in analysis (missing `Test core`, `--max-warnings 0`, shallow `check:architecture`, thin smoke tests) — each will be a separate focused PR