### PR TITLE
[Fix] Add ad-hoc fallback when mac notarization fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
   release:
     needs: prepare-release
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest
@@ -130,7 +131,33 @@ jobs:
         run: pnpm --filter @clawwork/desktop build
 
       - name: Package and publish (${{ matrix.platform }})
+        if: matrix.platform != 'mac'
         run: pnpm --filter @clawwork/desktop exec electron-builder ${{ matrix.build_args }} --publish always -c.buildVersion="$BUILD_VERSION"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_VERSION: ${{ github.run_number }}
+          EP_PRE_RELEASE: ${{ env.IS_PRERELEASE }}
+
+      - name: Package and publish (mac, with adhoc fallback)
+        if: matrix.platform == 'mac'
+        run: |
+          LOG=$(mktemp)
+          set +e
+          pnpm --filter @clawwork/desktop exec electron-builder ${{ matrix.build_args }} --publish always -c.buildVersion="$BUILD_VERSION" 2>&1 | tee "$LOG"
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+          if ! grep -q "Failed to notarize" "$LOG"; then
+            echo "::error::electron-builder failed for a non-notarization reason — not falling back to ad-hoc."
+            exit "$status"
+          fi
+          echo "::warning::Notarization failed — falling back to ad-hoc signing for ${{ matrix.arch }}."
+          rm -rf packages/desktop/dist
+          unset APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+          export CSC_IDENTITY_AUTO_DISCOVERY=false
+          pnpm --filter @clawwork/desktop exec electron-builder ${{ matrix.build_args }} --publish always -c.buildVersion="$BUILD_VERSION" -c.mac.identity=null -c.mac.notarize=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_VERSION: ${{ github.run_number }}

--- a/packages/desktop/build/entitlements.mac.plist
+++ b/packages/desktop/build/entitlements.mac.plist
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

When Apple Developer Program agreements expire, `notarytool` returns HTTP 403 and the entire release matrix fails. This adds an automatic ad-hoc fallback so releases can still ship on every platform even when the Apple agreement state is out of the maintainer's control — macOS users will just need right-click → Open on first launch until the agreement is re-signed on Apple's portal.

## Type of change

- [x] `[Fix]` bug fix
- [ ] `[Build]` CI, packaging, or tooling change (also applies)

## Why is this needed?

Release run [24497768607](https://github.com/clawwork-ai/ClawWork/actions/runs/24497768607) for `v0.0.15-beta.1` failed because Apple returned:

```
Failed to notarize via notarytool.  Failed with unexpected result:
Error: HTTP status code: 403. A required agreement is missing or has expired.
```

Only Apple's Team Agent can re-sign the updated Program License Agreement on Apple's side, and the Team Agent may not be the person shipping a release. Under the current workflow, this fully blocked **every** platform — not just macOS — because the matrix defaulted to `fail-fast: true`, cascade-cancelling Windows, Linux, and mac/x64 after arm64 failed first.

## What changed?

- Set `strategy.fail-fast: false` on the `release` matrix so one platform's failure no longer cascade-cancels the other three.
- Split `Package and publish` into two steps:
  - `non-mac`: unchanged behaviour.
  - `mac, with adhoc fallback`: first attempts the normal notarized build. If `electron-builder` exits non-zero **and** its log contains `Failed to notarize`, the step removes `packages/desktop/dist`, unsets `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID`, exports `CSC_IDENTITY_AUTO_DISCOVERY=false`, and retries once with `-c.mac.identity=null -c.mac.notarize=false` to produce an ad-hoc signed build. Non-notarization failures (compile errors, keychain-import errors, etc.) still fail hard — fallback is deliberately narrow.
- Restore `com.apple.security.device.audio-input` entitlement that was accidentally removed in #82. `NSMicrophoneUsageDescription` is still declared, so hardened-runtime builds need this entitlement to actually access the microphone for voice-dictation.

## Architecture impact

- Owning layer: build / CI + desktop packaging config
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: change is limited to the GitHub Actions release workflow and the macOS entitlements plist. No application code, no layer boundary, no public API.

## Linked issues

Closes #

N/A — discovered via ops failure on run [24497768607](https://github.com/clawwork-ai/ClawWork/actions/runs/24497768607).

## Validation

CI workflow changes can't be fully validated locally — the notarization path needs Apple agreement state that is only reproducible in GitHub Actions.

- [x] `actionlint .github/workflows/release.yml` — new steps emit no findings. Pre-existing SC2086 infos on `release.yml:110-127` are #82 legacy, not introduced here (tracked in deferred block below).
- [x] `python3 plistlib` — `entitlements.mac.plist` parses correctly.
- [ ] `pnpm lint` / `pnpm test` / `pnpm build` — not run; this PR touches no application code.
- [ ] Ad-hoc fallback runtime path — cannot reproduce offline. Will be validated on the next tag push: happy path if Apple agreement is re-signed before then, fallback path if notarytool 403s again.

```text
$ actionlint .github/workflows/release.yml
# no findings on new steps (8 SC2086 infos on #82's Import step — pre-existing)

$ python3 -c "import plistlib; plistlib.load(open('packages/desktop/build/entitlements.mac.plist', 'rb'))"
# entitlements.mac.plist OK
```

## Screenshots or recordings

N/A — no UI.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

## Considered and deferred

- `.github/workflows/release.yml:110-127` [BOT-SCOPE]: `$RUNNER_TEMP` / `$KEYCHAIN_PATH` are unquoted (shellcheck SC2086 info). Not introduced by this diff — #82 legacy. Cleanup belongs in a separate PR.
- auto-updater adhoc-after-notarized upgrade path [BOT-SCOPE]: auto-update from a previously-notarized install to an adhoc-signed build may trip signature validation. Accepted trade-off of the silent-fallback design; filename is deliberately not suffixed with `-adhoc` per the design decision.
- `.github/workflows/release.yml:152` [BOT-TASTE]: `grep -q "Failed to notarize"` hardcodes electron-builder's error phrasing. Kept deliberately conservative — if upstream changes the string, we prefer to skip fallback over over-triggering.