### PR TITLE
[Build] Tighten CI: zero-warning lint + Test core step

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -26,6 +26,7 @@ jobs:
       typecheck_pwa: ${{ steps.plan.outputs.typecheck_pwa }}
       typecheck_website: ${{ steps.plan.outputs.typecheck_website }}
       test_shared: ${{ steps.plan.outputs.test_shared }}
+      test_core: ${{ steps.plan.outputs.test_core }}
       test_desktop: ${{ steps.plan.outputs.test_desktop }}
       test_pwa: ${{ steps.plan.outputs.test_pwa }}
       build_desktop: ${{ steps.plan.outputs.build_desktop }}
@@ -107,6 +108,7 @@ jobs:
           set_flag typecheck_pwa "$GLOBAL" "$SHARED" "$CORE" "$PWA"
           set_flag typecheck_website "$GLOBAL" "$WEBSITE"
           set_flag test_shared "$GLOBAL" "$SHARED"
+          set_flag test_core "$GLOBAL" "$SHARED" "$CORE"
           set_flag test_desktop "$GLOBAL" "$SHARED" "$CORE" "$DESKTOP_RENDERER" "$DESKTOP_MAIN" "$DESKTOP_PACKAGE"
           set_flag test_pwa "$GLOBAL" "$SHARED" "$CORE" "$PWA"
           set_flag build_desktop "$GLOBAL" "$SHARED" "$CORE" "$DESKTOP_RENDERER" "$DESKTOP_MAIN" "$DESKTOP_PACKAGE"
@@ -205,6 +207,10 @@ jobs:
       - name: Test shared
         if: needs.changes.outputs.test_shared == 'true'
         run: pnpm --filter @clawwork/shared test
+
+      - name: Test core
+        if: needs.changes.outputs.test_core == 'true'
+        run: pnpm --filter @clawwork/core test
 
       - name: Test desktop
         if: needs.changes.outputs.test_desktop == 'true'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:renderer-copy": "node scripts/check-renderer-copy.mjs",
     "check:ui-contract": "node scripts/check-ui-contract.mjs",
     "typecheck": "pnpm --filter @clawwork/shared exec tsc -b && pnpm --filter @clawwork/core exec tsc -b && pnpm --filter @clawwork/pwa exec tsc --noEmit && pnpm --filter @clawwork/desktop exec tsc --noEmit && pnpm --filter @clawwork/website exec tsc --noEmit",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/desktop/src/renderer/components/PopoverListBase.tsx
+++ b/packages/desktop/src/renderer/components/PopoverListBase.tsx
@@ -29,7 +29,7 @@ export default function PopoverListBase({
 
   useEffect(() => {
     selectedItemRef.current?.scrollIntoView({ block: 'nearest' });
-  }, [selectedIndex]);
+  }, [selectedIndex, selectedItemRef]);
 
   return (
     <AnimatePresence>


### PR DESCRIPTION
## Why

Analyzing the PR Check workflow surfaced three small but real gaps:

1. **`@clawwork/core` tests never ran in CI** — the package has 73 unit tests (system-session-store / team-parser / team-installer / system-session-service) that `pnpm check` runs locally, but `pr-check.yml` had no `Test core` step. Any regression in core was invisible to CI.

2. **`pnpm lint` had no `--max-warnings 0`** — ESLint warnings silently passed. The repo had 1 active warning (`react-hooks/exhaustive-deps` in `PopoverListBase.tsx`) accumulating without being flagged as a regression.

3. **The existing warning** would flip to a failure once (2) lands, so it has to be fixed in the same PR.

## What

| Change | Lines |
|---|---|
| `pr-check.yml` — add `test_core` flag in the `changes` plan + `Test core` step in the `test` job | +6 |
| `package.json` — `lint` script now uses `--max-warnings 0` | +1/-1 |
| `PopoverListBase.tsx` — add `selectedItemRef` to the `useEffect` dep array | +1/-1 |

The PopoverListBase fix is behavior-neutral: the ref's identity is stable across renders (it's a `useRef` from the parent), so adding it to the dep array doesn't cause additional effect runs. This is exactly what the lint rule is designed to encourage.

## Verification

- `pnpm check` passes locally (exit 0)
- `actionlint` clean on the workflow change
- Local test count: shared 12 + **core 73** + desktop 237 + pwa 60 = 382 tests; the new step makes the 73 core tests CI-visible

## Out of scope (separate PRs)

- Test files into typecheck — probed locally, surfaces ~40 errors (mostly `vi.mocked()` cast patterns, not bugs). Will be a focused refactor PR.
- Architecture guardrails expansion — PR3.
- E2E smoke tests rewrite — PR4.