### PR TITLE
Security: Unbounded base64 decode in inbox save can cause memory/disk exhaustion

### DIFF
--- a/packages/desktop/src/main/ipc/inbox-handlers.ts
+++ b/packages/desktop/src/main/ipc/inbox-handlers.ts
@@ -3,12 +3,21 @@ import { saveInboxAttachment } from '../inbox/save.js';
 import { readInboxFile, resolveInboxPath } from '../inbox/resolve.js';
 import { getWorkspacePath } from '../workspace/config.js';
 
+const MAX_INBOX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
 export function registerInboxHandlers(): void {
   ipcMain.handle('inbox:save', async (_event, params: { taskId: string; fileName: string; base64: string }) => {
     const workspacePath = getWorkspacePath();
     if (!workspacePath) return { ok: false, error: 'workspace not configured' };
     try {
-      const buffer = Buffer.from(params.base64, 'base64');
+      const base64 = params.base64.trim();
+      const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+      const estimatedBytes = Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+      if (estimatedBytes > MAX_INBOX_ATTACHMENT_BYTES) return { ok: false, error: 'attachment too large' };
+
+      const buffer = Buffer.from(base64, 'base64');
+      if (buffer.length > MAX_INBOX_ATTACHMENT_BYTES) return { ok: false, error: 'attachment too large' };
+
       const result = await saveInboxAttachment({
         workspacePath,
         taskId: params.taskId,


### PR DESCRIPTION
## Summary

Security: Unbounded base64 decode in inbox save can cause memory/disk exhaustion

## Problem

**Severity**: `Medium` | **File**: `packages/desktop/src/main/ipc/inbox-handlers.ts:L7`

`inbox:save` decodes attacker-controlled base64 directly with `Buffer.from(params.base64, 'base64')` and writes it to disk without enforcing a size limit. A malicious renderer can submit very large payloads to trigger excessive memory allocation and/or fill disk space (local DoS).

## Solution

Enforce strict maximum payload/file sizes before decoding, reject oversized requests early, and consider streaming writes instead of buffering entire content in memory. Return structured errors when limits are exceeded.

## Changes

- `packages/desktop/src/main/ipc/inbox-handlers.ts` (modified)