### PR TITLE
[Fix] Cancel agent-not-responding timer on response signal

### DIFF
--- a/packages/core/src/services/chat-composer.ts
+++ b/packages/core/src/services/chat-composer.ts
@@ -31,11 +31,6 @@ export interface ChatComposerDeps {
     ) => Message;
     setProcessing: (taskId: string, processing: boolean) => void;
     clearMessages: (taskId: string) => void;
-    processingBySession: Set<string>;
-    activeTurnBySession: Record<
-      string,
-      { streamingText: string; streamingThinking: string; toolCalls: { id: string }[] }
-    >;
   };
 
   persistMessage: (msg: {
@@ -97,6 +92,7 @@ function resolveMentionTargets(
 
 export function createChatComposer(deps: ChatComposerDeps) {
   const responseTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const sessionToTask = new Map<string, string>();
 
   function resolveTask(taskId?: string): TaskRef | null {
     if (taskId) {
@@ -130,6 +126,14 @@ export function createChatComposer(deps: ChatComposerDeps) {
       clearTimeout(timer);
       responseTimers.delete(taskId);
     }
+    for (const [sk, tid] of sessionToTask) {
+      if (tid === taskId) sessionToTask.delete(sk);
+    }
+  }
+
+  function notifyResponse(sessionKey: string): void {
+    const taskId = sessionToTask.get(sessionKey);
+    if (taskId) clearTimer(taskId);
   }
 
   async function send(taskId: string | undefined, options: SendOptions): Promise<{ ok: boolean; taskId?: string }> {
@@ -222,23 +226,18 @@ export function createChatComposer(deps: ChatComposerDeps) {
 
       clearTimer(task.id);
       const watchKeys = isMentionSend ? mentionTargets : [task.sessionKey];
+      for (const sk of watchKeys) sessionToTask.set(sk, task.id);
       responseTimers.set(
         task.id,
         setTimeout(() => {
           responseTimers.delete(task.id);
-          const s = deps.getMessageStore();
-          const stillProcessing = watchKeys.some((sk) => s.processingBySession.has(sk));
-          const anyResponded = watchKeys.some((sk) => {
-            const turn = s.activeTurnBySession[sk];
-            return turn && (turn.streamingText || turn.streamingThinking || turn.toolCalls.length > 0);
-          });
-          if (stillProcessing || anyResponded) return;
+          for (const sk of watchKeys) sessionToTask.delete(sk);
           const appError = buildAppError({
             source: 'gateway',
             stage: 'lifecycle',
             rawMessage: deps.translate('errors.agentNotResponding'),
           });
-          s.addMessage(task.id, 'system', formatErrorForUser(appError, deps.translate));
+          deps.getMessageStore().addMessage(task.id, 'system', formatErrorForUser(appError, deps.translate));
         }, SEND_TIMEOUT_MS),
       );
 
@@ -343,9 +342,10 @@ export function createChatComposer(deps: ChatComposerDeps) {
   function dispose(): void {
     for (const timer of responseTimers.values()) clearTimeout(timer);
     responseTimers.clear();
+    sessionToTask.clear();
   }
 
-  return { send, abort, applySlashCommand, clearTimer, dispose };
+  return { send, abort, applySlashCommand, clearTimer, notifyResponse, dispose };
 }
 
 export type ChatComposer = ReturnType<typeof createChatComposer>;

--- a/packages/core/src/services/gateway-dispatcher.ts
+++ b/packages/core/src/services/gateway-dispatcher.ts
@@ -121,6 +121,7 @@ export interface GatewayDispatcherDeps {
   onSubagentCandidate?: (sessionKey: string, gatewayId: string) => void;
   onApprovalRequested?: (gatewayId: string, approval: unknown) => void;
   onApprovalResolved?: (id: string) => void;
+  notifyAgentResponse?: (sessionKey: string) => void;
   onToast?: (type: 'error' | 'warning' | 'success', title: string, opts?: { description?: string }) => void;
   translate: TranslateFn;
   isWindowFocused: () => boolean;
@@ -260,6 +261,8 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
     if (taskId !== deps.getActiveTaskId()) {
       deps.markUnread(taskId);
     }
+
+    deps.notifyAgentResponse?.(sessionKey);
 
     const store = deps.getMessageStore();
     const text = extractText(payload);
@@ -473,6 +476,8 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
   function handleAgentToolStream(taskId: string, sessionKey: string, data: AgentToolData): void {
     if (!data.name || !data.toolCallId) return;
 
+    deps.notifyAgentResponse?.(sessionKey);
+
     if (taskId !== deps.getActiveTaskId()) {
       deps.markUnread(taskId);
     }
@@ -517,6 +522,7 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
 
     switch (data.phase) {
       case 'start':
+        deps.notifyAgentResponse?.(sessionKey);
         store.setProcessing(sessionKey, true);
         debugEvent('renderer.agent.lifecycle.start', { taskId, sessionKey });
         break;

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcherSetup.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcherSetup.ts
@@ -4,7 +4,7 @@ import { parseAgentIdFromSessionKey, parseTaskIdFromSessionKey } from '@clawwork
 import { toast } from 'sonner';
 import { hydrateFromLocal, retrySyncPending, syncFromGateway, syncSessionMessages } from '../lib/session-sync';
 import i18n from '../i18n';
-import { composerBridge, ports, useMessageStore, useTaskStore, useUiStore, useRoomStore } from '../platform';
+import { composer, composerBridge, ports, useMessageStore, useTaskStore, useUiStore, useRoomStore } from '../platform';
 import { useApprovalStore } from '../stores/approvalStore';
 
 export type GatewayDispatcher = ReturnType<typeof createGatewayDispatcher>;
@@ -110,6 +110,7 @@ function getDispatcher(): GatewayDispatcher {
       onApprovalResolved: (id) => {
         useApprovalStore.getState().removeApproval(id);
       },
+      notifyAgentResponse: (sessionKey) => composer.notifyResponse(sessionKey),
       onToast: (type, title, opts) => {
         if (type === 'error') toast.error(title, opts);
         else if (type === 'warning') toast.warning(title, opts);

--- a/packages/pwa/src/stores/index.ts
+++ b/packages/pwa/src/stores/index.ts
@@ -151,6 +151,7 @@ function getDispatcher() {
         uiStoreApi.getState().setAgentCatalogForGateway(gwId, agents as AgentInfo[], defaultId),
       setToolsCatalogForGateway: (gwId, catalog) => uiStoreApi.getState().setToolsCatalogForGateway(gwId, catalog),
       setSkillsStatusForGateway: (gwId, report) => uiStoreApi.getState().setSkillsStatusForGateway(gwId, report),
+      notifyAgentResponse: (sessionKey) => getComposer().notifyResponse(sessionKey),
       translate: (key, opts) => i18next.t(key, opts),
       isWindowFocused: () => typeof document !== 'undefined' && document.hasFocus(),
       reportDebugEvent: (event) => reportDebugEvent(event as Partial<DebugEvent>),


### PR DESCRIPTION
## Summary

Fixes the false-positive `Agent: Agent 未响应 — 可能不可用或服务端配置有误，请尝试其他 Agent` system message that frequently appears 30 seconds after a message is sent even though the agent actually replied (including replies that already rendered, finalized, and completed tool calls).

## Type of change

- [x] `[Fix]` bug fix

## Why is this needed?

The `chat-composer` 30s send-timeout probe judged *"agent unresponsive"* by inspecting transient state — `processingBySession` / `activeTurnBySession` — at the moment the timer fired. Fast replies (common for slash-command warnings, short answers, and any sub-30s agent turn) are already promoted to canonical messages and cleared from active-turn state by `session-sync.promoteActiveTurn` by that point, so the probe mis-fired even though the agent had fully replied. Reported via in-app screenshots showing the system error trailing behind a completed assistant turn with tool calls.

## What changed?

- `chat-composer.ts`: expose `notifyResponse(sessionKey)`; maintain a `sessionKey → taskId` map while a send timer is active; timer callback is now a simple "no signal arrived within 30s" emitter (no more transient-state probing).
- `gateway-dispatcher.ts`: new optional `notifyAgentResponse?: (sessionKey) => void` dep, invoked at the top of `handleChatEvent` (covers delta / final / error / aborted), `handleAgentToolStream`, and `handleAgentLifecycleStream` phase `start`.
- `packages/desktop/.../useGatewayDispatcherSetup.ts` + `packages/pwa/src/stores/index.ts`: wire `composer.notifyResponse` into the dispatcher dep.
- Narrow `ChatComposerDeps.getMessageStore` return type by removing `processingBySession` / `activeTurnBySession` — no longer read in the composer.

The effect: the timer is cancelled the moment the agent shows any sign of life, so it can only fire when the agent truly produced nothing for 30s.

## Architecture impact

- Owning layer: core (shared contract between composer and dispatcher), with wiring updates in desktop renderer and pwa.
- Cross-layer impact: yes — adds one optional callback `notifyAgentResponse` on `GatewayDispatcherDeps` and one new public method `notifyResponse` on `ChatComposer`. Both are internal to the core/renderer boundary; preload bridge is untouched.
- Invariants touched from `docs/architecture-invariants.md`: none. Session keying, task isolation, message-persistence single-writer, and gateway-event filtering all remain unchanged.
- Why those invariants remain protected: `notifyAgentResponse` is a pure in-memory timer cancellation; it does not persist, mutate messages, or cross the preload boundary. The sessionKey→taskId map is cleared on timer fire, `clearTimer`, `dispose`, and explicit abort.

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check → EXIT=0
  shared / core / desktop (237 tests) / pwa (61 tests) all pass
  lint + architecture + ui-contract + renderer-copy + i18n + dead-code + format + typecheck + typecheck:tests all pass
```

Manual smoke test not executed by the author — reviewer or author to confirm in-app: send a short message via any agent, wait >30s, confirm no spurious "Agent 未响应" message appears in the message list.

## Screenshots or recordings

N/A — no UI tokens, layout, or component structure were changed. The affected surface is a system message that should no longer appear under the fixed conditions.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fix: Stop the spurious "Agent not responding" system message from appearing after fast (<30s) agent replies.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

## Considered and deferred

- packages/core/src/services/chat-composer.ts:130 [BOT-SCOPE]: No dedicated unit test for the new `notifyResponse` cancellation path. Covered indirectly by `pnpm check` (core + 237 desktop + 61 pwa tests pass); a focused test is a reasonable follow-up but out of scope for this minimal behavioral fix.
