### PR TITLE
[CI] Upgrade action runtimes to Node 24 and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       actions:
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: chore
       include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,10 +17,10 @@ jobs:
       smoke: ${{ steps.plan.outputs.smoke }}
       gateway: ${{ steps.plan.outputs.gateway }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             global:
@@ -85,15 +85,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload smoke report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-smoke-report
           path: playwright-report/
@@ -128,15 +128,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload gateway report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-gateway-report
           path: playwright-report/

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -32,10 +32,10 @@ jobs:
       build_desktop: ${{ steps.plan.outputs.build_desktop }}
       test_job: ${{ steps.plan.outputs.test_job }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             global:
@@ -120,15 +120,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -168,15 +168,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -242,15 +242,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
 
@@ -83,17 +83,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -178,13 +178,13 @@ jobs:
       RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -200,7 +200,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload draft as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-notes-${{ env.RELEASE_TAG }}
           path: /tmp/release-notes.md

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout tap repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: clawwork-ai/homebrew-clawwork
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -22,13 +22,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Why

GitHub Actions is removing Node 20 runtime on **2026-09-16**. All `v4`-era first-party actions (`checkout`, `setup-node`, `upload-artifact`, `deploy-pages`) run on Node 20 and will start failing. This PR resolves the deadline and adds Dependabot so future bumps arrive as a single grouped PR rather than five.

## What changed

**Action version bumps** (all first-party actions with Node 20 runtime in their current major):

| Action | From | To | Runtime delta |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | Node 20 → 24 |
| `actions/setup-node` | v4 | v5 | Node 20 → 24 |
| `actions/upload-artifact` | v4 | v5 | Node 20 → 24 |
| `actions/deploy-pages` | v4 | v5 | Node 20 → 24 |
| `pnpm/action-setup` | v4 | v5 | Node 20 → 24 |
| `dorny/paths-filter` | v3 | v4 | Node 20 → 24 |

**Intentionally not bumped**:
- `actions/upload-pages-artifact@v3` — composite action (verified via `action.yml`: `using: composite`). No Node runtime of its own, so no deadline risk. Dependabot will surface future bumps.
- `wzshiming/gh-ci-bot@v1.4.0` — third-party bot, pinned by convention.

**New `.github/dependabot.yml`**:
- `package-ecosystem: github-actions`, weekly on Monday
- All actions grouped (`groups: actions.patterns: ["*"]`) → single PR per week
- `commit-message: { prefix: chore, include: scope }`

## Why not v6 / v7

`actions/checkout@v6` and `actions/setup-node@v6` are GA but newer; `actions/upload-artifact@v7` changes artifact compression defaults. This PR's stated goal is to resolve the Node 20 deadline, not chase latest majors — v5 already moves everything to Node 24. Dependabot will propose later major bumps in isolated reviewable PRs.

## Compatibility notes

- `pnpm/action-setup@v5` can read the `packageManager` field from `package.json` when `version` is omitted. Our root `package.json` does not declare `packageManager`, and every workflow passes `with: { version: 10 }` explicitly → no behavior change.
- `actions/setup-node@v5` does not change the `with: { node-version, cache }` input shape used here.
- `actions/upload-artifact@v5` keeps the `name/path/retention-days` inputs backward-compatible; our uploads do not rely on the deprecated v3 behaviors.

## Test plan

CI on this PR runs:
- `pr-check` — exercises `checkout@v5`, `setup-node@v5`, `pnpm/action-setup@v5`, `paths-filter@v4`
- `e2e` (smoke + gateway) — exercises `upload-artifact@v5` on Xvfb runners

Release-only paths (`release.yml`, `update-homebrew.yml`) and the Pages build (`website.yml`) are covered by their own workflow triggers (tag push / main push); no runtime change to their inputs.

## Pre-ship audit

Pre-ship caught one MUST-FIX on an earlier version of the diff:
- `.github/workflows/website.yml:75` — `deploy-pages@v4` left on Node 20 runtime, contradicting the stated PR goal. Fixed in this commit.

## Considered and deferred

- `.github/workflows/website.yml:58` [BOT-NIT]: `upload-pages-artifact@v3` → `v5` is a pure style bump (composite action, no runtime risk). Out of scope for the deadline. Dependabot handles future bumps.