### PR TITLE
[Fix] Restore DevTools shortcut when Developer Mode is enabled

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, shell, BrowserWindow, Menu, ipcMain, globalShortcut, dialog, protocol } from 'electron';
 import { join } from 'path';
-import { electronApp, optimizer, is } from '@electron-toolkit/utils';
+import { electronApp, is } from '@electron-toolkit/utils';
 import { nativeTheme } from 'electron';
 import { initAllGateways, destroyAllGateways } from './ws/index.js';
 import { getMainWindow, setMainWindow } from './window-manager.js';
@@ -34,6 +34,7 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 let isQuitting = false;
+let devModeEnabled = false;
 
 process.stdout?.on?.('error', () => {});
 process.stderr?.on?.('error', () => {});
@@ -97,8 +98,8 @@ function buildAppMenu(devMode = false): Menu {
 
 function createWindow(): BrowserWindow {
   getDebugLogger().info({ domain: 'app', event: 'app.window.create' });
-  const devMode = readConfig()?.devMode === true;
-  Menu.setApplicationMenu(buildAppMenu(devMode));
+  devModeEnabled = readConfig()?.devMode === true;
+  Menu.setApplicationMenu(buildAppMenu(devModeEnabled));
 
   const win = new BrowserWindow({
     width: 1280,
@@ -136,13 +137,21 @@ function createWindow(): BrowserWindow {
     win.show();
   });
 
-  win.webContents.on('before-input-event', (_event, input) => {
-    if (!(input.meta || input.control) || input.type !== 'keyDown') return;
-    if (input.key === '-' || input.key === '_') {
+  win.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown') return;
+
+    if ((input.meta || input.control) && (input.key === '-' || input.key === '_')) {
       const level = win.webContents.getZoomLevel() - 0.5;
       win.webContents.setZoomLevel(level);
       updateConfig({ zoomLevel: level });
+      event.preventDefault();
+      return;
     }
+
+    if (is.dev || devModeEnabled) return;
+
+    const isReload = input.key === 'F5' || ((input.meta || input.control) && input.code === 'KeyR');
+    if (isReload) event.preventDefault();
   });
 
   win.on('blur', () => {
@@ -192,10 +201,6 @@ if (!gotLock) {
     getDebugLogger().info({ domain: 'app', event: 'app.start', data: { userData: app.getPath('userData') } });
     electronApp.setAppUserModelId('com.clawwork.app');
 
-    app.on('browser-window-created', (_, window) => {
-      optimizer.watchWindowShortcuts(window);
-    });
-
     registerWsHandlers();
     registerArtifactHandlers();
     registerInboxHandlers();
@@ -217,8 +222,8 @@ if (!gotLock) {
     registerHubHandlers();
 
     ipcMain.handle('app:rebuild-menu', () => {
-      const dm = readConfig()?.devMode === true;
-      Menu.setApplicationMenu(buildAppMenu(dm));
+      devModeEnabled = readConfig()?.devMode === true;
+      Menu.setApplicationMenu(buildAppMenu(devModeEnabled));
     });
 
     ipcMain.on('ui:set-window-button-visibility', (_event, visible: boolean) => {


### PR DESCRIPTION
## Summary

Make the DevTools keyboard shortcut actually work in packaged builds when developer mode is enabled. Previously `@electron-toolkit/utils.optimizer.watchWindowShortcuts` silently blocked `F12` / `Cmd+Alt+I` / `Ctrl+Shift+I` whenever `is.dev` was false, so the runtime developer-mode toggle in Settings → About → tap version N times never re-enabled the DevTools hotkey — only the menu click worked.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The project has a runtime developer-mode toggle (5-tap on the version number), which rebuilds the application menu to include `reload` and `toggleDevTools` items. `optimizer.watchWindowShortcuts` is built on the assumption that `dev` vs `prod` is a compile-time binary (`is.dev`). That assumption is incompatible with the runtime toggle, and the library does not expose any way to feed it the current devMode state. The net effect in a packaged build:

- Menu path: works (user can click View → Toggle Developer Tools)
- Keyboard path: swallowed by `before-input-event.preventDefault()` inside optimizer — no way to recover

Fighting the library with an external `if` is a workaround. The correct fix is to take ownership of the shortcut policy, which is what Electron's native menu accelerator already provides for free.

## What changed?

- Remove `optimizer.watchWindowShortcuts(window)` from `app.on('browser-window-created', ...)`. The entire `browser-window-created` handler is deleted (optimizer was its only body).
- DevTools availability is now driven purely by the `toggleDevTools` menu role. `buildAppMenu(devMode)` already conditionally adds the role based on `devMode || is.dev`; the accelerator is registered/unregistered automatically by Electron when `app:rebuild-menu` IPC rebuilds the menu after a devMode toggle.
- Extend the existing single `before-input-event` handler in `createWindow()` to cover reload protection as well as zoom:
  - `Cmd/Ctrl + -` / `_` → custom zoom out (existing behavior, preserved)
  - `F5` / `Cmd+R` / `Ctrl+R` → `event.preventDefault()` only when `!is.dev && !devModeEnabled` (prevents accidental state loss in production for non-developers; developers with devMode on get reload back)
  - DevTools keys are intentionally NOT handled here — the menu accelerator owns them exclusively.
- Cache the current devMode in a module-level `devModeEnabled` variable. It is initialized in `createWindow()` and refreshed in the `app:rebuild-menu` IPC handler, so `before-input-event` never does synchronous config-file IO on every keystroke.

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: this change is contained entirely within `packages/desktop/src/main/index.ts`. No IPC surface added, no preload contract touched, no renderer code modified. The existing `app:rebuild-menu` IPC is unchanged in signature; only its body now refreshes the cache alongside the existing menu rebuild.

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check  # all 11 gates pass:
# lint + architecture + ui-contract + renderer-copy + i18n + knip +
# prettier + typecheck + typecheck:tests + typecheck:e2e + test (383 tests)
```

Manual verification still recommended by the reviewer on a packaged build:
1. Default (devMode off) in packaged app: `Cmd+Alt+I` does nothing, `Cmd+R` does nothing.
2. Enable devMode via Settings → About → tap version 7 times: `Cmd+Alt+I` opens DevTools, `Cmd+R` reloads the window.
3. Disable devMode: both hotkeys become inert again without restarting the app.

## Screenshots or recordings

Not applicable — main-process keyboard policy change, no UI surface.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
[Fix] DevTools keyboard shortcut (Cmd+Alt+I / Ctrl+Shift+I / F12) now works in packaged builds when Developer Mode is enabled in Settings → About.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
