### PR TITLE
[CI] Add secret-scan gate with gitleaks CLI

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -264,8 +264,33 @@ jobs:
       - name: Package Linux smoke build
         run: pnpm --filter @clawwork/desktop exec electron-builder --linux --x64 --publish never
 
+  secrets-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GITLEAKS_VERSION: 8.30.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -fsSL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan PR diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: gitleaks detect --source . --log-opts "${BASE_SHA}..${HEAD_SHA}" --redact --verbose --no-banner
+
   ci-passed:
-    needs: [changes, quality, test, build]
+    needs: [changes, quality, test, build, secrets-scan]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

PR #428 introduced architecture guardrails but explicitly documented one gap: the [HIGH] "no secrets in client code" invariant had no CI enforcement. Anyone could commit an API key and the pipeline would happily ship it. This PR closes that gap.

## Design choices

### CLI, not `gitleaks/gitleaks-action@v2`

The action wrapper's `action.yml` declares `using: 'node20'`. That would directly contradict #431 (which is removing Node 20 runtimes ahead of the 2026-09-16 deadline). Upstream has no v3 yet. Calling the gitleaks CLI straight from a `run:` step gives us the same scanning behavior with zero Node runtime dependency.

### Always-on, not paths-filter-gated

The rest of `pr-check.yml` uses `dorny/paths-filter` to skip irrelevant jobs. We deliberately do NOT gate `secrets-scan` — any file (including markdown, JSON fixtures, workflow YAML) can leak a secret, so this has to run on every PR regardless of which paths changed.

### Bounded range scan

`gitleaks detect --log-opts "\${BASE_SHA}..\${HEAD_SHA}"` scans only the commits in the PR, not the repo's full history. Local smoke: 3 commits, 12 KB, 35 ms.

### Pinned binary version

`GITLEAKS_VERSION=8.30.1` is pinned as a job-level env var so Dependabot can bump it via one-line PRs once the weekly schedule (added in #431) is active.

## Aggregation

`ci-passed` now lists `secrets-scan` as a required need. A leaked secret makes the PR un-mergeable, just like a lint/test/build failure.

## Test plan

- Local smoke: `gitleaks detect --source . --log-opts "HEAD~3..HEAD" --redact --verbose --no-banner` → exit 0, no leaks found.
- Local full-tree scan: 713 MB in 37 s, no leaks found — confirms the current repo is clean and no allowlist is needed.
- This PR will go through its own `secrets-scan` on CI; if the scanner itself has a config issue, the job will surface it.

## Out of scope

- Pre-commit hook for local scanning. Separate concern; this PR's scope is the CI gate.
- `.gitleaks.toml` custom rule overrides. Default rules are sufficient for the current repo.