### PR TITLE
[Build] Expand check-architecture from 1 rule to 4

### DIFF
--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1,68 +1,188 @@
 import { readdirSync, readFileSync } from 'node:fs';
+import { builtinModules } from 'node:module';
 import path from 'node:path';
 
 const root = process.cwd();
 const violations = [];
 
-function walk(relativeDir) {
+function walk(relativeDir, predicate = () => true) {
   const absoluteDir = path.join(root, relativeDir);
-  const entries = readdirSync(absoluteDir, { withFileTypes: true });
-  const files = [];
-
+  let entries;
+  try {
+    entries = readdirSync(absoluteDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
   for (const entry of entries) {
-    const nextRelativePath = path.posix.join(relativeDir, entry.name);
+    const next = path.posix.join(relativeDir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...walk(nextRelativePath));
+      out.push(...walk(next, predicate));
       continue;
     }
-    files.push(nextRelativePath);
+    if (predicate(next)) out.push(next);
   }
-
-  return files;
+  return out;
 }
 
-function getLineAndColumn(content, index) {
+function getLineCol(content, index) {
   const before = content.slice(0, index);
   const lines = before.split('\n');
   return { line: lines.length, column: lines.at(-1).length + 1 };
 }
 
-function addViolation(filePath, content, index, message, match) {
-  const { line, column } = getLineAndColumn(content, index);
-  violations.push({ filePath, line, column, message, match });
+function record(rule, filePath, content, rawMatch, message, match) {
+  const offset = rawMatch[0].startsWith('\n') ? 1 : 0;
+  const { line, column } = getLineCol(content, rawMatch.index + offset);
+  violations.push({ rule, filePath, line, column, message, match });
 }
 
-function scanFile(filePath, regex, message) {
-  const absolutePath = path.join(root, filePath);
-  const content = readFileSync(absolutePath, 'utf8');
-  const matches = content.matchAll(regex);
+const isCodeFile = (p) => /\.(ts|tsx|mts|cts)$/.test(p);
 
-  for (const match of matches) {
-    addViolation(filePath, content, match.index, message, match[0]);
+const importRE = /(?:^|\n)\s*(?:import|export)\s+(?:type\s+)?(?:[^'"`]*?\sfrom\s+)?['"]([^'"`]+)['"]/g;
+
+function ruleSessionKey() {
+  const RULE = 'session-key';
+  const files = [
+    ...walk('packages/shared/src', isCodeFile),
+    ...walk('packages/core/src', isCodeFile),
+    ...walk('packages/desktop/src', isCodeFile),
+    ...walk('packages/pwa/src', isCodeFile),
+  ].filter((p) => p !== 'packages/shared/src/constants.ts');
+
+  for (const filePath of files) {
+    const content = readFileSync(path.join(root, filePath), 'utf8');
+    for (const m of content.matchAll(/clawwork:task:/g)) {
+      record(RULE, filePath, content, m, 'Construct session keys via buildSessionKey() in @clawwork/shared.', m[0]);
+    }
   }
 }
 
-const sessionKeySourceFiles = [
-  ...walk('packages/shared/src').filter((filePath) => filePath.endsWith('.ts')),
-  ...walk('packages/core/src').filter((filePath) => filePath.endsWith('.ts')),
-  ...walk('packages/desktop/src').filter((filePath) => /\.(ts|tsx)$/.test(filePath)),
-].filter((filePath) => filePath !== 'packages/shared/src/constants.ts');
+const NODE_BUILTINS = new Set(builtinModules);
 
-for (const filePath of sessionKeySourceFiles) {
-  scanFile(
-    filePath,
-    /clawwork:task:/g,
-    'Do not construct raw session keys outside buildSessionKey() in @clawwork/shared.',
-  );
+function ruleRendererBoundary() {
+  const RULE = 'renderer-boundary';
+  const files = walk('packages/desktop/src/renderer', isCodeFile);
+  for (const filePath of files) {
+    const content = readFileSync(path.join(root, filePath), 'utf8');
+    for (const m of content.matchAll(importRE)) {
+      const spec = m[1];
+      if (spec === 'electron' || spec.startsWith('electron/')) {
+        record(RULE, filePath, content, m, 'Renderer must not import "electron" — use the preload bridge.', spec);
+        continue;
+      }
+      const bare = spec.replace(/^node:/, '');
+      if (spec.startsWith('node:') || NODE_BUILTINS.has(bare)) {
+        record(RULE, filePath, content, m, `Renderer must not import Node builtin "${spec}".`, spec);
+        continue;
+      }
+      if (spec.startsWith('../main/') || /(?:\.\.\/)+main(?:\/|$)/.test(spec)) {
+        record(RULE, filePath, content, m, 'Renderer must not import from main process — use IPC.', spec);
+        continue;
+      }
+      if (spec.startsWith('../preload/') || /(?:\.\.\/)+preload(?:\/|$)/.test(spec)) {
+        record(
+          RULE,
+          filePath,
+          content,
+          m,
+          'Renderer must not import preload directly — use window.clawwork API.',
+          spec,
+        );
+      }
+    }
+  }
 }
+
+const FORBIDDEN_DEPS = {
+  'packages/shared/src': ['@clawwork/core', '@clawwork/desktop', '@clawwork/pwa'],
+  'packages/core/src': ['@clawwork/desktop', '@clawwork/pwa'],
+};
+
+function ruleDepDirection() {
+  const RULE = 'dep-direction';
+  for (const [pkgDir, forbidden] of Object.entries(FORBIDDEN_DEPS)) {
+    const pkgName = pkgDir.split('/')[1];
+    const files = walk(pkgDir, isCodeFile);
+    for (const filePath of files) {
+      const content = readFileSync(path.join(root, filePath), 'utf8');
+      for (const m of content.matchAll(importRE)) {
+        const spec = m[1];
+        for (const f of forbidden) {
+          if (spec === f || spec.startsWith(f + '/')) {
+            record(RULE, filePath, content, m, `Forbidden dependency: @clawwork/${pkgName} cannot import ${f}.`, spec);
+          }
+        }
+      }
+    }
+  }
+}
+
+function ruleCrossPackageRelative() {
+  const RULE = 'cross-package-relative';
+  const files = [
+    ...walk('packages/shared/src', isCodeFile),
+    ...walk('packages/core/src', isCodeFile),
+    ...walk('packages/desktop/src', isCodeFile),
+    ...walk('packages/pwa/src', isCodeFile),
+  ];
+  for (const filePath of files) {
+    const content = readFileSync(path.join(root, filePath), 'utf8');
+    const pkgMatch = filePath.match(/^(packages\/[^/]+)\//);
+    if (!pkgMatch) continue;
+    const sourcePkgRoot = path.join(root, pkgMatch[1]);
+
+    for (const m of content.matchAll(importRE)) {
+      const spec = m[1];
+      if (!spec.startsWith('.')) continue;
+      const fromAbs = path.dirname(path.join(root, filePath));
+      const targetAbs = path.resolve(fromAbs, spec);
+      const relToPkg = path.relative(sourcePkgRoot, targetAbs);
+      if (!relToPkg.startsWith('..')) continue;
+
+      const otherPkg = path
+        .relative(root, targetAbs)
+        .replace(/\\/g, '/')
+        .match(/^packages\/([^/]+)/);
+      if (otherPkg) {
+        record(
+          RULE,
+          filePath,
+          content,
+          m,
+          `Cross-package relative import lands in packages/${otherPkg[1]}/. Use @clawwork/${otherPkg[1]} instead.`,
+          spec,
+        );
+      }
+    }
+  }
+}
+
+const rules = [
+  { name: 'session-key', run: ruleSessionKey },
+  { name: 'renderer-boundary', run: ruleRendererBoundary },
+  { name: 'dep-direction', run: ruleDepDirection },
+  { name: 'cross-package-relative', run: ruleCrossPackageRelative },
+];
+
+for (const r of rules) r.run();
 
 if (violations.length > 0) {
   console.error('Architecture guardrail violations found:\n');
-  for (const violation of violations) {
-    console.error(`- ${violation.filePath}:${violation.line}:${violation.column} ${violation.message}`);
-    console.error(`  ${violation.match}`);
+  const byRule = new Map();
+  for (const v of violations) {
+    if (!byRule.has(v.rule)) byRule.set(v.rule, []);
+    byRule.get(v.rule).push(v);
+  }
+  for (const [rule, list] of byRule) {
+    console.error(`[${rule}] (${list.length})`);
+    for (const v of list) {
+      console.error(`  ${v.filePath}:${v.line}:${v.column}  ${v.message}`);
+      console.error(`    ${v.match}`);
+    }
+    console.error();
   }
   process.exit(1);
 }
 
-console.log('Architecture guardrails passed.');
+console.log(`Architecture guardrails passed (${rules.length} rules, 0 violations).`);


### PR DESCRIPTION
## Why

`scripts/check-architecture.mjs` was 68 lines enforcing **only 1 of 8** [HIGH] invariants in [.claude/rules/architecture.md](.claude/rules/architecture.md): the no-raw-session-key rule. The other 7 relied on review discipline, and 'Architecture guardrails passed' gave false confidence.

## What

Refactor to a rule registry (single file, 4 rule functions) + add 3 new enforced invariants. Codebase passes all 4 with **zero violations** today — this is a pure 'lock the door' change.

| # | Rule | What it catches |
|---|---|---|
| 1 | `session-key` (existing) | raw `clawwork:task:` literals outside the canonical `buildSessionKey()` site |
| 2 | `renderer-boundary` (new) | `packages/desktop/src/renderer/**` importing `electron`, `node:*` / node builtins, `../main/`, or `../preload/` |
| 3 | `dep-direction` (new) | `shared` importing `@clawwork/core`/`desktop`/`pwa`; `core` importing `@clawwork/desktop`/`pwa` |
| 4 | `cross-package-relative` (new) | relative imports in `packages/*` resolving into a different `packages/*` dir (use `@clawwork/<pkg>` alias instead) |

## Verification

Verified rule correctness with a synthetic fixture suite at `/tmp/arch-probe/` covering **9 violation cases across all 4 rules**:

```
[session-key]            (1) — raw template literal in main/violator.ts
[renderer-boundary]      (4) — electron, node:fs/promises, fs, ../main/secret
[dep-direction]          (3) — shared→core, shared→desktop, core→desktop
[cross-package-relative] (1) — desktop relative path resolving to packages/shared/
```

All 9 caught with correct `file:line:col` reporting (fixed an off-by-one where the import-anchor regex matched the leading \\n of the previous line).

Real codebase: `pnpm check:architecture` → `Architecture guardrails passed (4 rules, 0 violations).` `pnpm check` exit 0.

## Output format

Now groups violations by rule for faster triage:

```
[renderer-boundary] (4)
  packages/desktop/src/renderer/v1.ts:1:1  Renderer must not import "electron" — ...
    electron
  ...
```

## Documented gaps

Three [HIGH] invariants from the doc are **not** in the rule set, deliberately:

- **forked-protocol-types** — detecting structural type forks across packages requires an AST pass over `@clawwork/shared` exports + diff against desktop redeclarations. High false-positive risk; deferred.
- **secrets-in-client-code** — out of scope for in-tree script. Will be a separate PR adding [`gitleaks/gitleaks-action`](https://github.com/gitleaks/gitleaks-action) to `pr-check.yml`.
- **task-isolation-via-global-state** — too semantic. Would need project-specific heuristics that drift over time.

## Considered and deferred

- `scripts/check-architecture.mjs` [BOT-SCOPE]: no permanent test fixtures committed for the rule registry. Verified rules with `/tmp` synthetic fixtures locally; permanent test infra would require a new test runner setup for shell scripts. Out of scope for this PR — should land as its own refactor when rule #5+ raises regression risk.