### PR TITLE
[Feat] Cancel in-progress update download

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "better-sqlite3": "^12.6.2",
+    "builder-util-runtime": "9.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cronstrue": "^3.14.0",

--- a/packages/desktop/src/main/auto-updater.ts
+++ b/packages/desktop/src/main/auto-updater.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow } from 'electron';
 import electronUpdater from 'electron-updater';
 import type { UpdateInfo, ProgressInfo } from 'electron-updater';
+import { CancellationToken } from 'builder-util-runtime';
 import { is } from '@electron-toolkit/utils';
 import { getDebugLogger } from './debug/index.js';
 import { readConfig } from './workspace/config.js';
@@ -31,6 +32,7 @@ let initialized = false;
 let state: UpdaterState = 'idle';
 let inFlightCheck: Promise<UpdateCheckResult> | null = null;
 let installingUpdate = false;
+let currentDownloadToken: CancellationToken | null = null;
 
 function broadcast(channel: string, data: unknown): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -156,15 +158,32 @@ export async function downloadUpdate(): Promise<{ ok: boolean; error?: string }>
     return { ok: false, error: 'no-update-available' };
   }
   state = 'downloading';
+  const token = new CancellationToken();
+  currentDownloadToken = token;
   try {
-    await autoUpdater.downloadUpdate();
+    await autoUpdater.downloadUpdate(token);
     return { ok: true };
   } catch (err) {
+    const cancelled = token.cancelled || (err as { isCancelled?: boolean })?.isCancelled === true;
+    if (cancelled) {
+      state = 'available';
+      return { ok: false, error: 'cancelled' };
+    }
     state = 'error';
     const message = err instanceof Error ? err.message : String(err);
     broadcast('update:error', { message, code: classifyError(err) });
     return { ok: false, error: message };
+  } finally {
+    if (currentDownloadToken === token) currentDownloadToken = null;
   }
+}
+
+export function cancelUpdateDownload(): { ok: boolean; error?: string } {
+  if (state !== 'downloading' || !currentDownloadToken) {
+    return { ok: false, error: 'no-download-in-progress' };
+  }
+  currentDownloadToken.cancel();
+  return { ok: true };
 }
 
 export function installUpdate(): { ok: boolean; error?: string } {

--- a/packages/desktop/src/main/ipc/update-handlers.ts
+++ b/packages/desktop/src/main/ipc/update-handlers.ts
@@ -6,6 +6,7 @@ import {
   downloadUpdate,
   installUpdate,
   getUpdateChannel,
+  cancelUpdateDownload,
 } from '../auto-updater.js';
 
 interface ReleaseInfo {
@@ -108,5 +109,12 @@ export function registerUpdateHandlers(): void {
       return { ok: false, error: 'dev-not-supported' };
     }
     return installUpdate();
+  });
+
+  ipcMain.handle('app:cancel-update-download', (): { ok: boolean; error?: string } => {
+    if (!isAutoUpdaterAvailable()) {
+      return { ok: false, error: 'dev-not-supported' };
+    }
+    return cancelUpdateDownload();
   });
 }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -369,6 +369,7 @@ export interface ClawWorkAPI {
   getAppVersion: () => Promise<string>;
   checkForUpdates: () => Promise<UpdateCheckResult>;
   downloadUpdate: () => Promise<{ ok: boolean; error?: string }>;
+  cancelUpdateDownload: () => Promise<{ ok: boolean; error?: string }>;
   installUpdate: () => Promise<{ ok: boolean; error?: string }>;
   onUpdateDownloadProgress: (callback: (progress: UpdateDownloadProgress) => void) => () => void;
   onUpdateDownloaded: (callback: (info: UpdateDownloadedInfo) => void) => () => void;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -181,6 +181,7 @@ function buildApi(): ClawWorkAPI {
     getAppVersion: () => ipcRenderer.invoke('app:get-version'),
     checkForUpdates: () => ipcRenderer.invoke('app:check-for-updates'),
     downloadUpdate: () => ipcRenderer.invoke('app:download-update'),
+    cancelUpdateDownload: () => ipcRenderer.invoke('app:cancel-update-download'),
     installUpdate: () => ipcRenderer.invoke('app:install-update'),
     onUpdateDownloadProgress: (callback) => {
       const listener = (_event: Electron.IpcRendererEvent, data: unknown): void => {

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -451,6 +451,7 @@
     "alreadyLatest": "Sie verwenden die neueste Version",
     "appearance": "Darstellung",
     "authMethod": "Authentifizierung",
+    "cancelDownload": "Download abbrechen",
     "cannotDeleteMain": "Der Haupt-Agent kann nicht geloescht werden",
     "channelBeta": "Beta",
     "channelStable": "Stabil",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -451,6 +451,7 @@
     "alreadyLatest": "You are on the latest version",
     "appearance": "Appearance",
     "authMethod": "Authentication",
+    "cancelDownload": "Cancel Download",
     "cannotDeleteMain": "The main agent cannot be deleted",
     "channelBeta": "Beta",
     "channelStable": "Stable",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -451,6 +451,7 @@
     "alreadyLatest": "Ya tienes la versión más reciente",
     "appearance": "Apariencia",
     "authMethod": "Autenticación",
+    "cancelDownload": "Cancelar descarga",
     "cannotDeleteMain": "El agente principal no se puede eliminar",
     "channelBeta": "Beta",
     "channelStable": "Estable",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -451,6 +451,7 @@
     "alreadyLatest": "最新バージョンです",
     "appearance": "外観",
     "authMethod": "認証方式",
+    "cancelDownload": "ダウンロードをキャンセル",
     "cannotDeleteMain": "メインエージェントは削除できません",
     "channelBeta": "ベータ版",
     "channelStable": "安定版",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -451,6 +451,7 @@
     "alreadyLatest": "최신 버전을 사용 중입니다",
     "appearance": "외관",
     "authMethod": "인증 방식",
+    "cancelDownload": "다운로드 취소",
     "cannotDeleteMain": "메인 에이전트는 삭제할 수 없습니다",
     "channelBeta": "베타",
     "channelStable": "안정",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -451,6 +451,7 @@
     "alreadyLatest": "Você está na versão mais recente",
     "appearance": "Aparência",
     "authMethod": "Autenticação",
+    "cancelDownload": "Cancelar download",
     "cannotDeleteMain": "O agente principal não pode ser excluído",
     "channelBeta": "Beta",
     "channelStable": "Estável",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -451,6 +451,7 @@
     "alreadyLatest": "已是最新版本",
     "appearance": "外觀",
     "authMethod": "驗證方式",
+    "cancelDownload": "取消下載",
     "cannotDeleteMain": "無法刪除主要代理",
     "channelBeta": "測試版",
     "channelStable": "穩定版",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -451,6 +451,7 @@
     "alreadyLatest": "已是最新版本",
     "appearance": "外观",
     "authMethod": "认证方式",
+    "cancelDownload": "取消下载",
     "cannotDeleteMain": "主智能体不可删除",
     "channelBeta": "测试版",
     "channelStable": "稳定版",

--- a/packages/desktop/src/renderer/layouts/Settings/sections/AboutSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AboutSection.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Star, Bug, RefreshCw, Loader2, Download, RotateCcw } from 'lucide-react';
+import { Star, Bug, RefreshCw, Loader2, Download, RotateCcw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
@@ -171,9 +171,17 @@ export default function AboutSection() {
     setUpdateState('downloading');
     setDownloadPercent(0);
     const result = await window.clawwork.downloadUpdate();
-    if (!result.ok) {
+    if (!result.ok && result.error !== 'cancelled') {
       setUpdateState('error');
       setErrorMessage(result.error ?? 'Download failed');
+    }
+  }, []);
+
+  const handleCancelDownload = useCallback(async () => {
+    const result = await window.clawwork.cancelUpdateDownload();
+    if (result.ok) {
+      setUpdateState('available');
+      setDownloadPercent(0);
     }
   }, []);
 
@@ -262,9 +270,20 @@ export default function AboutSection() {
         {updateState === 'downloading' && (
           <div className="px-5 py-4">
             <div className="rounded-lg px-4 py-3 bg-[var(--bg-tertiary)] border border-[var(--border)]">
-              <p className="type-body mb-2 text-[var(--text-secondary)]">
-                {t('settings.downloadProgress', { percent: downloadPercent })}
-              </p>
+              <div className="flex items-center justify-between gap-3 mb-2">
+                <p className="type-body text-[var(--text-secondary)]">
+                  {t('settings.downloadProgress', { percent: downloadPercent })}
+                </p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleCancelDownload}
+                  className="gap-1.5 h-7 px-2 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                >
+                  <X size={14} />
+                  {t('settings.cancelDownload')}
+                </Button>
+              </div>
               <div className="h-2 rounded-full bg-[var(--bg-hover)] overflow-hidden">
                 <div
                   className="h-full rounded-full bg-[var(--accent)] transition-all duration-300"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
+      builder-util-runtime:
+        specifier: 9.5.1
+        version: 9.5.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
## Summary

Adds a Cancel button to the in-settings update download UI so users can abort an in-progress download and immediately retry or walk away. Previously, once `Download Update` was tapped the only exits were to let the download finish or force-quit the app.

## Type of change

- [x] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

A download can take several minutes on slow networks, and users had no way to back out once started. The only feedback was a progress bar with no escape hatch — reported as confusing UX. `electron-updater` supports cancellation via `CancellationToken`; this PR exposes that capability end-to-end.

## What changed?

- Main process holds a `CancellationToken` while `autoUpdater.downloadUpdate(token)` is in flight; on cancel, state resets to `'available'` so the user can retry without re-running the update check.
- New IPC `app:cancel-update-download` bridged through preload as `cancelUpdateDownload()`.
- Renderer's download progress panel grows a ghost `Cancel` button (X icon + label) to the right of the percentage.
- Added `builder-util-runtime: 9.5.1` as a direct dependency to import `CancellationToken` (version pinned to match electron-updater 6.8.3's transitive pin).
- Added `settings.cancelDownload` translation key to all 8 locale files.

## Architecture impact

- Owning layer: main (updater lifecycle), preload (bridge surface), renderer (UI)
- Cross-layer impact: yes — new IPC channel follows the existing `app:*` update family pattern (check / download / install), additive only
- Invariants touched from `docs/architecture-invariants.md`: none — no new globals, no session-key changes, preload bridge stays minimal
- Why those invariants remain protected: the CancellationToken lives in main process only; the renderer only ever sees `{ ok, error }` through the existing IPC result convention

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check → all green (lint + architecture + ui-contract + renderer-copy + i18n + dead-code + format + typecheck + typecheck:tests + test)
i18n key parity: OK across all 7 non-en locales
tests: 39 desktop / 4 pwa / 4 core / 2 shared test files, 237+61+73+12 passed

Not manually smoke-tested in a packaged build: auto-updater is gated by
`isAutoUpdaterAvailable()` which returns false outside packaged builds,
so this needs a release build to exercise end-to-end. The cancel path
itself is small and mirrors the existing download/install IPC shape.
```

## Screenshots or recordings

No static screenshot attached — the new element is an X-icon ghost button that appears only while a download is active (state === `'downloading'`), aligned to the right of the percentage label inside the existing `bg-[var(--bg-tertiary)]` panel. It uses `var(--text-muted)` → `var(--text-primary)` on hover to match the project's existing ghost-button treatment (see `SettingsSidebar` and `ChatInput` ghost buttons for the canonical style). No new design tokens were introduced.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Settings: you can now cancel an in-progress app-update download. The cancel button appears next to the download progress and returns the UI to the "update available" state so you can retry immediately.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
