### PR TITLE
[Feat] Wire Gateway commands.list RPC into slash menu

### DIFF
--- a/packages/core/src/ports/gateway-transport.ts
+++ b/packages/core/src/ports/gateway-transport.ts
@@ -1,4 +1,4 @@
-import type { IpcResult } from '@clawwork/shared';
+import type { CommandsListParams, IpcResult } from '@clawwork/shared';
 
 export interface GatewayEvent {
   event: string;
@@ -84,6 +84,7 @@ export interface GatewayTransportPort {
   syncSessions: () => Promise<SyncResult>;
   listGateways: () => Promise<GatewayListItem[]>;
   listModels: (gatewayId: string) => Promise<IpcResult>;
+  listCommands: (gatewayId: string, params?: CommandsListParams) => Promise<IpcResult>;
   listAgents: (gatewayId: string) => Promise<IpcResult>;
   getToolsCatalog: (gatewayId: string, agentId?: string) => Promise<IpcResult>;
   getSkillsStatus: (gatewayId: string, agentId?: string) => Promise<IpcResult>;

--- a/packages/core/src/services/gateway-dispatcher.ts
+++ b/packages/core/src/services/gateway-dispatcher.ts
@@ -4,6 +4,8 @@ import type {
   ToolCallStatus,
   ModelListResponse,
   AgentListResponse,
+  CommandEntry,
+  CommandsListResponse,
   SkillStatusReport,
   ToolsCatalog,
 } from '@clawwork/shared';
@@ -115,6 +117,7 @@ export interface GatewayDispatcherDeps {
   setAgentCatalogForGateway: (gatewayId: string, agents: unknown[], defaultId: string) => void;
   setToolsCatalogForGateway: (gatewayId: string, catalog: ToolsCatalog) => void;
   setSkillsStatusForGateway: (gatewayId: string, report: SkillStatusReport) => void;
+  setCommandCatalogForGateway: (gatewayId: string, commands: CommandEntry[]) => void;
 
   onPerformerCandidate?: (taskId: string, sessionKey: string, gatewayId: string) => void;
   lookupTaskIdBySubagentKey?: (subagentKey: string) => string | undefined;
@@ -590,11 +593,12 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
 
   async function fetchCatalogs(gatewayId: string): Promise<void> {
     try {
-      const [modelsRes, agentsRes, toolsRes, skillsRes] = await Promise.all([
+      const [modelsRes, agentsRes, toolsRes, skillsRes, commandsRes] = await Promise.all([
         deps.gateway.listModels(gatewayId),
         deps.gateway.listAgents(gatewayId),
         deps.gateway.getToolsCatalog(gatewayId),
         deps.gateway.getSkillsStatus(gatewayId),
+        deps.gateway.listCommands(gatewayId, { scope: 'text', includeArgs: true }),
       ]);
       if (modelsRes.ok && modelsRes.result) {
         const data = modelsRes.result as unknown as ModelListResponse;
@@ -612,8 +616,14 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
         const data = skillsRes.result as unknown as SkillStatusReport;
         if (Array.isArray(data.skills)) deps.setSkillsStatusForGateway(gatewayId, data);
       }
+      if (commandsRes.ok && commandsRes.result) {
+        const data = commandsRes.result as unknown as CommandsListResponse;
+        if (Array.isArray(data.commands)) {
+          deps.setCommandCatalogForGateway(gatewayId, data.commands);
+        }
+      }
     } catch (err) {
-      console.warn('[catalogs] Failed to fetch model/agent/tools/skills catalogs for gateway', gatewayId, err);
+      console.warn('[catalogs] Failed to fetch catalogs for gateway', gatewayId, err);
     }
   }
 

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -1,5 +1,5 @@
 import { createStore } from 'zustand/vanilla';
-import type { AgentInfo, ModelCatalogEntry, SkillStatusReport, ToolsCatalog } from '@clawwork/shared';
+import type { AgentInfo, CommandEntry, ModelCatalogEntry, SkillStatusReport, ToolsCatalog } from '@clawwork/shared';
 
 export type MainView = 'chat' | 'files' | 'archived' | 'cron' | 'teams' | 'dashboard';
 export type Theme = 'dark' | 'light' | 'auto';
@@ -85,6 +85,9 @@ export interface UiState {
 
   skillsStatusByGateway: Record<string, SkillStatusReport>;
   setSkillsStatusForGateway: (gatewayId: string, report: SkillStatusReport) => void;
+
+  commandCatalogByGateway: Record<string, CommandEntry[]>;
+  setCommandCatalogForGateway: (gatewayId: string, commands: CommandEntry[]) => void;
 
   sendShortcut: SendShortcut;
   setSendShortcut: (shortcut: SendShortcut) => void;
@@ -272,6 +275,15 @@ export function createUiStore(deps: UiStoreDeps) {
         skillsStatusByGateway: {
           ...s.skillsStatusByGateway,
           [gatewayId]: report,
+        },
+      })),
+
+    commandCatalogByGateway: {},
+    setCommandCatalogForGateway: (gatewayId, commands) =>
+      set((s) => ({
+        commandCatalogByGateway: {
+          ...s.commandCatalogByGateway,
+          [gatewayId]: commands,
         },
       })),
 

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -6,6 +6,7 @@ import { parseToolArgs } from '@clawwork/core';
 import type {
   ApprovalDecision,
   ChatAttachment,
+  CommandsListParams,
   ConfigPatchParams,
   ConfigSetParams,
   ExecApprovalResolveParams,
@@ -385,6 +386,23 @@ export function registerWsHandlers(): void {
     if (!gw?.isConnected) return { ok: false, error: 'gateway not connected' };
     try {
       const result = await gw.listModels();
+      return { ok: true, result };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };
+    }
+  });
+
+  ipcMain.handle('ws:commands-list', async (_event, payload: { gatewayId: string } & CommandsListParams) => {
+    const gw = getGatewayClient(payload.gatewayId);
+    if (!gw?.isConnected) return { ok: false, error: 'gateway not connected' };
+    const params: Record<string, unknown> = {
+      scope: payload.scope ?? 'text',
+      includeArgs: payload.includeArgs ?? true,
+    };
+    if (payload.agentId) params.agentId = payload.agentId;
+    if (payload.provider) params.provider = payload.provider;
+    try {
+      const result = await gw.listCommands(params);
       return { ok: true, result };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -591,6 +591,10 @@ export class GatewayClient {
     return this.sendReq('models.list', {});
   }
 
+  async listCommands(params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.sendReq('commands.list', params);
+  }
+
   async listAgents(): Promise<Record<string, unknown>> {
     return this.sendReq('agents.list', {});
   }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -1,6 +1,7 @@
 import type {
   IpcResult as SharedIpcResult,
   ChatAttachment as SharedChatAttachment,
+  CommandsListParams,
   Team,
   TeamHubRegistry,
   ApprovalDecision,
@@ -243,6 +244,7 @@ export interface ClawWorkAPI {
   abortChat: (gatewayId: string, sessionKey: string) => Promise<IpcResult>;
 
   listModels: (gatewayId: string) => Promise<IpcResult>;
+  listCommands: (gatewayId: string, params?: CommandsListParams) => Promise<IpcResult>;
   listAgents: (gatewayId: string) => Promise<IpcResult>;
   createAgent: (
     gatewayId: string,

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import type {
   ApprovalDecision,
+  CommandsListParams,
   CronJobCreate,
   CronJobPatch,
   CronListParams,
@@ -31,6 +32,8 @@ function buildApi(): ClawWorkAPI {
       ipcRenderer.invoke('ws:abort-chat', { gatewayId, sessionKey }),
     listGateways: () => ipcRenderer.invoke('ws:list-gateways'),
     listModels: (gatewayId: string) => ipcRenderer.invoke('ws:models-list', { gatewayId }),
+    listCommands: (gatewayId: string, params?: CommandsListParams) =>
+      ipcRenderer.invoke('ws:commands-list', { gatewayId, ...(params ?? {}) }),
     listAgents: (gatewayId: string) => ipcRenderer.invoke('ws:agents-list', { gatewayId }),
     createAgent: (gatewayId: string, params: { name: string; workspace: string; emoji?: string; avatar?: string }) =>
       ipcRenderer.invoke('ws:agents-create', { gatewayId, ...params }),

--- a/packages/desktop/src/renderer/components/ChatInput/useSlashAutocomplete.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useSlashAutocomplete.ts
@@ -1,12 +1,13 @@
-import { useState, useCallback, type RefObject } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef, type RefObject } from 'react';
 import { useTaskStore } from '../../stores/taskStore';
 import { useUiStore } from '../../stores/uiStore';
 import {
   filterSlashCommands,
-  parseSlashQuery,
-  getEnumOptions,
+  getChoiceOptions,
+  getCommandsForGateway,
   hasArgPicker,
-  type SlashCommand,
+  parseSlashQuery,
+  type SlashCommandView,
 } from '@/lib/slash-commands';
 import type { ArgOption } from '../SlashArgPicker';
 
@@ -17,14 +18,22 @@ interface UseSlashAutocompleteOpts {
 export function useSlashAutocomplete(opts: UseSlashAutocompleteOpts) {
   const { textareaRef } = opts;
 
+  const activeGatewayId = useTaskStore((s) => {
+    const id = s.activeTaskId;
+    const task = id ? s.tasks.find((t) => t.id === id) : undefined;
+    return task?.gatewayId ?? s.pendingNewTask?.gatewayId ?? null;
+  });
+  const commandCatalog = useUiStore((s) => (activeGatewayId ? s.commandCatalogByGateway[activeGatewayId] : undefined));
+  const allCommands = useMemo(() => getCommandsForGateway(commandCatalog), [commandCatalog]);
+
   const [slashMenuVisible, setSlashMenuVisible] = useState(false);
   const [slashQuery, setSlashQuery] = useState('');
   const [slashIndex, setSlashIndex] = useState(0);
-  const slashCommands = filterSlashCommands(slashQuery);
+  const slashCommands = useMemo(() => filterSlashCommands(slashQuery, allCommands), [slashQuery, allCommands]);
   const [dashboardOpen, setDashboardOpen] = useState(false);
 
   const [argPickerVisible, setArgPickerVisible] = useState(false);
-  const [argPickerCommand, setArgPickerCommand] = useState<SlashCommand | null>(null);
+  const [argPickerCommand, setArgPickerCommand] = useState<SlashCommandView | null>(null);
   const [argPickerOptions, setArgPickerOptions] = useState<ArgOption[]>([]);
   const [argPickerIndex, setArgPickerIndex] = useState(0);
 
@@ -41,7 +50,7 @@ export function useSlashAutocomplete(opts: UseSlashAutocompleteOpts) {
     }
   }, [textareaRef]);
 
-  const buildArgOptions = useCallback((cmd: SlashCommand): ArgOption[] => {
+  const buildArgOptions = useCallback((cmd: SlashCommandView): ArgOption[] => {
     if (cmd.pickerType === 'model') {
       const gwId =
         useTaskStore.getState().tasks.find((t) => t.id === useTaskStore.getState().activeTaskId)?.gatewayId ??
@@ -53,32 +62,18 @@ export function useSlashAutocomplete(opts: UseSlashAutocompleteOpts) {
         detail: m.provider,
       }));
     }
-    const enumOpts = getEnumOptions(cmd);
-    if (enumOpts) return enumOpts.map((v) => ({ value: v, label: v }));
+    const choices = getChoiceOptions(cmd);
+    if (choices) return choices.map((c) => ({ value: c.value, label: c.label }));
     return [];
   }, []);
 
   const commitSlashCommand = useCallback(
-    (cmd: SlashCommand) => {
+    (cmd: SlashCommandView) => {
       const ta = textareaRef.current;
       if (!ta) return;
       setSlashMenuVisible(false);
       setSlashQuery('');
       setSlashIndex(0);
-
-      if (hasArgPicker(cmd)) {
-        const newValue = `/${cmd.name} `;
-        ta.value = newValue;
-        ta.style.height = 'auto';
-        ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
-        ta.setSelectionRange(newValue.length, newValue.length);
-        ta.focus();
-        setArgPickerCommand(cmd);
-        setArgPickerOptions(buildArgOptions(cmd));
-        setArgPickerIndex(0);
-        setArgPickerVisible(true);
-        return;
-      }
 
       const newValue = `/${cmd.name} `;
       ta.value = newValue;
@@ -86,6 +81,13 @@ export function useSlashAutocomplete(opts: UseSlashAutocompleteOpts) {
       ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
       ta.setSelectionRange(newValue.length, newValue.length);
       ta.focus();
+
+      if (hasArgPicker(cmd)) {
+        setArgPickerCommand(cmd);
+        setArgPickerOptions(buildArgOptions(cmd));
+        setArgPickerIndex(0);
+        setArgPickerVisible(true);
+      }
     },
     [textareaRef, buildArgOptions],
   );
@@ -116,6 +118,40 @@ export function useSlashAutocomplete(opts: UseSlashAutocompleteOpts) {
     textareaRef.current?.focus();
   }, [textareaRef]);
 
+  const argPickerIndexRef = useRef(argPickerIndex);
+  argPickerIndexRef.current = argPickerIndex;
+  const argPickerOptionsRef = useRef(argPickerOptions);
+  argPickerOptionsRef.current = argPickerOptions;
+
+  useEffect(() => {
+    if (!argPickerVisible) return;
+    const raf = requestAnimationFrame(() => textareaRef.current?.focus());
+    const onKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (document.activeElement === textareaRef.current) return;
+      const opts = argPickerOptionsRef.current;
+      if (opts.length === 0) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setArgPickerIndex((i) => (i + 1) % opts.length);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setArgPickerIndex((i) => (i - 1 + opts.length) % opts.length);
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        const opt = opts[argPickerIndexRef.current];
+        if (opt) commitArgOption(opt);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        closeArgPicker();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [argPickerVisible, commitArgOption, closeArgPicker, textareaRef]);
+
   return {
     slashMenuVisible,
     setSlashMenuVisible,
@@ -123,6 +159,7 @@ export function useSlashAutocomplete(opts: UseSlashAutocompleteOpts) {
     slashIndex,
     setSlashIndex,
     slashCommands,
+    allCommands,
     dashboardOpen,
     setDashboardOpen,
     argPickerVisible,

--- a/packages/desktop/src/renderer/components/CommandSourceBadge.tsx
+++ b/packages/desktop/src/renderer/components/CommandSourceBadge.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+import { SOURCE_I18N_KEYS, type SlashCommandView } from '@/lib/slash-commands';
+
+interface CommandSourceBadgeProps {
+  source: SlashCommandView['source'];
+}
+
+export default function CommandSourceBadge({ source }: CommandSourceBadgeProps) {
+  const { t } = useTranslation();
+  if (source === 'native') return null;
+  const label = t(SOURCE_I18N_KEYS[source]);
+  return (
+    <span
+      className="type-meta shrink-0 rounded-sm border border-[var(--border-subtle)] px-1.5 py-0.5 text-[var(--text-muted)]"
+      title={label}
+    >
+      {label}
+    </span>
+  );
+}

--- a/packages/desktop/src/renderer/components/SlashCommandDashboard.tsx
+++ b/packages/desktop/src/renderer/components/SlashCommandDashboard.tsx
@@ -1,51 +1,99 @@
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Search } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
-import { groupCommandsByCategory, CATEGORY_I18N_KEYS, type SlashCommand } from '@/lib/slash-commands';
+import {
+  CATEGORY_I18N_KEYS,
+  filterSlashCommands,
+  getCommandsForGateway,
+  groupCommandsByCategory,
+  type SlashCommandView,
+} from '@/lib/slash-commands';
+import { useTaskStore } from '../stores/taskStore';
+import { useUiStore } from '../stores/uiStore';
+import CommandSourceBadge from './CommandSourceBadge';
 
 interface SlashCommandDashboardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSelectCommand?: (cmd: SlashCommand) => void;
+  onSelectCommand?: (cmd: SlashCommandView) => void;
 }
-
-const groups = groupCommandsByCategory();
 
 export default function SlashCommandDashboard({ open, onOpenChange, onSelectCommand }: SlashCommandDashboardProps) {
   const { t } = useTranslation();
+  const [query, setQuery] = useState('');
+
+  const activeGatewayId = useTaskStore((s) => {
+    const id = s.activeTaskId;
+    const task = id ? s.tasks.find((t) => t.id === id) : undefined;
+    return task?.gatewayId ?? s.pendingNewTask?.gatewayId ?? null;
+  });
+  const commandCatalog = useUiStore((s) => (activeGatewayId ? s.commandCatalogByGateway[activeGatewayId] : undefined));
+  const allCommands = useMemo(() => getCommandsForGateway(commandCatalog), [commandCatalog]);
+  const filtered = useMemo(() => filterSlashCommands(query.trim(), allCommands), [query, allCommands]);
+  const groups = useMemo(() => groupCommandsByCategory(filtered), [filtered]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setQuery('');
+        onOpenChange(next);
+      }}
+    >
       <DialogContent className="max-w-xl">
         <DialogHeader>
           <DialogTitle>{t('slashDashboard.title')}</DialogTitle>
           <DialogDescription>{t('slashDashboard.description')}</DialogDescription>
         </DialogHeader>
 
-        <div className="mt-4 space-y-5">
-          {groups.map(({ category, commands }) => (
-            <div key={category}>
-              <h3 className="type-meta mb-2 text-[var(--text-muted)]">{t(CATEGORY_I18N_KEYS[category])}</h3>
-              <div className="space-y-0.5">
-                {commands.map((cmd) => (
-                  <button
-                    key={cmd.name}
-                    type="button"
-                    className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-[var(--bg-hover)] transition-colors"
-                    onClick={() => {
-                      onSelectCommand?.(cmd);
-                      onOpenChange(false);
-                    }}
-                  >
-                    <span className="type-mono-data shrink-0 text-[var(--accent)]">/{cmd.name}</span>
-                    <span className="type-support flex-1 truncate text-[var(--text-secondary)]">{cmd.description}</span>
-                    {cmd.argHint && (
-                      <span className="type-mono-data shrink-0 text-[var(--text-muted)]">{cmd.argHint}</span>
-                    )}
-                  </button>
-                ))}
+        <div className="relative mt-2">
+          <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
+          <input
+            autoFocus
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('slashDashboard.searchPlaceholder')}
+            className="type-support w-full rounded-md border border-[var(--border-subtle)] bg-[var(--bg-input)] py-2 pr-3 pl-9 text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+          />
+        </div>
+
+        <div className="mt-4 h-96 overflow-y-auto pr-1">
+          {groups.length === 0 ? (
+            <p className="type-support flex h-full items-center justify-center text-[var(--text-muted)]">
+              {t('slashDashboard.empty')}
+            </p>
+          ) : null}
+          <div className="space-y-5">
+            {groups.map(({ category, commands }) => (
+              <div key={category}>
+                <h3 className="type-meta mb-2 text-[var(--text-muted)]">{t(CATEGORY_I18N_KEYS[category])}</h3>
+                <div className="space-y-0.5">
+                  {commands.map((cmd) => (
+                    <button
+                      key={cmd.name}
+                      type="button"
+                      className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-[var(--bg-hover)]"
+                      onClick={() => {
+                        onSelectCommand?.(cmd);
+                        onOpenChange(false);
+                      }}
+                    >
+                      <span className="type-mono-data shrink-0 text-[var(--accent)]">/{cmd.name}</span>
+                      <CommandSourceBadge source={cmd.source} />
+                      <span className="type-support flex-1 truncate text-[var(--text-secondary)]">
+                        {cmd.description}
+                      </span>
+                      {cmd.argHint && (
+                        <span className="type-mono-data shrink-0 text-[var(--text-muted)]">{cmd.argHint}</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/desktop/src/renderer/components/SlashCommandMenu.tsx
+++ b/packages/desktop/src/renderer/components/SlashCommandMenu.tsx
@@ -1,12 +1,13 @@
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { SlashCommand } from '@/lib/slash-commands';
+import { type SlashCommandView } from '@/lib/slash-commands';
+import CommandSourceBadge from './CommandSourceBadge';
 import PopoverListBase, { PopoverListItem } from './PopoverListBase';
 
 interface SlashCommandMenuProps {
-  commands: SlashCommand[];
+  commands: SlashCommandView[];
   selectedIndex: number;
-  onSelect: (command: SlashCommand) => void;
+  onSelect: (command: SlashCommandView) => void;
   onHoverIndex: (index: number) => void;
   onClose: () => void;
   className?: string;
@@ -41,6 +42,7 @@ export default function SlashCommandMenu({
           onSelect={() => onSelect(cmd)}
         >
           <span className="type-mono-data shrink-0 text-[var(--accent)]">/{cmd.name}</span>
+          <CommandSourceBadge source={cmd.source} />
           <span className="type-support truncate">{cmd.description}</span>
           {cmd.argHint && (
             <span className="type-mono-data ml-auto shrink-0 text-[var(--text-muted)]">{cmd.argHint}</span>

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcherSetup.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcherSetup.ts
@@ -102,6 +102,8 @@ function getDispatcher(): GatewayDispatcher {
         useUiStore.getState().setToolsCatalogForGateway(gatewayId, catalog),
       setSkillsStatusForGateway: (gatewayId, report) =>
         useUiStore.getState().setSkillsStatusForGateway(gatewayId, report),
+      setCommandCatalogForGateway: (gatewayId, commands) =>
+        useUiStore.getState().setCommandCatalogForGateway(gatewayId, commands),
 
       lookupTaskIdBySubagentKey: (key) => useRoomStore.getState().lookupTaskIdBySubagentKey(key),
       onPerformerCandidate: (taskId, sessionKey) => handlePerformerCandidate(taskId, sessionKey),

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -661,11 +661,19 @@
     "argOptions": "Optionen fuer /{{command}}"
   },
   "slashDashboard": {
-    "categoryAccess": "Zugriff & Sicherheit",
-    "categoryInfo": "Info & Hilfe",
-    "categoryModel": "Modell & Qualitaet",
+    "categoryDocks": "Docks",
+    "categoryManagement": "Zugriff & Verwaltung",
+    "categoryMedia": "Medien",
+    "categoryOptions": "Optionen & Qualität",
     "categorySession": "Sitzung & Agent",
+    "categoryStatus": "Status & Info",
+    "categoryTools": "Werkzeuge",
     "description": "Alle verfuegbaren Befehle fuer die aktuelle Sitzung",
+    "empty": "Keine passenden Befehle gefunden",
+    "searchPlaceholder": "Befehle suchen",
+    "sourceNative": "Nativ",
+    "sourcePlugin": "Plugin",
+    "sourceSkill": "Skill",
     "title": "Slash-Befehle",
     "tooltip": "Befehle"
   },

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -661,11 +661,19 @@
     "argOptions": "Options for /{{command}}"
   },
   "slashDashboard": {
-    "categoryAccess": "Access & Security",
-    "categoryInfo": "Info & Help",
-    "categoryModel": "Model & Quality",
+    "categoryDocks": "Docks",
+    "categoryManagement": "Access & Management",
+    "categoryMedia": "Media",
+    "categoryOptions": "Options & Quality",
     "categorySession": "Session & Agent",
+    "categoryStatus": "Status & Info",
+    "categoryTools": "Tools",
     "description": "All available commands for the current session",
+    "empty": "No commands match your search",
+    "searchPlaceholder": "Search commands",
+    "sourceNative": "Native",
+    "sourcePlugin": "Plugin",
+    "sourceSkill": "Skill",
     "title": "Slash Commands",
     "tooltip": "Commands"
   },

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -661,11 +661,19 @@
     "argOptions": "Opciones de /{{command}}"
   },
   "slashDashboard": {
-    "categoryAccess": "Acceso y seguridad",
-    "categoryInfo": "Información y ayuda",
-    "categoryModel": "Modelo y calidad",
+    "categoryDocks": "Docks",
+    "categoryManagement": "Acceso y gestión",
+    "categoryMedia": "Medios",
+    "categoryOptions": "Opciones y calidad",
     "categorySession": "Sesión y agente",
+    "categoryStatus": "Estado e información",
+    "categoryTools": "Herramientas",
     "description": "Todos los comandos disponibles para la sesión actual",
+    "empty": "Ningún comando coincide",
+    "searchPlaceholder": "Buscar comandos",
+    "sourceNative": "Nativo",
+    "sourcePlugin": "Plugin",
+    "sourceSkill": "Skill",
     "title": "Comandos slash",
     "tooltip": "Comandos"
   },

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -661,11 +661,19 @@
     "argOptions": "/{{command}} のオプション"
   },
   "slashDashboard": {
-    "categoryAccess": "アクセス & セキュリティ",
-    "categoryInfo": "情報 & ヘルプ",
-    "categoryModel": "モデル & 品質",
+    "categoryDocks": "Docks",
+    "categoryManagement": "権限 & 管理",
+    "categoryMedia": "メディア",
+    "categoryOptions": "オプション & 品質",
     "categorySession": "セッション & エージェント",
+    "categoryStatus": "ステータス & 情報",
+    "categoryTools": "ツール",
     "description": "現在のセッションで利用可能なすべてのコマンド",
+    "empty": "一致するコマンドがありません",
+    "searchPlaceholder": "コマンドを検索",
+    "sourceNative": "ネイティブ",
+    "sourcePlugin": "プラグイン",
+    "sourceSkill": "スキル",
     "title": "スラッシュコマンド",
     "tooltip": "コマンド"
   },

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -661,11 +661,19 @@
     "argOptions": "/{{command}} 옵션"
   },
   "slashDashboard": {
-    "categoryAccess": "접근 및 보안",
-    "categoryInfo": "정보 및 도움말",
-    "categoryModel": "모델 및 품질",
+    "categoryDocks": "Docks",
+    "categoryManagement": "권한 및 관리",
+    "categoryMedia": "미디어",
+    "categoryOptions": "옵션 및 품질",
     "categorySession": "세션 및 에이전트",
+    "categoryStatus": "상태 및 정보",
+    "categoryTools": "도구",
     "description": "현재 세션에서 사용 가능한 모든 명령어",
+    "empty": "일치하는 명령어가 없습니다",
+    "searchPlaceholder": "명령어 검색",
+    "sourceNative": "기본",
+    "sourcePlugin": "플러그인",
+    "sourceSkill": "스킬",
     "title": "슬래시 명령어",
     "tooltip": "명령어"
   },

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -661,11 +661,19 @@
     "argOptions": "Opções para /{{command}}"
   },
   "slashDashboard": {
-    "categoryAccess": "Acesso e Segurança",
-    "categoryInfo": "Info e Ajuda",
-    "categoryModel": "Modelo e Qualidade",
+    "categoryDocks": "Docks",
+    "categoryManagement": "Acesso e Gerenciamento",
+    "categoryMedia": "Mídia",
+    "categoryOptions": "Opções e Qualidade",
     "categorySession": "Sessão e Agente",
+    "categoryStatus": "Status e Informações",
+    "categoryTools": "Ferramentas",
     "description": "Todos os comandos disponíveis para a sessão atual",
+    "empty": "Nenhum comando corresponde",
+    "searchPlaceholder": "Buscar comandos",
+    "sourceNative": "Nativo",
+    "sourcePlugin": "Plugin",
+    "sourceSkill": "Skill",
     "title": "Comandos Slash",
     "tooltip": "Comandos"
   },

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -661,11 +661,19 @@
     "argOptions": "/{{command}} 的選項"
   },
   "slashDashboard": {
-    "categoryAccess": "存取與安全",
-    "categoryInfo": "資訊與說明",
-    "categoryModel": "模型與品質",
+    "categoryDocks": "Docks",
+    "categoryManagement": "權限與管理",
+    "categoryMedia": "媒體",
+    "categoryOptions": "選項與品質",
     "categorySession": "工作階段與代理",
+    "categoryStatus": "狀態與資訊",
+    "categoryTools": "工具",
     "description": "目前工作階段可用的所有指令",
+    "empty": "沒有符合的指令",
+    "searchPlaceholder": "搜尋指令",
+    "sourceNative": "原生",
+    "sourcePlugin": "外掛",
+    "sourceSkill": "Skill",
     "title": "斜線指令",
     "tooltip": "指令"
   },

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -661,11 +661,19 @@
     "argOptions": "/{{command}} 的可选项"
   },
   "slashDashboard": {
-    "categoryAccess": "权限与安全",
-    "categoryInfo": "信息与帮助",
-    "categoryModel": "模型与质量",
+    "categoryDocks": "Docks",
+    "categoryManagement": "权限与管理",
+    "categoryMedia": "媒体",
+    "categoryOptions": "选项与质量",
     "categorySession": "会话与 Agent",
+    "categoryStatus": "状态与信息",
+    "categoryTools": "工具",
     "description": "当前会话可用的全部命令",
+    "empty": "没有匹配的命令",
+    "searchPlaceholder": "搜索命令",
+    "sourceNative": "原生",
+    "sourcePlugin": "插件",
+    "sourceSkill": "Skill",
     "title": "斜杠命令",
     "tooltip": "命令面板"
   },

--- a/packages/desktop/src/renderer/lib/slash-commands.ts
+++ b/packages/desktop/src/renderer/lib/slash-commands.ts
@@ -1,89 +1,296 @@
-/**
- * Slash command definitions for ClawWork input autocomplete.
- *
- * Source: mirrors OpenClaw's native command surface.
- * Reference: ~/git/openclaw/src/tui/commands.ts (getSlashCommands)
- *            ~/git/openclaw/src/auto-reply/commands-registry.ts (NativeCommandSpec)
- *
- * PLACEHOLDER: In a future version, this list should be fetched dynamically from
- * the Gateway via a `commands.list` RPC (not yet exposed in the Gateway API).
- * When that RPC is available, extend `gateway-client.ts` with `listCommands()`,
- * add an IPC handler `ws:commands-list`, and replace the static list below with
- * a store that hydrates on gateway connect.
- */
+import type { CommandArg, CommandCategory, CommandEntry, CommandSource } from '@clawwork/shared';
 
-export type SlashCommandCategory = 'session' | 'model' | 'access' | 'info';
-export type SlashPickerType = 'enum' | 'model';
+export type SlashPickerType = 'model' | 'choices' | 'free';
 
-export interface SlashCommand {
+export interface SlashCommandView {
   name: string;
+  nativeName?: string;
   description: string;
+  aliases: string[];
+  category: CommandCategory;
+  source: CommandSource;
+  acceptsArgs: boolean;
+  args: CommandArg[];
+  pickerType: SlashPickerType;
   argHint?: string;
-  category?: SlashCommandCategory;
-  pickerType?: SlashPickerType;
 }
 
-/**
- * Static list of OpenClaw native slash commands supported in ClawWork sessions.
- * Derived from ~/git/openclaw/src/tui/commands.ts and the gateway NativeCommandSpec list.
- *
- * PLACEHOLDER: replace/extend with dynamic gateway commands when available.
- */
-const STATIC_SLASH_COMMANDS: SlashCommand[] = [
-  { name: 'new', description: 'Reset the session', argHint: undefined, category: 'session' },
-  { name: 'reset', description: 'Reset the session', argHint: undefined, category: 'session' },
-  { name: 'abort', description: 'Abort the active run', argHint: undefined, category: 'session' },
-  { name: 'agent', description: 'Switch agent (or open picker)', argHint: '<id>', category: 'session' },
-  { name: 'agents', description: 'Open agent picker', argHint: undefined, category: 'session' },
-  { name: 'session', description: 'Switch session (or open picker)', argHint: '<key>', category: 'session' },
-  { name: 'sessions', description: 'Open session picker', argHint: undefined, category: 'session' },
+const CATEGORY_ORDER: CommandCategory[] = ['session', 'options', 'management', 'tools', 'media', 'docks', 'status'];
 
+export const CATEGORY_I18N_KEYS: Record<CommandCategory, string> = {
+  session: 'slashDashboard.categorySession',
+  options: 'slashDashboard.categoryOptions',
+  status: 'slashDashboard.categoryStatus',
+  management: 'slashDashboard.categoryManagement',
+  media: 'slashDashboard.categoryMedia',
+  tools: 'slashDashboard.categoryTools',
+  docks: 'slashDashboard.categoryDocks',
+};
+
+export const SOURCE_I18N_KEYS: Record<CommandSource, string> = {
+  native: 'slashDashboard.sourceNative',
+  skill: 'slashDashboard.sourceSkill',
+  plugin: 'slashDashboard.sourcePlugin',
+};
+
+const MODEL_PICKER_COMMAND = 'model';
+
+function detectPickerType(entry: CommandEntry): SlashPickerType {
+  if (!entry.acceptsArgs) return 'free';
+  const first = entry.args?.[0];
+  if (!first) return 'free';
+  if (first.dynamic) {
+    const key = entry.nativeName ?? entry.name;
+    if (key === MODEL_PICKER_COMMAND) return 'model';
+    return 'free';
+  }
+  if (first.choices && first.choices.length > 0) return 'choices';
+  return 'free';
+}
+
+function buildArgHint(entry: CommandEntry, picker: SlashPickerType): string | undefined {
+  if (!entry.acceptsArgs) return undefined;
+  const first = entry.args?.[0];
+  if (!first) return undefined;
+  if (picker === 'choices' && first.choices) {
+    return first.choices.map((c) => c.value).join('|');
+  }
+  return `<${first.name}>`;
+}
+
+function commandEntryToView(entry: CommandEntry): SlashCommandView {
+  const picker = detectPickerType(entry);
+  const aliases = Array.from(new Set([entry.name, ...(entry.textAliases ?? [])]));
+  return {
+    name: entry.name,
+    nativeName: entry.nativeName,
+    description: entry.description,
+    aliases,
+    category: entry.category ?? 'status',
+    source: entry.source,
+    acceptsArgs: entry.acceptsArgs,
+    args: entry.args ?? [],
+    pickerType: picker,
+    argHint: buildArgHint(entry, picker),
+  };
+}
+
+function enumArg(name: string, description: string, values: string[], dynamic = false): CommandArg {
+  return {
+    name,
+    description,
+    type: 'string',
+    choices: values.map((v) => ({ value: v, label: v })),
+    dynamic,
+  };
+}
+
+function dynamicArg(name: string, description: string): CommandArg {
+  return { name, description, type: 'string', dynamic: true };
+}
+
+const NATIVE_OVERLAY: CommandEntry[] = [
+  {
+    name: 'new',
+    description: 'Reset the session',
+    source: 'native',
+    scope: 'text',
+    category: 'session',
+    acceptsArgs: false,
+  },
+  {
+    name: 'reset',
+    description: 'Reset the session',
+    source: 'native',
+    scope: 'text',
+    category: 'session',
+    acceptsArgs: false,
+  },
+  {
+    name: 'abort',
+    description: 'Abort the active run',
+    source: 'native',
+    scope: 'text',
+    category: 'session',
+    acceptsArgs: false,
+  },
+  {
+    name: 'agent',
+    description: 'Switch agent (or open picker)',
+    source: 'native',
+    scope: 'text',
+    category: 'session',
+    acceptsArgs: true,
+    args: [dynamicArg('id', 'Agent id')],
+  },
+  {
+    name: 'agents',
+    description: 'Open agent picker',
+    source: 'native',
+    scope: 'text',
+    category: 'session',
+    acceptsArgs: false,
+  },
+  {
+    name: 'session',
+    description: 'Switch session (or open picker)',
+    source: 'native',
+    scope: 'text',
+    category: 'session',
+    acceptsArgs: true,
+    args: [dynamicArg('key', 'Session key')],
+  },
+  {
+    name: 'sessions',
+    description: 'Open session picker',
+    source: 'native',
+    scope: 'text',
+    category: 'session',
+    acceptsArgs: false,
+  },
   {
     name: 'model',
     description: 'Set model (or open picker)',
-    argHint: '<provider/model>',
-    category: 'model',
-    pickerType: 'model',
+    source: 'native',
+    scope: 'text',
+    category: 'options',
+    acceptsArgs: true,
+    args: [dynamicArg('model', 'Model id')],
   },
-  { name: 'models', description: 'Open model picker', argHint: undefined, category: 'model' },
+  {
+    name: 'models',
+    description: 'Open model picker',
+    source: 'native',
+    scope: 'text',
+    category: 'options',
+    acceptsArgs: false,
+  },
   {
     name: 'think',
     description: 'Set thinking level',
-    argHint: 'off|minimal|low|medium|high|adaptive',
-    category: 'model',
+    source: 'native',
+    scope: 'text',
+    category: 'options',
+    acceptsArgs: true,
+    args: [enumArg('level', 'Thinking level', ['off', 'minimal', 'low', 'medium', 'high', 'adaptive'])],
   },
-  { name: 'fast', description: 'Set fast mode', argHint: 'status|on|off', category: 'model' },
-  { name: 'verbose', description: 'Set verbose on/off', argHint: 'on|off', category: 'model' },
-  { name: 'reasoning', description: 'Set reasoning on/off', argHint: 'on|off|stream', category: 'model' },
-  { name: 'usage', description: 'Toggle per-response usage line', argHint: 'off|tokens|full|cost', category: 'model' },
-
-  { name: 'elevated', description: 'Set elevated permission level', argHint: 'on|off|ask|full', category: 'access' },
-  { name: 'elev', description: 'Alias for /elevated', argHint: 'on|off|ask|full', category: 'access' },
-  { name: 'activation', description: 'Set group activation mode', argHint: 'mention|always', category: 'access' },
-
-  { name: 'help', description: 'Show slash command help', argHint: undefined, category: 'info' },
-  { name: 'status', description: 'Show gateway status summary', argHint: undefined, category: 'info' },
-  { name: 'settings', description: 'Open settings', argHint: undefined, category: 'info' },
+  {
+    name: 'fast',
+    description: 'Set fast mode',
+    source: 'native',
+    scope: 'text',
+    category: 'options',
+    acceptsArgs: true,
+    args: [enumArg('mode', 'Fast mode', ['status', 'on', 'off'])],
+  },
+  {
+    name: 'verbose',
+    description: 'Set verbose on/off',
+    source: 'native',
+    scope: 'text',
+    category: 'options',
+    acceptsArgs: true,
+    args: [enumArg('state', 'Verbose state', ['on', 'off'])],
+  },
+  {
+    name: 'reasoning',
+    description: 'Set reasoning on/off',
+    source: 'native',
+    scope: 'text',
+    category: 'options',
+    acceptsArgs: true,
+    args: [enumArg('state', 'Reasoning state', ['on', 'off', 'stream'])],
+  },
+  {
+    name: 'usage',
+    description: 'Toggle per-response usage line',
+    source: 'native',
+    scope: 'text',
+    category: 'options',
+    acceptsArgs: true,
+    args: [enumArg('mode', 'Usage mode', ['off', 'tokens', 'full', 'cost'])],
+  },
+  {
+    name: 'elevated',
+    description: 'Set elevated permission level',
+    textAliases: ['elev'],
+    source: 'native',
+    scope: 'text',
+    category: 'management',
+    acceptsArgs: true,
+    args: [enumArg('level', 'Elevated level', ['on', 'off', 'ask', 'full'])],
+  },
+  {
+    name: 'activation',
+    description: 'Set group activation mode',
+    source: 'native',
+    scope: 'text',
+    category: 'management',
+    acceptsArgs: true,
+    args: [enumArg('mode', 'Activation mode', ['mention', 'always'])],
+  },
+  {
+    name: 'help',
+    description: 'Show slash command help',
+    source: 'native',
+    scope: 'text',
+    category: 'status',
+    acceptsArgs: false,
+  },
+  {
+    name: 'status',
+    description: 'Show gateway status summary',
+    source: 'native',
+    scope: 'text',
+    category: 'status',
+    acceptsArgs: false,
+  },
+  {
+    name: 'settings',
+    description: 'Open settings',
+    source: 'native',
+    scope: 'text',
+    category: 'management',
+    acceptsArgs: false,
+  },
 ];
 
-const CATEGORY_ORDER: SlashCommandCategory[] = ['session', 'model', 'access', 'info'];
+const OVERLAY_BY_NAME = new Map<string, CommandEntry>();
+for (const overlay of NATIVE_OVERLAY) {
+  OVERLAY_BY_NAME.set(overlay.name, overlay);
+  if (overlay.nativeName) OVERLAY_BY_NAME.set(overlay.nativeName, overlay);
+  for (const alias of overlay.textAliases ?? []) OVERLAY_BY_NAME.set(alias, overlay);
+}
 
-export const CATEGORY_I18N_KEYS: Record<SlashCommandCategory, string> = {
-  session: 'slashDashboard.categorySession',
-  model: 'slashDashboard.categoryModel',
-  access: 'slashDashboard.categoryAccess',
-  info: 'slashDashboard.categoryInfo',
-};
+function mergeWithOverlay(entry: CommandEntry): CommandEntry {
+  if (entry.source !== 'native') return entry;
+  const overlay = OVERLAY_BY_NAME.get(entry.nativeName ?? entry.name);
+  if (!overlay) return entry;
+  const gwFirst = entry.args?.[0];
+  const ovFirst = overlay.args?.[0];
+  if (!gwFirst || !ovFirst) return entry;
+  const gwHasChoices = (gwFirst.choices?.length ?? 0) > 0;
+  const ovHasChoices = (ovFirst.choices?.length ?? 0) > 0;
+  if (gwHasChoices || !ovHasChoices) return entry;
+  return {
+    ...entry,
+    args: [{ ...gwFirst, choices: ovFirst.choices }, ...(entry.args ?? []).slice(1)],
+  };
+}
+
+export function getCommandsForGateway(catalog: CommandEntry[] | undefined): SlashCommandView[] {
+  if (!catalog || catalog.length === 0) return NATIVE_OVERLAY.map(commandEntryToView);
+  return catalog.map(mergeWithOverlay).map(commandEntryToView);
+}
 
 export function groupCommandsByCategory(
-  commands: SlashCommand[] = STATIC_SLASH_COMMANDS,
-): { category: SlashCommandCategory; commands: SlashCommand[] }[] {
-  const groups = new Map<SlashCommandCategory, SlashCommand[]>();
+  commands: SlashCommandView[],
+): { category: CommandCategory; commands: SlashCommandView[] }[] {
+  const groups = new Map<CommandCategory, SlashCommandView[]>();
   for (const cmd of commands) {
-    const cat = cmd.category ?? 'info';
-    const arr = groups.get(cat);
+    const arr = groups.get(cmd.category);
     if (arr) arr.push(cmd);
-    else groups.set(cat, [cmd]);
+    else groups.set(cmd.category, [cmd]);
   }
   return CATEGORY_ORDER.filter((c) => groups.has(c)).map((c) => ({
     category: c,
@@ -91,27 +298,12 @@ export function groupCommandsByCategory(
   }));
 }
 
-/**
- * Filter slash commands by the text the user has typed after the `/`.
- * Returns all commands when query is empty (bare "/" input).
- */
-export function filterSlashCommands(query: string, commands: SlashCommand[] = STATIC_SLASH_COMMANDS): SlashCommand[] {
+export function filterSlashCommands(query: string, commands: SlashCommandView[]): SlashCommandView[] {
   const q = query.toLowerCase();
   if (!q) return commands;
-  return commands.filter((cmd) => cmd.name.startsWith(q));
+  return commands.filter((cmd) => cmd.aliases.some((a) => a.toLowerCase().startsWith(q)));
 }
 
-/**
- * Parse the textarea value to determine if slash-command autocomplete should show.
- *
- * Rules:
- * - The cursor must be on the *first* line.
- * - The line must start with `/`.
- * - There must be no whitespace-separated second token yet (i.e. we haven't
- *   entered the argument phase).
- *
- * Returns `{ active: true, query }` or `{ active: false }`.
- */
 export function parseSlashQuery(
   value: string,
   selectionStart: number,
@@ -124,16 +316,13 @@ export function parseSlashQuery(
   return { active: true, query: afterSlash };
 }
 
-export function getEnumOptions(cmd: SlashCommand): string[] | null {
-  if (!cmd.argHint) return null;
-  if (cmd.argHint.includes('<')) return null;
-  if (!cmd.argHint.includes('|')) return null;
-  return cmd.argHint
-    .split('|')
-    .map((s) => s.trim())
-    .filter(Boolean);
+export function hasArgPicker(cmd: SlashCommandView): boolean {
+  return cmd.pickerType !== 'free';
 }
 
-export function hasArgPicker(cmd: SlashCommand): boolean {
-  return cmd.pickerType === 'model' || getEnumOptions(cmd) !== null;
+export function getChoiceOptions(cmd: SlashCommandView): { value: string; label: string }[] | null {
+  if (cmd.pickerType !== 'choices') return null;
+  const first = cmd.args[0];
+  if (!first?.choices) return null;
+  return first.choices;
 }

--- a/packages/desktop/src/renderer/platform/electron-adapter.ts
+++ b/packages/desktop/src/renderer/platform/electron-adapter.ts
@@ -22,6 +22,7 @@ export function createElectronPorts(): PlatformPorts {
       syncSessions: api.syncSessions,
       listGateways: api.listGateways,
       listModels: api.listModels,
+      listCommands: api.listCommands,
       listAgents: api.listAgents,
       getToolsCatalog: api.getToolsCatalog,
       getSkillsStatus: api.getSkillsStatus,

--- a/packages/desktop/test/gateway-dispatcher-subagent.test.ts
+++ b/packages/desktop/test/gateway-dispatcher-subagent.test.ts
@@ -76,6 +76,7 @@ function createHarness(
     setAgentCatalogForGateway: vi.fn(),
     setToolsCatalogForGateway: vi.fn(),
     setSkillsStatusForGateway: vi.fn(),
+    setCommandCatalogForGateway: vi.fn(),
     onPerformerCandidate: vi.fn((taskId, sessionKey, gatewayId) => {
       performerCandidates.push({ taskId, sessionKey, gatewayId });
     }),

--- a/packages/pwa/src/gateway/client.ts
+++ b/packages/pwa/src/gateway/client.ts
@@ -269,6 +269,10 @@ export class BrowserGatewayClient {
     return this.sendReq('models.list', {});
   }
 
+  async listCommands(params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.sendReq('commands.list', params);
+  }
+
   async listAgents(): Promise<Record<string, unknown>> {
     return this.sendReq('agents.list', {});
   }

--- a/packages/pwa/src/platform/gateway-adapter.ts
+++ b/packages/pwa/src/platform/gateway-adapter.ts
@@ -324,6 +324,24 @@ export function createBrowserGatewayTransport(
       }
     },
 
+    async listCommands(gatewayId, params) {
+      const client = getClient(gatewayId);
+      if (!client?.isConnected)
+        return { ok: false, error: 'gateway not connected', errorCode: 'GATEWAY_NOT_CONNECTED' };
+      const req: Record<string, unknown> = {
+        scope: params?.scope ?? 'text',
+        includeArgs: params?.includeArgs ?? true,
+      };
+      if (params?.agentId) req.agentId = params.agentId;
+      if (params?.provider) req.provider = params.provider;
+      try {
+        const result = await client.listCommands(req);
+        return { ok: true, result };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : 'listCommands failed' };
+      }
+    },
+
     async listAgents(gatewayId) {
       const client = getClient(gatewayId);
       if (!client?.isConnected)

--- a/packages/pwa/src/stores/index.ts
+++ b/packages/pwa/src/stores/index.ts
@@ -151,6 +151,8 @@ function getDispatcher() {
         uiStoreApi.getState().setAgentCatalogForGateway(gwId, agents as AgentInfo[], defaultId),
       setToolsCatalogForGateway: (gwId, catalog) => uiStoreApi.getState().setToolsCatalogForGateway(gwId, catalog),
       setSkillsStatusForGateway: (gwId, report) => uiStoreApi.getState().setSkillsStatusForGateway(gwId, report),
+      setCommandCatalogForGateway: (gwId, commands) =>
+        uiStoreApi.getState().setCommandCatalogForGateway(gwId, commands),
       notifyAgentResponse: (sessionKey) => getComposer().notifyResponse(sessionKey),
       translate: (key, opts) => i18next.t(key, opts),
       isWindowFocused: () => typeof document !== 'undefined' && document.hasFocus(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -330,6 +330,49 @@ export interface ModelListResponse {
   models: ModelCatalogEntry[];
 }
 
+export type CommandSource = 'native' | 'skill' | 'plugin';
+
+export type CommandScope = 'text' | 'native' | 'both';
+
+export type CommandCategory = 'session' | 'options' | 'status' | 'management' | 'media' | 'tools' | 'docks';
+
+export interface CommandArgChoice {
+  value: string;
+  label: string;
+}
+
+export interface CommandArg {
+  name: string;
+  description: string;
+  type: 'string' | 'number' | 'boolean';
+  required?: boolean;
+  choices?: CommandArgChoice[];
+  dynamic?: boolean;
+}
+
+export interface CommandEntry {
+  name: string;
+  nativeName?: string;
+  textAliases?: string[];
+  description: string;
+  category?: CommandCategory;
+  source: CommandSource;
+  scope: CommandScope;
+  acceptsArgs: boolean;
+  args?: CommandArg[];
+}
+
+export interface CommandsListParams {
+  agentId?: string;
+  provider?: string;
+  scope?: CommandScope;
+  includeArgs?: boolean;
+}
+
+export interface CommandsListResponse {
+  commands: CommandEntry[];
+}
+
 export interface ToolEntry {
   id: string;
   label: string;


### PR DESCRIPTION
## Summary

Replaces the hardcoded `STATIC_SLASH_COMMANDS` list with a dynamic catalog hydrated from the upstream `commands.list` RPC (openclaw/openclaw#62656). The slash menu in ChatInput and the `/` command Dashboard now reflect the actual native / skill / plugin commands available on the connected Gateway, with a local overlay supplying `choices` for native commands (e.g. `/think`, `/fast`, `/verbose`) when the Gateway omits them and a full static fallback when the Gateway is unreachable.

## Type of change

- [x] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The old static table drifted out of sync with OpenClaw's native command surface and could never show workspace skills or plugin commands. Upstream PR openclaw/openclaw#62656 added a `commands.list` gateway RPC that returns a structured, per-session command list (with source, scope, category, and argument definitions). ClawWork needs to consume this RPC so the slash UI reflects the real set of commands available to the active session.

## What changed?

- **shared**: new `CommandEntry` / `CommandArg` / `CommandArgChoice` / `CommandsListParams` / `CommandsListResponse` / `CommandSource` / `CommandScope` / `CommandCategory` types mirroring the Gateway schema one-to-one.
- **main**: `gateway-client.listCommands()` (`commands.list` sendReq), `ws:commands-list` IPC handler defaulting to `scope: 'text'` + `includeArgs: true`, preload bridge + `.d.ts` exposure.
- **core**: `GatewayTransportPort.listCommands`, `uiStore.commandCatalogByGateway` + `setCommandCatalogForGateway`, `gateway-dispatcher.fetchCatalogs` pulls commands in parallel with models / agents / tools / skills on connect.
- **pwa**: mirrors the same port on the web adapter (gateway client + gateway adapter + store bridge) so the PWA path stays consistent.
- **renderer**: `slash-commands.ts` rewritten around `CommandEntry → SlashCommandView`. `NATIVE_OVERLAY` preserves `choices` for `/think /fast /verbose /reasoning /usage /elevated /activation` when Gateway data omits them (only for `source: 'native'` entries). `mergeWithOverlay` composes gateway data with local defaults; alias-aware prefix filter handles `textAliases` (e.g. `/elev` → `/elevated`).
- **UI**: `SlashCommandMenu` and `SlashCommandDashboard` show a `CommandSourceBadge` for skill/plugin commands; Dashboard gains a search input, empty state, and fixed-height scroll area (no jitter when result count changes).
- **keyboard**: `useSlashAutocomplete` adds a `requestAnimationFrame` re-focus + window-level keydown fallback so arg-picker navigation survives Radix Dialog FocusScope returning focus to the Dashboard trigger; `document.activeElement` arbitration prevents double-trigger.
- **i18n**: 8 locales (en / zh / zh-TW / ja / ko / es / pt / de) updated — 7 category keys + 3 source labels + search placeholder + empty-state string; deterministic key sorting preserved; parity check passes.

## Architecture impact

- Owning layer: shared + core + main + preload + renderer + pwa (cross-layer RPC wiring, same shape as the existing `listModels` / `listAgents` chains).
- Cross-layer impact: **yes** — additive only. New port method, new store slot, new shared types. No existing behavior path modified; layering direction (`shared ← core ← desktop/pwa`) preserved.
- Invariants touched from `docs/architecture-invariants.md`:
  - Single Gateway WS connection (`commands.list` flows through the existing WS client).
  - `ipcMain.handle()` registered once at app startup inside `registerWsHandlers`.
  - No Node builtins / electron imports leaked into renderer.
  - Preload bridge exposes only the narrow `listCommands` method; no raw `ipcRenderer`.
  - Task / session isolation untouched — catalog is gateway-scoped, not session-scoped.
- Why those invariants remain protected: the new code slots into the exact same template as `listModels` / `listAgents` (existing, reviewed patterns) at every layer. `greptileai`-style adversarial scan found 0 divergences from the canonical chain.

## Linked issues

Closes #

Depends on: openclaw/openclaw#62656 (merged; live in OpenClaw 2026.4.15-beta.1+).

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm check:ui-contract`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check       # EXIT=0 — lint + architecture + ui-contract +
                 # renderer-copy + i18n (8 locales parity OK) +
                 # knip (dead-code) + format + typecheck +
                 # 237/237 desktop tests + 73/73 core + 61/61 pwa
pre-ship         # 7-lens adversarial scan: 0 MUST-FIX, 9 deferred
                 # (see "Considered and deferred" at commit body tail)
manual           # `/` menu shows gateway commands including skill/plugin
                 # source badges; `/think` picker shows choices; model
                 # picker for `/model` still resolves via modelCatalog;
                 # offline fallback surfaces 19 native commands;
                 # dashboard search input stays fixed as results change.
```

## Screenshots or recordings

UI changes: new `CommandSourceBadge` visible for non-native commands in both the popover and Dashboard; Dashboard has a search input with sticky position. All colors routed through existing CSS variables (`--accent`, `--border-subtle`, `--text-muted`, etc.) — no new hex values. No `pnpm check:ui-contract` rules bent; one switch from `max-h-[60vh]` (arbitrary-value escape hatch) to `h-96` (token-compliant) landed during this PR to appease the layout-escape rule.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Slash commands (`/`) are now sourced live from the connected gateway. Skills
and plugin commands appear alongside native commands, with source badges in
the menu and dashboard. `/think`, `/fast`, and similar options retain their
quick-select arg pickers.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

## Considered and deferred

- packages/desktop/src/renderer/lib/slash-commands.ts [BOT-TASTE]: Default category for uncategorized gateway commands resolves to 'status'. Both 'status' and 'tools' are defensible buckets; upstream CommandEntry.category is optional by schema. Revisit after UX feedback.
- packages/desktop/src/renderer/lib/slash-commands.ts [BOT-NIT]: SlashCommandView.acceptsArgs is populated but not currently consumed by any renderer. Kept for parity with upstream CommandEntry shape; safe to drop in a later cleanup.
- packages/desktop/src/renderer/lib/slash-commands.ts [BOT-NIT]: getCommandsForGateway runs two sequential .map passes. Cold path (per-reconnect); fuse if profiling ever points here.
- packages/desktop/src/renderer/lib/slash-commands.ts [BOT-NIT]: filterSlashCommands lower-cases aliases per keystroke. Negligible for <50 commands; pre-lowercase at view-build time if catalog scales.
- packages/desktop/src/renderer/lib/slash-commands.ts [BOT-SCOPE]: No unit tests for mergeWithOverlay / commandEntryToView / detectPickerType / getCommandsForGateway. Follow-up PR to cover overlay precedence and empty-catalog fallback.
- packages/shared/src/types.ts [BOT-NIT]: CommandEntry / CommandArg / CommandsListResponse lack JSDoc anchoring to the Gateway upstream schema. Additive types are back-compat; link in a later docs pass.
- packages/desktop/src/renderer/components/ChatInput/useSlashAutocomplete.ts [BOT-TASTE]: activeGatewayId selector duplicated in SlashCommandDashboard. Pre-existing pattern across 4+ renderer sites; extract useActiveGatewayId() hook in a cleanup PR.
- packages/desktop/src/renderer/components/ChatInput/useSlashAutocomplete.ts [BOT-TASTE]: Window-level keydown fallback survives Radix Dialog FocusScope handoff; document.activeElement guard keeps it a no-op on the happy path. Document the rationale inline in a follow-up.
- packages/desktop/src/renderer/components/ChatInput/useSlashAutocomplete.ts [BOT-TASTE]: buildArgOptions reads useTaskStore and useUiStore via getState(). Functionally correct; consider lifting to explicit selectors for surface clarity.
