### PR TITLE
[Test] Add Layer 3 DB-asserting e2e business paths

### DIFF
--- a/e2e/gateway/integration.spec.ts
+++ b/e2e/gateway/integration.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import type { ElectronApplication, Page } from 'playwright';
+import type { ElectronApplication, Page } from '@playwright/test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/e2e/gateway/persistence.spec.ts
+++ b/e2e/gateway/persistence.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import { launchApp } from '../helpers/electron-app';
+import { setupPairedApp, waitForGatewayConnected, type PairedApp } from '../helpers/pairing-flow';
+import { GATEWAY_ID, buildSessionKey } from '../helpers/constants';
+import { messagesForTask, countByRole, readAllMessages } from '../helpers/db-query';
+
+type PersistTaskInput = Parameters<typeof window.clawwork.persistTask>[0];
+type PersistMessageInput = Parameters<typeof window.clawwork.persistMessage>[0];
+
+function newTaskInput(): PersistTaskInput {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  return {
+    id,
+    sessionKey: buildSessionKey(id),
+    sessionId: '',
+    title: `e2e-${id.slice(0, 8)}`,
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+    tags: [],
+    artifactDir: '',
+    gatewayId: '',
+  };
+}
+
+function newUserMessage(taskId: string, content: string): PersistMessageInput {
+  return {
+    id: randomUUID(),
+    taskId,
+    role: 'user',
+    content,
+    timestamp: new Date().toISOString(),
+    sessionKey: buildSessionKey(taskId),
+  };
+}
+
+let paired: PairedApp;
+let app: ElectronApplication;
+let page: Page;
+
+test.describe('Layer 3: DB-asserting business paths', () => {
+  test.beforeAll(async () => {
+    paired = await setupPairedApp();
+    app = paired.app;
+    page = paired.page;
+  });
+
+  test.afterAll(async () => {
+    if (app) await app.close().catch(() => {});
+    paired?.cleanup?.();
+  });
+
+  test('B1: user message persists exactly once', async () => {
+    const task = newTaskInput();
+    const taskRes = await page.evaluate((t) => window.clawwork.persistTask(t), task);
+    expect(taskRes.ok).toBe(true);
+
+    const sendRes = await page.evaluate(([gwId, sk]) => window.clawwork.sendMessage(gwId, sk, 'B1: gateway send'), [
+      GATEWAY_ID,
+      task.sessionKey,
+    ] as const);
+    expect(sendRes.ok).toBe(true);
+
+    const persistRes = await page.evaluate(
+      (msg) => window.clawwork.persistMessage(msg),
+      newUserMessage(task.id, 'B1: gateway send'),
+    );
+    expect(persistRes.ok).toBe(true);
+
+    const rows = messagesForTask(paired.workspaceDir, task.id);
+    expect(countByRole(rows, 'user')).toBe(1);
+    expect(rows[0]?.content).toBe('B1: gateway send');
+  });
+
+  test('B2: assistant message never duplicated (regression gate for finalizeStream dual-write)', async () => {
+    const task = newTaskInput();
+    await page.evaluate((t) => window.clawwork.persistTask(t), task);
+
+    const sendRes = await page.evaluate(([gwId, sk]) => window.clawwork.sendMessage(gwId, sk, 'B2: trigger response'), [
+      GATEWAY_ID,
+      task.sessionKey,
+    ] as const);
+    expect(sendRes.ok).toBe(true);
+
+    await page.waitForTimeout(3_000);
+
+    const rows = messagesForTask(paired.workspaceDir, task.id);
+    const assistantCount = countByRole(rows, 'assistant');
+    expect(assistantCount).toBeLessThanOrEqual(1);
+  });
+
+  test('B3: gateway-routed messages do not leak across tasks', async () => {
+    const t1 = newTaskInput();
+    const t2 = newTaskInput();
+    await page.evaluate((t) => window.clawwork.persistTask(t), t1);
+    await page.evaluate((t) => window.clawwork.persistTask(t), t2);
+
+    const send1 = await page.evaluate(([gwId, sk]) => window.clawwork.sendMessage(gwId, sk, 'B3: only-in-T1'), [
+      GATEWAY_ID,
+      t1.sessionKey,
+    ] as const);
+    expect(send1.ok).toBe(true);
+    await page.evaluate((msg) => window.clawwork.persistMessage(msg), newUserMessage(t1.id, 'B3: only-in-T1'));
+
+    const send2 = await page.evaluate(([gwId, sk]) => window.clawwork.sendMessage(gwId, sk, 'B3: only-in-T2'), [
+      GATEWAY_ID,
+      t2.sessionKey,
+    ] as const);
+    expect(send2.ok).toBe(true);
+    await page.evaluate((msg) => window.clawwork.persistMessage(msg), newUserMessage(t2.id, 'B3: only-in-T2'));
+
+    await page.waitForTimeout(2_000);
+
+    const all = readAllMessages(paired.workspaceDir);
+    const inT1 = all.filter((m) => m.task_id === t1.id);
+    const inT2 = all.filter((m) => m.task_id === t2.id);
+
+    expect(inT1.some((m) => m.content === 'B3: only-in-T1')).toBe(true);
+    expect(inT1.some((m) => m.content === 'B3: only-in-T2')).toBe(false);
+    expect(inT2.some((m) => m.content === 'B3: only-in-T2')).toBe(true);
+    expect(inT2.some((m) => m.content === 'B3: only-in-T1')).toBe(false);
+  });
+});
+
+test.describe('Layer 3: reload persistence with attachments (#424)', () => {
+  let local: PairedApp;
+  let localApp: ElectronApplication;
+  let localPage: Page;
+
+  test.beforeAll(async () => {
+    local = await setupPairedApp();
+    localApp = local.app;
+    localPage = local.page;
+  });
+
+  test.afterAll(async () => {
+    if (localApp) await localApp.close().catch(() => {});
+    local?.cleanup?.();
+  });
+
+  test('B4: message + inbox attachment survive app restart', async () => {
+    const task = newTaskInput();
+    const fileName = 'b4-test.txt';
+    const originalContent = 'hello from B4 reload test';
+    const base64 = Buffer.from(originalContent, 'utf8').toString('base64');
+
+    await localPage.evaluate((t) => window.clawwork.persistTask(t), task);
+
+    const saveRes = await localPage.evaluate(
+      ([taskId, fn, b64]) => window.clawwork.saveInboxAttachment({ taskId, fileName: fn, base64: b64 }),
+      [task.id, fileName, base64] as const,
+    );
+    expect(saveRes.ok).toBe(true);
+    const localPath = saveRes.result?.localPath;
+    expect(localPath).toBeTruthy();
+
+    const msg: PersistMessageInput = {
+      ...newUserMessage(task.id, 'B4: msg with attachment'),
+      attachments: [{ localPath, fileName, mimeType: 'text/plain', size: originalContent.length }],
+    };
+    const persistRes = await localPage.evaluate((m) => window.clawwork.persistMessage(m), msg);
+    expect(persistRes.ok).toBe(true);
+
+    await localApp.close();
+
+    ({ app: localApp, page: localPage } = await launchApp({
+      gateway: true,
+      userDataDir: local.userDataDir,
+      workspaceDir: local.workspaceDir,
+    }));
+    await waitForGatewayConnected(localPage);
+
+    const loaded = await localPage.evaluate((taskId) => window.clawwork.loadMessages(taskId), task.id);
+    expect(loaded.ok).toBe(true);
+    const reloaded = (loaded.rows ?? []).find((m) => m.id === msg.id);
+    expect(reloaded?.content).toBe('B4: msg with attachment');
+    const attachments = reloaded?.attachments as Array<{ localPath: string }> | undefined;
+    expect(attachments?.[0]?.localPath).toBe(localPath);
+
+    const readRes = await localPage.evaluate((lp) => window.clawwork.readInboxFile(lp), localPath as string);
+    expect(readRes.ok).toBe(true);
+    const decoded = Buffer.from(readRes.result?.content ?? '', 'base64').toString('utf8');
+    expect(decoded).toBe(originalContent);
+  });
+});

--- a/e2e/helpers/db-query.ts
+++ b/e2e/helpers/db-query.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import { join } from 'path';
+
+const DB_FILE_NAME = '.clawwork.db';
+
+interface DbMessageRow {
+  id: string;
+  task_id: string;
+  role: string;
+  content: string;
+  timestamp: string;
+  image_attachments: string | null;
+  tool_calls: string | null;
+}
+
+function selectAll<T>(workspaceDir: string, sql: string): T[] {
+  const dbPath = join(workspaceDir, DB_FILE_NAME);
+  if (!fs.existsSync(dbPath)) return [];
+  const stdout = execFileSync('sqlite3', [dbPath, '-json', sql], { encoding: 'utf8' });
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+  return JSON.parse(trimmed) as T[];
+}
+
+export function readAllMessages(workspaceDir: string): DbMessageRow[] {
+  return selectAll<DbMessageRow>(workspaceDir, 'SELECT * FROM messages');
+}
+
+export function messagesForTask(workspaceDir: string, taskId: string): DbMessageRow[] {
+  return readAllMessages(workspaceDir).filter((m) => m.task_id === taskId);
+}
+
+export function countByRole(rows: DbMessageRow[], role: string): number {
+  return rows.filter((m) => m.role === role).length;
+}

--- a/e2e/helpers/electron-app.ts
+++ b/e2e/helpers/electron-app.ts
@@ -1,5 +1,5 @@
-import { _electron as electron } from 'playwright';
-import type { ElectronApplication, Page } from 'playwright';
+import { _electron as electron } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';

--- a/e2e/helpers/pairing-flow.ts
+++ b/e2e/helpers/pairing-flow.ts
@@ -1,0 +1,51 @@
+import { expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { launchApp } from './electron-app';
+import { waitForGateway } from './gateway';
+import { approvePendingPairing, getDeviceIdFromUserData, getDeviceTokenFromUserData } from './pairing';
+import { GATEWAY_ID, CONNECTION_TIMEOUT_MS } from './constants';
+
+export interface PairedApp {
+  app: ElectronApplication;
+  page: Page;
+  cleanup: () => void;
+  userDataDir: string;
+  workspaceDir: string;
+}
+
+export async function waitForGatewayConnected(targetPage: Page): Promise<void> {
+  await expect(async () => {
+    const status = await targetPage.evaluate(() => window.clawwork.gatewayStatus());
+    expect(status[GATEWAY_ID]?.connected).toBe(true);
+  }).toPass({ timeout: CONNECTION_TIMEOUT_MS });
+}
+
+export async function setupPairedApp(): Promise<PairedApp> {
+  await waitForGateway();
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-e2e-userdata-'));
+  const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-e2e-ws-'));
+  const initial = await launchApp({ gateway: true, userDataDir, workspaceDir });
+  const { cleanup } = initial;
+  let { app, page } = initial;
+
+  await expect(async () => {
+    const status = await page.evaluate(() => window.clawwork.gatewayStatus());
+    expect(status[GATEWAY_ID]?.error).toBe('pairing required');
+  }).toPass({ timeout: 15_000 });
+
+  const deviceId = getDeviceIdFromUserData(userDataDir);
+  approvePendingPairing(deviceId);
+  await page.evaluate(([gwId]) => window.clawwork.updateGateway(gwId, {}), [GATEWAY_ID] as const);
+  await waitForGatewayConnected(page);
+
+  expect(getDeviceTokenFromUserData(userDataDir, GATEWAY_ID)).toBeTruthy();
+
+  await app.close();
+  ({ app, page } = await launchApp({ gateway: true, userDataDir, workspaceDir }));
+  await waitForGatewayConnected(page);
+
+  return { app, page, cleanup, userDataDir, workspaceDir };
+}

--- a/e2e/smoke/app-launch.spec.ts
+++ b/e2e/smoke/app-launch.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import type { ElectronApplication, Page } from 'playwright';
+import type { ElectronApplication, Page } from '@playwright/test';
 import { launchApp } from '../helpers/electron-app';
 
 let app: ElectronApplication;
@@ -46,10 +46,10 @@ test.describe('Layer 1: Smoke Tests', () => {
   });
 
   test('S4: preload API is exposed', async () => {
-    const apiType = await page.evaluate(() => typeof (window as Record<string, unknown>).clawwork);
+    const apiType = await page.evaluate(() => typeof window.clawwork);
     expect(apiType).toBe('object');
 
-    const methods = await page.evaluate(() => Object.keys((window as Record<string, unknown>).clawwork as object));
+    const methods = await page.evaluate(() => Object.keys(window.clawwork as object));
     expect(methods).toContain('sendMessage');
     expect(methods).toContain('gatewayStatus');
     expect(methods).toContain('listGateways');

--- a/e2e/smoke/typography-smoke.spec.ts
+++ b/e2e/smoke/typography-smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import type { ElectronApplication, Page } from 'playwright';
+import type { ElectronApplication, Page } from '@playwright/test';
 import { launchApp } from '../helpers/electron-app';
 
 let app: ElectronApplication;

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -9,6 +9,6 @@
     "declarationMap": false,
     "sourceMap": false
   },
-  "include": ["./**/*.ts"],
+  "include": ["./**/*.ts", "../packages/desktop/src/preload/clawwork.d.ts"],
   "exclude": ["dist"]
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "test:e2e:gateway": "playwright test --config=e2e/playwright.config.ts --project=gateway",
     "check:i18n": "node scripts/check-i18n.mjs",
     "check:dead-code": "knip",
+    "typecheck:e2e": "pnpm --filter @clawwork/desktop exec tsc --noEmit -p ../../e2e/tsconfig.json",
     "release-notes": "node scripts/generate-release-notes.mjs",
-    "check": "pnpm lint && pnpm check:architecture && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm typecheck:tests && pnpm test"
+    "check": "pnpm lint && pnpm check:architecture && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm typecheck:tests && pnpm typecheck:e2e && pnpm test"
   },
   "lint-staged": {
     "*.{ts,tsx,mts,cts,js,mjs,cjs}": [


### PR DESCRIPTION
## Why

The existing e2e tiers leave a coverage gap on the rule that matters most:

- **Layer 1 (smoke)** — process-level health (window opens, preload exposed, no JS errors). Cheap, no Docker.
- **Layer 2 (gateway)** — IPC plumbing (G3-G7). All assertions are \`expect(result.ok).toBe(true)\`. **Does not verify side effects in SQLite.**

The message single-writer rule (\`.claude/rules/message-persistence.md\`) and task isolation invariant could regress without any test failing. The dual-write bug (#126) that this rule was created to prevent has no regression test.

## What this PR adds

A new tier — **Layer 3: business paths** — that asserts on the actual \`.clawwork.db\` state after each operation.

\`e2e/gateway/persistence.spec.ts\`:

| Test | Asserts | Regresses if |
|---|---|---|
| **B1** user message persists exactly once | After \`persistMessage\` IPC, \`SELECT count(*) FROM messages WHERE task_id=? AND role='user'\` is \`1\` | Single-writer rule broken |
| **B2** assistant non-duplicate | After sending to gateway, assistant row count \`<= 1\` | finalizeStream dual-write returns (#126) |
| **B3** task isolation | Two tasks each get a user message — DB queries by task_id don't cross-contaminate | sessionKey filter regression |
| **B4** message + inbox attachment survive restart | After \`saveInboxAttachment\` + \`persistMessage\` + close + relaunch, \`loadMessages\` and \`readInboxFile\` round-trip the original content | Blob-URL regression returns (#424) |

Helpers:
- \`e2e/helpers/db-query.ts\` — \`sqlite3\` CLI shellout with \`-json\`. Avoids better-sqlite3 native module ABI conflicts between electron's bundled Node and the host Playwright runner.
- \`e2e/helpers/pairing-flow.ts\` — extracts the device-pairing + gateway-connect bootstrap into \`setupPairedApp()\`.

## Why \`<= 1\` (not \`== 1\`) for B2

The unconfigured gateway image may or may not return an assistant message within the 3s test window. The bug we want to catch is **dual writes** (\`>= 2\`), which is invariant under any timing. A strict \`== 1\` would couple the assertion to gateway response speed; \`<= 1\` is timing-independent and still catches the regression.

## Why \`sqlite3\` CLI (not better-sqlite3)

\`better-sqlite3\` is a native module bound to the runtime that built it. The e2e Playwright runner uses host Node, but the electron app loaded \`better-sqlite3\` via its own bundled Node. Opening the same DB from both sides during a test would risk ABI mismatch errors. \`sqlite3\` CLI is preinstalled on macOS and ubuntu-latest, has no native bindings, and reads safely under WAL mode while electron has the DB open.

## Verification

- \`pnpm check\` passes locally (lint, format, typecheck, test, knip, i18n, architecture).
- \`actionlint\` not affected — no workflow changes.
- e2e tests themselves run in the existing \`gateway\` Playwright project, which is already gated on Docker + OpenClaw image in \`.github/workflows/e2e.yml\`.

## Considered and deferred

Documented in commit body. Most notable:

- **\`pairing-flow.ts\` duplicates the inline flow at \`integration.spec.ts:24-52\`** — migrating the existing spec is out of scope for this PR (purely additive). Follow-up cleanup PR will collapse the duplication.
- **B2 uses \`page.waitForTimeout(3_000)\`** — fine because \`<= 1\` is timing-independent. Future improvement: subscribe to a message-persisted event instead of polling.

## Out of scope

Not touched in this PR:
- Layer 1 smoke tests — they have independent value as cheap process-health signal
- Existing G1-G7 gateway tests — they remain as IPC plumbing checks
- \`actions/upload-pages-artifact@v3\` bump (composite, no Node 20 risk) — left for Dependabot