### PR TITLE
[Build] Typecheck test files via tsconfig.test.json

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -204,6 +204,22 @@ jobs:
         if: needs.changes.outputs.typecheck_website == 'true'
         run: pnpm --filter @clawwork/website exec tsc --noEmit
 
+      - name: Type check shared tests
+        if: needs.changes.outputs.test_shared == 'true'
+        run: pnpm --filter @clawwork/shared exec tsc --noEmit -p tsconfig.test.json
+
+      - name: Type check core tests
+        if: needs.changes.outputs.test_core == 'true'
+        run: pnpm --filter @clawwork/core exec tsc --noEmit -p tsconfig.test.json
+
+      - name: Type check desktop tests
+        if: needs.changes.outputs.test_desktop == 'true'
+        run: pnpm --filter @clawwork/desktop exec tsc --noEmit -p tsconfig.test.json
+
+      - name: Type check PWA tests
+        if: needs.changes.outputs.test_pwa == 'true'
+        run: pnpm --filter @clawwork/pwa exec tsc --noEmit -p tsconfig.test.json
+
       - name: Test shared
         if: needs.changes.outputs.test_shared == 'true'
         run: pnpm --filter @clawwork/shared test

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:renderer-copy": "node scripts/check-renderer-copy.mjs",
     "check:ui-contract": "node scripts/check-ui-contract.mjs",
     "typecheck": "pnpm --filter @clawwork/shared exec tsc -b && pnpm --filter @clawwork/core exec tsc -b && pnpm --filter @clawwork/pwa exec tsc --noEmit && pnpm --filter @clawwork/desktop exec tsc --noEmit && pnpm --filter @clawwork/website exec tsc --noEmit",
+    "typecheck:tests": "pnpm --filter @clawwork/shared exec tsc --noEmit -p tsconfig.test.json && pnpm --filter @clawwork/core exec tsc --noEmit -p tsconfig.test.json && pnpm --filter @clawwork/desktop exec tsc --noEmit -p tsconfig.test.json && pnpm --filter @clawwork/pwa exec tsc --noEmit -p tsconfig.test.json",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -28,7 +29,7 @@
     "check:i18n": "node scripts/check-i18n.mjs",
     "check:dead-code": "knip",
     "release-notes": "node scripts/generate-release-notes.mjs",
-    "check": "pnpm lint && pnpm check:architecture && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm test"
+    "check": "pnpm lint && pnpm check:architecture && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm typecheck:tests && pnpm test"
   },
   "lint-staged": {
     "*.{ts,tsx,mts,cts,js,mjs,cjs}": [

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src", "test"]
+}

--- a/packages/desktop/test/approval-store.test.ts
+++ b/packages/desktop/test/approval-store.test.ts
@@ -25,7 +25,7 @@ async function flushMicrotasks() {
 describe('approval store', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as Window & {
+    const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as unknown as Window & {
       clawwork: {
         resolveExecApproval: ReturnType<typeof vi.fn>;
         updateSettings: ReturnType<typeof vi.fn>;
@@ -87,7 +87,7 @@ describe('approval store', () => {
   it('keeps pending approval visible when resolve fails', async () => {
     const { approvalStore } = await loadStores();
 
-    window.clawwork.resolveExecApproval.mockResolvedValueOnce({ ok: false, error: 'denied upstream' });
+    vi.mocked(window.clawwork.resolveExecApproval).mockResolvedValueOnce({ ok: false, error: 'denied upstream' });
 
     approvalStore.useApprovalStore.setState({
       pendingApprovals: [

--- a/packages/desktop/test/avatar-handlers.test.ts
+++ b/packages/desktop/test/avatar-handlers.test.ts
@@ -5,9 +5,9 @@ let protocolHandler: ((request: { url: string }) => Promise<Response>) | null = 
 
 const mkdirMock = vi.fn();
 const writeFileMock = vi.fn();
-const readdirMock = vi.fn<() => Promise<string[]>>(() => Promise.resolve([]));
+const readdirMock = vi.fn<(...args: unknown[]) => Promise<string[]>>(() => Promise.resolve([]));
 const unlinkMock = vi.fn();
-const netFetchMock = vi.fn(() => new Response('ok'));
+const netFetchMock = vi.fn<(...args: unknown[]) => Response>(() => new Response('ok'));
 const debugInfoMock = vi.fn();
 
 vi.mock('electron', () => ({

--- a/packages/desktop/test/conductor-catalog-fallback.test.tsx
+++ b/packages/desktop/test/conductor-catalog-fallback.test.tsx
@@ -192,7 +192,7 @@ describe('conductor initialization - catalog fallback', () => {
     expect(mocks.roomState.initConductor).toHaveBeenCalledTimes(1);
 
     // Verify the agentCatalogStr passed to initConductor contains the two worker agents.
-    const catalogArg = mocks.roomState.initConductor.mock.calls[0][3] as string;
+    const catalogArg = (mocks.roomState.initConductor.mock.calls[0] as unknown[])[3] as string;
     expect(catalogArg).toContain('worker-a');
     expect(catalogArg).toContain('worker-b');
     // Manager agent should be excluded (it equals task.agentId).
@@ -247,7 +247,7 @@ describe('conductor initialization - catalog fallback', () => {
     expect(mocks.roomState.initConductor).toHaveBeenCalledTimes(1);
 
     // When catalog IS loaded, agent names from the catalog should appear.
-    const catalogArg = mocks.roomState.initConductor.mock.calls[0][3] as string;
+    const catalogArg = (mocks.roomState.initConductor.mock.calls[0] as unknown[])[3] as string;
     expect(catalogArg).toContain('Worker A');
     expect(catalogArg).toContain('Worker B');
     // unrelated-agent is not in the team, should not appear.

--- a/packages/desktop/test/core-session-sync.test.ts
+++ b/packages/desktop/test/core-session-sync.test.ts
@@ -87,7 +87,7 @@ function createHarness(params: {
     },
     getTaskStore: () => taskStore,
     getMessageStore: () => messageStore,
-  });
+  } as unknown as Parameters<typeof createSessionSync>[0]);
 
   return { sessionSync, taskStore, messageStore, persisted };
 }

--- a/packages/desktop/test/gateway-dispatcher-subagent.test.ts
+++ b/packages/desktop/test/gateway-dispatcher-subagent.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createGatewayDispatcher } from '@clawwork/core';
-import type { GatewayDispatcherDeps } from '@clawwork/core';
-import type { GatewayEvent } from '@clawwork/core/ports/gateway-transport';
+import type { GatewayDispatcherDeps, GatewayEvent } from '@clawwork/core';
 
 type EventListener = (data: GatewayEvent) => void;
 
 function createHarness(
   overrides?: Partial<{
-    tasks: GatewayDispatcherDeps extends { getTaskStore: () => infer T } ? ReturnType<() => T>['tasks'] : never;
+    tasks: ReturnType<GatewayDispatcherDeps['getTaskStore']>['tasks'];
     lookupTaskIdBySubagentKey: (key: string) => string | undefined;
   }>,
 ) {
@@ -63,7 +62,7 @@ function createHarness(
       tasks,
       updateTaskTitle: vi.fn(),
     }),
-    getMessageStore: () => messageStore,
+    getMessageStore: () => messageStore as unknown as ReturnType<GatewayDispatcherDeps['getMessageStore']>,
     getActiveTaskId: () => null,
     markUnread: vi.fn(),
     setGatewayStatusByGateway: vi.fn(),

--- a/packages/desktop/test/gateway-settings-flow.test.tsx
+++ b/packages/desktop/test/gateway-settings-flow.test.tsx
@@ -70,14 +70,14 @@ describe('gateway settings flow', () => {
       defaultGatewayId: null,
       gatewayInfoMap: {},
     });
-    (globalThis.window as Window & typeof globalThis & { clawwork: Record<string, unknown> }).clawwork = {
+    (globalThis.window as unknown as Window & typeof globalThis & { clawwork: Record<string, unknown> }).clawwork = {
       getSettings: vi.fn().mockResolvedValue({ gateways: [], defaultGatewayId: null }),
       addGateway: vi.fn().mockResolvedValue({ ok: true }),
       updateGateway: vi.fn().mockResolvedValue({ ok: true }),
       removeGateway: vi.fn().mockResolvedValue({ ok: true }),
       setDefaultGateway: vi.fn().mockResolvedValue({ ok: true }),
       testGateway: vi.fn().mockResolvedValue({ ok: true }),
-    };
+    } as unknown as Window['clawwork'] & Record<string, unknown>;
   });
 
   afterEach(() => {

--- a/packages/desktop/test/message-store.test.ts
+++ b/packages/desktop/test/message-store.test.ts
@@ -9,7 +9,7 @@ async function loadStore() {
 describe('message store tool call persistence', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as Window & {
+    const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as unknown as Window & {
       clawwork: {
         persistMessage: ReturnType<typeof vi.fn>;
       };

--- a/packages/desktop/test/session-sync.test.ts
+++ b/packages/desktop/test/session-sync.test.ts
@@ -1,4 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+type MockedApi = {
+  syncSessions: Mock;
+  chatHistory: Mock;
+  persistTask: Mock;
+  persistTaskUpdate: Mock;
+  loadMessages: Mock;
+  loadTasks: Mock;
+  persistMessage: Mock;
+  getDeviceId: Mock;
+};
+
+let mockApi: MockedApi;
 
 function createDeferred<T>(): {
   promise: Promise<T>;
@@ -24,19 +37,7 @@ async function loadModules() {
 describe('session sync startup flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as Window & {
-      clawwork: {
-        syncSessions: ReturnType<typeof vi.fn>;
-        chatHistory: ReturnType<typeof vi.fn>;
-        persistTask: ReturnType<typeof vi.fn>;
-        persistTaskUpdate: ReturnType<typeof vi.fn>;
-        loadMessages: ReturnType<typeof vi.fn>;
-        loadTasks: ReturnType<typeof vi.fn>;
-        persistMessage: ReturnType<typeof vi.fn>;
-        getDeviceId: ReturnType<typeof vi.fn>;
-      };
-    };
-    windowWithClawwork.clawwork = {
+    mockApi = {
       syncSessions: vi.fn(),
       chatHistory: vi.fn(),
       persistTask: vi.fn().mockResolvedValue({ ok: true }),
@@ -46,6 +47,7 @@ describe('session sync startup flow', () => {
       persistMessage: vi.fn().mockResolvedValue({ ok: true }),
       getDeviceId: vi.fn().mockResolvedValue('device-1'),
     };
+    (globalThis.window ??= {} as typeof globalThis.window).clawwork = mockApi as unknown as Window['clawwork'];
   });
 
   it('filters gateway-injected model values from discovered session metadata', async () => {
@@ -59,7 +61,7 @@ describe('session sync startup flow', () => {
       highlightedMessageId: null,
     });
 
-    window.clawwork.syncSessions.mockResolvedValue({
+    mockApi.syncSessions.mockResolvedValue({
       ok: true,
       discovered: [
         {
@@ -86,7 +88,7 @@ describe('session sync startup flow', () => {
     expect(task).toBeTruthy();
     expect(task.model).toBeUndefined();
     expect(task.modelProvider).toBe('openclaw');
-    expect(window.clawwork.persistTaskUpdate).toHaveBeenCalledWith(
+    expect(mockApi.persistTaskUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'task-1',
         model: undefined,
@@ -134,9 +136,9 @@ describe('session sync startup flow', () => {
     };
     const loadMessagesDeferred = createDeferred<{ ok: true; rows: (typeof existingRow)[] }>();
 
-    window.clawwork.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
-    window.clawwork.loadMessages.mockReturnValue(loadMessagesDeferred.promise);
-    window.clawwork.syncSessions.mockResolvedValue({
+    mockApi.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
+    mockApi.loadMessages.mockReturnValue(loadMessagesDeferred.promise);
+    mockApi.syncSessions.mockResolvedValue({
       ok: true,
       discovered: [
         {
@@ -173,7 +175,7 @@ describe('session sync startup flow', () => {
 
     await Promise.all([hydratePromise, syncPromise]);
 
-    expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
+    expect(mockApi.persistMessage).not.toHaveBeenCalled();
     expect(messageStore.useMessageStore.getState().messagesByTask['task-1']).toEqual([
       expect.objectContaining({
         id: 'local-msg-1',
@@ -212,8 +214,8 @@ describe('session sync startup flow', () => {
       artifactDir: 'tasks/task-dup',
       gatewayId: 'gw-1',
     };
-    window.clawwork.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
-    window.clawwork.loadMessages.mockResolvedValue({
+    mockApi.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
+    mockApi.loadMessages.mockResolvedValue({
       ok: true,
       rows: [
         { id: 'u1', taskId: 'task-dup', role: 'user', content: 'Hello', timestamp: '2026-03-16T10:00:00.123Z' },
@@ -226,7 +228,7 @@ describe('session sync startup flow', () => {
         },
       ],
     });
-    window.clawwork.syncSessions.mockResolvedValue({
+    mockApi.syncSessions.mockResolvedValue({
       ok: true,
       discovered: [
         {
@@ -250,7 +252,7 @@ describe('session sync startup flow', () => {
     expect(msgs).toHaveLength(2);
     expect(msgs[0].content).toBe('Hello');
     expect(msgs[1].content).toBe('Hi there!');
-    expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
+    expect(mockApi.persistMessage).not.toHaveBeenCalled();
   });
 
   it('syncs only new assistant messages for existing tasks (single-writer)', async () => {
@@ -282,12 +284,12 @@ describe('session sync startup flow', () => {
       artifactDir: 'tasks/task-legit',
       gatewayId: 'gw-1',
     };
-    window.clawwork.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
-    window.clawwork.loadMessages.mockResolvedValue({
+    mockApi.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
+    mockApi.loadMessages.mockResolvedValue({
       ok: true,
       rows: [{ id: 'u1', taskId: 'task-legit', role: 'user', content: 'Hello', timestamp: '2026-03-16T10:00:00.000Z' }],
     });
-    window.clawwork.syncSessions.mockResolvedValue({
+    mockApi.syncSessions.mockResolvedValue({
       ok: true,
       discovered: [
         {
@@ -344,8 +346,8 @@ describe('session sync startup flow', () => {
       gatewayId: 'gw-1',
     };
 
-    window.clawwork.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
-    window.clawwork.loadMessages.mockResolvedValue({
+    mockApi.loadTasks.mockResolvedValue({ ok: true, rows: [taskRow] });
+    mockApi.loadMessages.mockResolvedValue({
       ok: true,
       rows: [
         {
@@ -357,7 +359,7 @@ describe('session sync startup flow', () => {
         },
       ],
     });
-    window.clawwork.syncSessions.mockResolvedValue({
+    mockApi.syncSessions.mockResolvedValue({
       ok: true,
       discovered: [
         {
@@ -483,7 +485,7 @@ describe('session sync startup flow', () => {
       highlightedMessageId: null,
     });
 
-    window.clawwork.chatHistory.mockResolvedValue({
+    mockApi.chatHistory.mockResolvedValue({
       ok: true,
       result: {
         messages: [
@@ -538,7 +540,7 @@ describe('session sync startup flow', () => {
       expect.objectContaining({ id: 'exec-1', status: 'done', result: 'fetch url' }),
       expect.objectContaining({ id: 'read-1', status: 'error', result: 'from memory/2026-03-23.md' }),
     ]);
-    expect(window.clawwork.persistMessage).toHaveBeenCalledTimes(1);
+    expect(mockApi.persistMessage).toHaveBeenCalledTimes(1);
   });
 
   it('prefers terminal tool status from active turn over stale running canonical tool calls during promote', async () => {
@@ -659,7 +661,7 @@ describe('session sync startup flow', () => {
       highlightedMessageId: null,
     });
 
-    window.clawwork.chatHistory.mockResolvedValue({
+    mockApi.chatHistory.mockResolvedValue({
       ok: true,
       result: {
         messages: [
@@ -682,7 +684,7 @@ describe('session sync startup flow', () => {
 
     await sessionSync.syncSessionMessages('task-sync-persist');
 
-    expect(window.clawwork.persistMessage).toHaveBeenCalledWith(
+    expect(mockApi.persistMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         taskId: 'task-sync-persist',
         role: 'assistant',
@@ -702,7 +704,7 @@ describe('session sync startup flow', () => {
       highlightedMessageId: null,
     });
 
-    window.clawwork.loadTasks.mockResolvedValue({
+    mockApi.loadTasks.mockResolvedValue({
       ok: true,
       rows: [
         {
@@ -725,15 +727,15 @@ describe('session sync startup flow', () => {
         },
       ],
     });
-    window.clawwork.loadMessages.mockResolvedValue({ ok: true, rows: [] });
-    window.clawwork.syncSessions.mockResolvedValue({ ok: true, discovered: [] });
+    mockApi.loadMessages.mockResolvedValue({ ok: true, rows: [] });
+    mockApi.syncSessions.mockResolvedValue({ ok: true, discovered: [] });
 
     await sessionSync.syncFromGateway();
     await sessionSync.syncFromGateway();
 
-    expect(window.clawwork.loadTasks).toHaveBeenCalledTimes(1);
-    expect(window.clawwork.loadMessages).toHaveBeenCalledTimes(1);
-    expect(window.clawwork.syncSessions).toHaveBeenCalledTimes(2);
+    expect(mockApi.loadTasks).toHaveBeenCalledTimes(1);
+    expect(mockApi.loadMessages).toHaveBeenCalledTimes(1);
+    expect(mockApi.syncSessions).toHaveBeenCalledTimes(2);
   });
 
   it('hydrates persisted tool calls from local storage', async () => {
@@ -747,7 +749,7 @@ describe('session sync startup flow', () => {
       highlightedMessageId: null,
     });
 
-    window.clawwork.loadTasks.mockResolvedValue({
+    mockApi.loadTasks.mockResolvedValue({
       ok: true,
       rows: [
         {
@@ -770,7 +772,7 @@ describe('session sync startup flow', () => {
         },
       ],
     });
-    window.clawwork.loadMessages.mockResolvedValue({
+    mockApi.loadMessages.mockResolvedValue({
       ok: true,
       rows: [
         {
@@ -813,7 +815,7 @@ describe('session sync startup flow', () => {
       highlightedMessageId: null,
     });
 
-    window.clawwork.syncSessions.mockResolvedValue({
+    mockApi.syncSessions.mockResolvedValue({
       ok: true,
       discovered: [
         {
@@ -853,7 +855,7 @@ describe('session sync startup flow', () => {
 
     await sessionSync.syncFromGateway();
 
-    expect(window.clawwork.persistMessage).toHaveBeenCalledWith(
+    expect(mockApi.persistMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         taskId: 'task-persist-tools',
         role: 'assistant',

--- a/packages/desktop/test/settings-ui-regressions.test.tsx
+++ b/packages/desktop/test/settings-ui-regressions.test.tsx
@@ -88,7 +88,7 @@ describe('settings UI regressions', () => {
       })),
     });
 
-    (globalThis.window as Window & typeof globalThis & { clawwork: Record<string, unknown> }).clawwork = {
+    (globalThis.window as unknown as Window & typeof globalThis & { clawwork: Record<string, unknown> }).clawwork = {
       getSettings: vi.fn().mockResolvedValue(null),
       updateSettings: vi.fn().mockResolvedValue({ ok: true, config: {} }),
       getQuickLaunchConfig: vi.fn().mockResolvedValue({ enabled: false, shortcut: 'Alt+Space', sendShortcut: 'enter' }),
@@ -99,7 +99,7 @@ describe('settings UI regressions', () => {
       addGateway: vi.fn().mockResolvedValue({ ok: true }),
       removeGateway: vi.fn().mockResolvedValue({ ok: true }),
       setDefaultGateway: vi.fn().mockResolvedValue({ ok: true }),
-    };
+    } as unknown as Window['clawwork'] & Record<string, unknown>;
   });
 
   afterEach(() => {

--- a/packages/desktop/test/theme-provider.test.tsx
+++ b/packages/desktop/test/theme-provider.test.tsx
@@ -58,10 +58,10 @@ describe('theme provider', () => {
     getSettingsMock = vi.fn().mockResolvedValue({});
     updateSettingsMock = vi.fn().mockResolvedValue({ ok: true, config: {} });
 
-    (globalThis.window as Window & typeof globalThis & { clawwork: Record<string, unknown> }).clawwork = {
+    (globalThis.window as unknown as Window & typeof globalThis & { clawwork: Record<string, unknown> }).clawwork = {
       getSettings: getSettingsMock,
       updateSettings: updateSettingsMock,
-    };
+    } as unknown as Window['clawwork'] & Record<string, unknown>;
   });
 
   afterEach(() => {

--- a/packages/desktop/tsconfig.test.json
+++ b/packages/desktop/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/pwa/test/gateway-adapter.test.ts
+++ b/packages/pwa/test/gateway-adapter.test.ts
@@ -315,7 +315,7 @@ describe('createBrowserGatewayTransport', () => {
 
   describe('syncSessions', () => {
     it('continues past a failed client and returns discovered from others', async () => {
-      mockClient.listSessions.mockRejectedValue(new Error('sync failed'));
+      vi.mocked(mockClient.listSessions).mockRejectedValue(new Error('sync failed'));
       const { transport } = createBrowserGatewayTransport(getClients, getClient, getDeviceId);
 
       const result = await transport.syncSessions();

--- a/packages/pwa/tsconfig.test.json
+++ b/packages/pwa/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/shared/tsconfig.test.json
+++ b/packages/shared/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Why

Each package's `tsconfig.json` had `include: ["src"]` only — `packages/*/test/` was excluded from `tsc`. Vitest runs tests via esbuild without strict type checking, so type bugs in test code were silently ignored.

Local probe surfaced **40 latent type errors** across 10 desktop test files plus 1 in pwa. None were runtime bugs, but they hid behind 'tests pass' green checkmarks.

## What

| Change | Lines |
|---|---|
| 4× `tsconfig.test.json` (shared/core/desktop/pwa) — extends each package's tsconfig and adds `test` to include | +36 |
| `package.json` — new `typecheck:tests` script + wired into root `pnpm check` | +2/-1 |
| `pr-check.yml` — 4× new `Type check {pkg} tests` steps gated by existing `test_{pkg}` flags | +16 |
| 10× desktop test files + 1× pwa test file — fix 40 type errors | +64/-63 |

For `shared`/`core` (which use `composite: true` + `rootDir: ./src`) the test config also disables composite and broadens rootDir so test files are reachable.

## Fix patterns applied

- **session-sync.test.ts (23 errors)** — lifted typed `mockApi` to module scope; replaced 30 `window.clawwork.X` access sites with `mockApi.X`. Tests no longer need to roundtrip through the global ambient `Window` declaration.
- **3× partial-mock files (3 errors)** — partial mock literals cast as `as unknown as Window['clawwork'] & Record<string, unknown>` to satisfy declared `ClawWorkAPI` shape.
- **3× window cast files (5 errors)** — added `as unknown as` to escape the source/target overlap check.
- **conductor-catalog (4 errors)** — `mock.calls[0][3]` cast through `unknown[]` because the mock signature is zero-arg by inference.
- **gateway-dispatcher-subagent (3 errors)** — `GatewayEvent` import switched to public barrel (already re-exported there); `infer T` rewritten as `ReturnType<…>['tasks']` to avoid TS2536.
- **avatar-handlers (2 errors)** — mock signatures typed as variadic `(...args: unknown[])` to satisfy spread-arg constraint.
- **approval-store, message-store, pwa gateway-adapter (3 errors)** — `vi.mocked()` wrap on `.mockResolvedValue` / `.mockRejectedValueOnce` calls.

## Verification

- `pnpm typecheck:tests` exit 0 across all 4 packages
- `pnpm check` (full local gate) exit 0
- Test counts unchanged: shared 12 + core 73 + desktop 237 + pwa 61 = **383 tests still pass**
- `actionlint` clean on `pr-check.yml`

## Considered and deferred

- 3 partial-mock files keep the inline cast pattern instead of lifting `mockApi` to module scope (which session-sync uses). Each has only 1–2 mock access sites — the lift's payoff doesn't justify the structural change. Revisit if those files grow.