### PR TITLE
fix(db): throw instead of silently ignoring initDatabase with differe…

### DIFF
--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -8,6 +8,7 @@ import { initFTS } from './fts.js';
 
 let db: ReturnType<typeof drizzle> | null = null;
 let sqlite: Database.Database | null = null;
+let initializedWorkspacePath: string | null = null;
 
 const CREATE_TABLES_SQL = `
 CREATE TABLE IF NOT EXISTS tasks (
@@ -107,12 +108,19 @@ function openDatabaseAt(workspacePath: string): void {
 }
 
 export function initDatabase(workspacePath: string): void {
-  if (db) return;
+  if (db) {
+    if (initializedWorkspacePath !== workspacePath) {
+      throw new Error('initDatabase called with different workspace path; use reinitDatabase to switch');
+    }
+    return;
+  }
+  initializedWorkspacePath = workspacePath;
   openDatabaseAt(workspacePath);
 }
 
 export function reinitDatabase(workspacePath: string): void {
   closeDatabase();
+  initializedWorkspacePath = workspacePath;
   openDatabaseAt(workspacePath);
 }
 
@@ -133,4 +141,5 @@ export function closeDatabase(): void {
   sqlite?.close();
   sqlite = null;
   db = null;
+  initializedWorkspacePath = null;
 }

--- a/packages/desktop/test/db.test.ts
+++ b/packages/desktop/test/db.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initDatabase, reinitDatabase, closeDatabase } from '../src/main/db/index.js';
+import Database from 'better-sqlite3';
+
+const mockDbInstance = {
+  pragma: vi.fn(),
+  exec: vi.fn(),
+  close: vi.fn(),
+};
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(() => mockDbInstance),
+}));
+
+describe('initDatabase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    closeDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  it('opens database on first call', () => {
+    expect(() => initDatabase('/tmp/workspace-a')).not.toThrow();
+    expect(Database).toHaveBeenCalled();
+  });
+
+  it('returns early when called with same path', () => {
+    initDatabase('/tmp/workspace-a');
+    vi.clearAllMocks();
+    expect(() => initDatabase('/tmp/workspace-a')).not.toThrow();
+    expect(Database).not.toHaveBeenCalled();
+  });
+
+  it('throws when called with different workspace path', () => {
+    initDatabase('/tmp/workspace-a');
+    expect(() => initDatabase('/tmp/workspace-b')).toThrow(
+      'initDatabase called with different workspace path; use reinitDatabase to switch',
+    );
+  });
+
+  it('allows init after close', () => {
+    initDatabase('/tmp/workspace-a');
+    closeDatabase();
+    vi.clearAllMocks();
+    expect(() => initDatabase('/tmp/workspace-b')).not.toThrow();
+  });
+
+  it('throws when init is called with old path after reinit with new path', () => {
+    initDatabase('/tmp/workspace-a');
+    reinitDatabase('/tmp/workspace-b');
+    expect(() => initDatabase('/tmp/workspace-a')).toThrow(
+      'initDatabase called with different workspace path; use reinitDatabase to switch',
+    );
+  });
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                                                
                                                                                                                                                                                                          
  `initDatabase` now tracks the workspace path used on first initialization. Previously, calling it a second time with a different path was silently ignored (short-circuited by `if (db) return`), causing 
  writes to continue going to the original database with no feedback. Now it throws an explicit error guiding callers to use `reinitDatabase` instead.                                                      
                                                                                                                                                                                                            
  ## Type of change                                         

  - [ ] `[Feat]` new feature
  - [x] `[Fix]` bug fix
  - [ ] `[UI]` UI or UX change                                                                                                                                                                              
  - [ ] `[Docs]` documentation-only change
  - [ ] `[Refactor]` internal cleanup                                                                                                                                                                       
  - [ ] `[Build]` CI, packaging, or tooling change          
  - [ ] `[Chore]` maintenance
                                                                                                                                                                                                            
  ## Why is this needed?
                                                                                                                                                                                                            
  Issue #392: After `initDatabase('/a')`, calling `initDatabase('/b')` was silently ignored. Writes kept going to `/a`'s database, making it very painful to debug "why aren't my writes showing up."       
  
  ## What changed?                                                                                                                                                                                          
                                                            
  - `packages/desktop/src/main/db/index.ts`: Added `initializedWorkspacePath` variable. `initDatabase` now detects path mismatches and throws. `reinitDatabase` and `closeDatabase` also sync reset this    
  variable.
  - `packages/desktop/test/db.test.ts`: Added 5 unit tests covering all scenarios.                                                                                                                          
                                                            
  ## Architecture impact                                                                                                                                                                                    
  
  - Owning layer: main                                                                                                                                                                                      
  - Cross-layer impact: none                                
  - Invariants touched: none

  ## Linked issues

  Closes #392

  ## Validation

  - [x] `pnpm lint`
  - [x] `pnpm test` — 97 passed
  - [x] `pnpm typecheck`                                                                                                                                                                                    
  - [ ] `pnpm build`
  - [ ] Manual smoke test                                                                                                                                                                                   
                                                            
  ## Screenshots or recordings

  No UI changes.                                                                                                                                                                                            
  
  ## Release note                                                                                                                                                                                           
                                                            
  ```release-note
  Fixed: initDatabase now throws an explicit error instead of silently ignoring a different workspace path, guiding callers to use reinitDatabase.

  Checklist

  - All commits are signed off (git commit -s) — note: need to amend with -s                                                                                                                                
  - PR title uses approved prefix fix(db): ...
  - Summary explains what changed and why                                                                                                                                                                   
  - Architecture impact described                           
  - Cross-layer changes justified                                                                                                                                                                           
  - Release note accurate    