### PR TITLE
[Docs] Add zh/zh-TW/ja/ko README translations and dedupe English README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,253 @@
+<div align="center">
+
+<table border="0" cellspacing="0" cellpadding="0"><tr>
+<td><img src="./docs/screenshot.png" alt="ClawWork Desktop" height="420" /></td>
+<td><img src="https://github.com/user-attachments/assets/3dd775d0-8441-45d9-92f5-19e843f793c4" alt="ClawWork PWA" height="420" /></td>
+</tr></table>
+
+[English](./README.md) · [简体中文](./README.zh.md) · [繁體中文](./README.zh-TW.md) · **日本語** · [한국어](./README.ko.md)
+
+# ClawWork
+
+**Agent OS 時代のための、ローカルファースト・ワークスペース。**
+
+[OpenClaw](https://github.com/openclaw/openclaw) のデスクトップクライアント —— エージェントのタスクを並列実行し、アーティファクトを永続化し、ファイルを見失わない。
+
+[![GitHub release](https://img.shields.io/github/v/release/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork/releases/latest)
+[![License](https://img.shields.io/github/license/clawwork-ai/clawwork?style=flat-square)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork)
+
+[ダウンロード](#ダウンロード) · [**PWA**](https://cpwa.pages.dev) · [クイックスタート](#クイックスタート) · [Teams](#teams) · [機能一覧](#機能一覧) · [データとアーキテクチャ](#データとアーキテクチャ) · [リポジトリ構成](#リポジトリ構成) · [Roadmap](#roadmap) · [コントリビュート](#コントリビュート) · [Keynote](https://clawwork-ai.github.io/ClawWork/keynote/)
+
+</div>
+
+> **⚠️ 公式リポジトリ**
+> これは ClawWork の**公式**プロジェクトです: https://github.com/clawwork-ai/clawwork
+>
+> ClawWork の名称を無断使用した類似リポジトリ (ClawWorkAi/ClawWork) と類似サイト (clawworkai.store) が見つかっています。上記の公式リンクをご利用ください。
+>
+> 公式サイト: https://clawwork-ai.github.io/ClawWork/
+
+> **📝 翻訳ステータス**
+> この日本語訳はコミュニティによるドラフト版です。不自然な表現が残っている可能性があります。ネイティブスピーカーによるレビューと [Pull Request](https://github.com/clawwork-ai/clawwork/pulls) を歓迎します。
+
+## なぜ ClawWork なのか
+
+**エージェントは増え続けている。ボトルネックはもはや能力ではなく、オペレーターの操作面だ。**
+
+Agent Runtime が次々と登場する中、ユーザーはチャットウィンドウ、Web UI、ターミナルを行き来させられ、それぞれが独自のコンテキストを持ち、共有メモリは存在しない。IDE がコードのオペレーター層となり、ターミナルが Unix のオペレーター層となったように、Agent OS にもワークスペース層が必要だ。ClawWork はまさにその層を築いている —— OpenClaw の最良のクライアントとして出発し、マルチランタイムの未来へと拡張していく。
+
+### 今： OpenClaw を、チャット履歴の沼から救う
+
+OpenClaw は強力だが、プレーンなチャットは、その実力を容れるには悪い器だ。
+
+複数セッション、長時間実行ジョブ、承認待ち、生成されたファイル、繰り返し実行される自動化、複数のゲートウェイ —— これらが重なった瞬間、チャット履歴は泥沼になる。ステータスが消える。ファイルが消える。コンテキストが消える。
+
+ClawWork はそれを解決する。タスクはすべて、独立したセッション・アーティファクト・制御・履歴を持つ永続的なワークスペースとなり、3 ペインのレイアウトに配置される: 左はタスク一覧、中央は進行中の作業、右はアーティファクトとコンテキスト。
+
+## Teams
+
+1 体のエージェントは便利。協調するエージェントチームは、労働力になる。
+
+ClawWork Teams は、複数のエージェントを 1 つのデプロイ可能な単位にまとめる —— ロール、パーソナリティ、スキル、ワークフローを含めて。**Coordinator** エージェントがタスクを分解し、**Worker** エージェントに委譲する。各 Worker は自分のサブセッションで動き、あなたはその全オーケストレーションをリアルタイムに観察できる。
+
+```
+skill → agent → team
+```
+
+### Team の構造
+
+```
+teams/clawwork-dev/
+├── TEAM.md                  # チームのメタデータとワークフロー
+└── agents/
+    ├── manager/             # coordinator —— チームを統括
+    │   ├── IDENTITY.md      # ロールとプロンプト
+    │   ├── SOUL.md          # パーソナリティとスタイル
+    │   └── skills.json      # スキル依存
+    ├── architect/            # worker —— 設計を担当
+    ├── frontend-dev/         # worker —— UI を構築
+    ├── core-dev/             # worker —— コアロジックを構築
+    └── ...
+```
+
+### Team を手に入れる 3 つの方法
+
+- **[TeamsHub](https://github.com/clawwork-ai/teamshub-community)** —— Git ネイティブなレジストリから、コミュニティ製の Team を探してインストール。
+- **手動で作る** —— ウィザードで Agent、アイデンティティ、スキルを段階的に定義。
+- **AI Builder** —— やりたいことを言葉で説明すると、LLM が Team の構造、ロール、プロンプトを設計してくれる。
+
+インストール後は、タスク作成時に Team を選ぶだけ。Coordinator が後を引き継ぐ。
+
+## ダウンロード
+
+### Homebrew (macOS)
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+### リリース版
+
+macOS、Windows、Linux のビルド済みバイナリは [Releases ページ](https://github.com/clawwork-ai/clawwork/releases/latest) から入手できます。アプリは自動アップデート —— バックグラウンドで新バージョンをダウンロードし、終了時にインストールします。
+
+### PWA (ブラウザ)
+
+インストール不要 —— モダンブラウザで **[cpwa.pages.dev](https://cpwa.pages.dev)** を開くだけ。デスクトップとモバイルの両方で動作し、ホーム画面に追加できます。
+
+## クイックスタート
+
+1. OpenClaw Gateway を起動する。
+2. ClawWork を開き、設定から gateway を追加。token、パスワード、またはペアリングコードで認証する。デフォルトのローカルエンドポイント: `ws://127.0.0.1:18789`。
+3. タスクを作成し、gateway とエージェントを選び、作業内容を記述する。
+4. チャットする: メッセージ送信、画像添付、`@` によるファイル参照、`/` コマンド。
+5. タスクの実行を追い、ツールの動きを確認し、出力ファイルを手元に残す。
+
+## 機能一覧
+
+### ⚡ タスクファーストなワークフロー
+
+- タスクを並列実行、それぞれが独立した OpenClaw セッション —— アーカイブしたタスクは後で再開可能
+- gateway ごとのセッションカタログ
+- 実用的なセッション制御: 停止、リセット、圧縮、削除、同期
+- バックグラウンドの作業が読みやすく、1 本の長いスレッドに潰れない
+- `cron`、`every`、`at` 式でタスクをスケジュール —— プリセットから選ぶか自前で書き、実行履歴を確認し、いつでも手動トリガー可能
+- セッションを Markdown にエクスポートして、アプリ外にクリーンな記録を残す
+
+### 👁 ひと目でわかる
+
+- リアルタイムのストリーミング応答
+- エージェントの作業中にインラインで表示されるツール呼び出しカード
+- サイドパネルに進捗とアーティファクト
+- 使用状況が一目でわかる —— gateway ごとの使用状況、セッションごとのコスト内訳、30 日ローリングのダッシュボード
+
+### 🎛 より良いコントロール
+
+- マルチ gateway 対応
+- タスクごとにエージェントとモデルを切り替え
+- エージェントを直接管理 —— アプリを離れずに作成、編集、削除、ワークスペース内ファイルの閲覧
+- 各 gateway のツールカタログを閲覧して、エージェントが触れる範囲を把握
+- 思考レベルの制御と slash コマンド
+- 機微な実行操作には事前承認プロンプト
+- バックグラウンドの出来事を通知 —— タスク完了、承認要求、gateway の切断 —— 通知をクリックすればタスクへジャンプ。イベント種別ごとにオン／オフでき、ノイズは自分で制御できます。
+
+### 📂 より良いファイル処理
+
+- 実用的なコンテキスト: 画像、`@` ファイル参照、音声入力、監視フォルダ
+- 最大 10 フォルダを監視、変更を自動検出して再インデックス —— コンテキストは常に最新
+- ローカルへのアーティファクト保存
+- アシスタント応答内のコードブロックとリモート画像を自動抽出してワークスペースに保存 —— 手動コピペ不要
+- タスク、メッセージ、アーティファクトを横断する全文検索
+
+### 🖥 より良いデスクトップ体験
+
+- システムトレイ対応
+- グローバルショートカットで呼び出せるクイックランチャーウィンドウ (既定 `Alt+Space`、カスタマイズ可)
+- アプリ全体でキーボードショートカット
+- バックグラウンドで自動アップデート —— 設定画面で進捗を確認でき、終了時にインストール
+- 読みやすさに合わせて UI をズーム、設定は記憶される
+- ライト／ダークテーマ + 8 言語対応
+
+### 🔧 デバッグ
+
+- 何か起きたときに、デバッグバンドル (ログ、gateway ステータス、機密を除いた設定) をエクスポート —— バグ報告に便利
+- 接続中の Gateway サーバーのバージョンを設定画面に表示
+
+## データとアーキテクチャ
+
+ClawWork は単一の Gateway WebSocket 接続で OpenClaw と通信します。タスクごとに独自のセッションキーを持って隔離され、すべてのデータはあなたが選んだローカルのワークスペースディレクトリに保存されます —— クラウド同期なし、外部データベースなし。
+
+- **Tasks** —— タスクごとに独立した OpenClaw セッションが 1 対 1 で対応。並列作業が衝突しない。
+- **Messages** —— ユーザー／アシスタント／システムメッセージ (ツール呼び出しや画像添付を含む) をすべてローカル永続化。
+- **Artifacts** —— エージェントが生成したコードブロック、画像、ファイル。アシスタント出力から自動抽出されるので失われない。
+- **全文検索** —— 上記すべてを横断検索。どのタスクだったか忘れた 3 週間前のスニペットも見つけ出せます。
+
+<div align="center">
+<img src="./docs/architecture.svg" alt="ClawWork Architecture" width="840" />
+</div>
+
+## リポジトリ構成
+
+```
+packages/shared/       — プロトコル型、定数 (依存ゼロ)
+packages/core/         — 共有ビジネスロジック: stores、services、ports
+packages/desktop/
+  src/main/            — Electron メイン: gateway WS、IPC、DB、artifacts、OS 連携
+  src/preload/         — 型付き window.clawwork ブリッジ
+  src/renderer/        — React UI: components、layouts、stores、hooks、i18n
+packages/pwa/          — Progressive Web App (ブラウザ + モバイル)
+docs/                  — 設計ドキュメント、アーキテクチャ不変条件
+e2e/                   — Playwright E2E テスト (スモーク + gateway 統合)
+scripts/               — ビルドとチェック用スクリプト
+website/               — プロジェクトサイト (React + Vite)
+keynote/               — プレゼン資料 (Slidev)
+```
+
+## 技術スタック
+
+Electron 34、React 19、TypeScript、Tailwind CSS v4、Zustand、SQLite (Drizzle ORM + better-sqlite3)、Framer Motion。
+
+## プラットフォームに関する注意
+
+- 音声入力にはローカルの [whisper.cpp](https://github.com/ggerganov/whisper.cpp) バイナリとモデルが必要です。
+- 自動アップデートはパッケージ版のみ有効。開発モードではスキップされます。
+- コンテキストフォルダ監視: 最大 10 ディレクトリ、深さ 4 階層、ファイルサイズ 10 MB まで。
+
+## Roadmap
+
+### ✅ リリース済み
+
+- タスクごとのセッション隔離による並列実行
+- マルチ gateway 認証 (token、パスワード、ペアリングコード)
+- cron スケジュールタスク + 実行履歴
+- gateway とセッションを横断する使用量／コストダッシュボード
+- タスク、メッセージ、アーティファクトを横断する全文検索
+- Teams と TeamsHub —— マルチエージェント編成の構築、共有、インストール
+- Skills (ClawHub 経由) —— 発見とインストール
+- AI Builder —— LLM による Team 作成補助
+- PWA のオフラインサポートとモバイル UI ([cpwa.pages.dev](https://cpwa.pages.dev))
+- クロスプラットフォーム: macOS、Windows、Linux (AppImage + deb)、自動アップデート付き
+
+### 🔮 次に来るもの
+
+- 会話のブランチ分岐
+- アーティファクトの diff ビュー
+- カスタムテーマ
+- 繰り返しワークフローのためのセッションテンプレート
+- Skills、Teams、Adapters の拡張 API ドキュメント
+
+### 🌐 ビジョン —— Agent OS のワークスペース層
+
+ClawWork は現時点では OpenClaw に最適化されています。私たちが目指すのは、ワークスペース層がランタイム非依存になる未来 —— ひとつのオペレーター面で、あなたが触れるあらゆるエージェントを扱えるようにする。
+
+- **マルチランタイム・アダプタ** —— 他のランタイムのエージェントを、同一の task / session / artifact モデルに取り込む
+- **より豊かなチームオーケストレーション** —— coordinator / worker を超える協調パターン
+- **エンタープライズ対応のローカルファースト** —— ローカルデータの所有権を手放さずに、より強いデータ境界とチーム協働パターンを提供
+
+項目はスコープが固まると _次に来るもの_ へ上がります。このセクションは時期の約束ではありません。
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+
+## コントリビュート
+
+参加方法:
+
+- セットアップとプロジェクト構成は [DEVELOPMENT.md](DEVELOPMENT.md) を参照
+- [Issues](https://github.com/clawwork-ai/clawwork/issues) を確認
+- [Pull Request](https://github.com/clawwork-ai/clawwork/pulls) を作成
+- 提出前に `pnpm check` を実行 —— lint、アーキテクチャ、UI 契約、レンダラー文言、i18n、デッドコード、フォーマット、型、テストをまとめてチェックします。
+
+翻訳は英語版より遅れることがあります。ズレを見つけたら PR を歓迎します。
+
+## License
+
+[Apache 2.0](LICENSE)
+
+<div align="center">
+
+[OpenClaw](https://github.com/openclaw/openclaw) のために作られています。[Peter Steinberger](https://github.com/steipete) の素晴らしい仕事に敬意を表して。
+
+</div>

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,253 @@
+<div align="center">
+
+<table border="0" cellspacing="0" cellpadding="0"><tr>
+<td><img src="./docs/screenshot.png" alt="ClawWork Desktop" height="420" /></td>
+<td><img src="https://github.com/user-attachments/assets/3dd775d0-8441-45d9-92f5-19e843f793c4" alt="ClawWork PWA" height="420" /></td>
+</tr></table>
+
+[English](./README.md) · [简体中文](./README.zh.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · **한국어**
+
+# ClawWork
+
+**Agent OS 시대를 위한 로컬 우선 워크스페이스.**
+
+[OpenClaw](https://github.com/openclaw/openclaw)의 데스크톱 클라이언트 —— 에이전트 태스크를 병렬로 실행하고, 아티팩트를 영구 보존하며, 파일을 잃어버리지 않습니다.
+
+[![GitHub release](https://img.shields.io/github/v/release/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork/releases/latest)
+[![License](https://img.shields.io/github/license/clawwork-ai/clawwork?style=flat-square)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork)
+
+[다운로드](#다운로드) · [**PWA**](https://cpwa.pages.dev) · [빠른 시작](#빠른-시작) · [Teams](#teams) · [주요 기능](#주요-기능) · [데이터 & 아키텍처](#데이터--아키텍처) · [저장소 구조](#저장소-구조) · [Roadmap](#roadmap) · [기여](#기여) · [Keynote](https://clawwork-ai.github.io/ClawWork/keynote/)
+
+</div>
+
+> **⚠️ 공식 저장소**
+> 이것은 ClawWork의 **공식** 프로젝트입니다: https://github.com/clawwork-ai/clawwork
+>
+> ClawWork 이름을 무단으로 사용한 유사 저장소(ClawWorkAi/ClawWork)와 유사 사이트(clawworkai.store)가 발견되었습니다. 위의 공식 링크를 이용해 주세요.
+>
+> 공식 사이트: https://clawwork-ai.github.io/ClawWork/
+
+> **📝 번역 상태**
+> 이 한국어 번역은 커뮤니티 초안입니다. 어색한 표현이 남아 있을 수 있습니다. 네이티브 스피커의 리뷰와 [Pull Request](https://github.com/clawwork-ai/clawwork/pulls)를 환영합니다.
+
+## 왜 ClawWork인가
+
+**에이전트는 계속 늘어나고 있다. 병목은 더 이상 능력이 아니라, 오퍼레이터의 조작 면이다.**
+
+Agent Runtime이 우후죽순 등장하면서, 사용자는 채팅 창, 웹 UI, 터미널 사이를 왔다 갔다 해야 하고, 각자가 자신의 컨텍스트를 가지며, 서로 공유되는 메모리는 없습니다. IDE가 코드의 오퍼레이터 계층이 되었고 터미널이 Unix의 오퍼레이터 계층이 된 것처럼, Agent OS 또한 워크스페이스 계층이 필요합니다. ClawWork는 바로 그 계층을 만들고 있습니다 —— OpenClaw를 위한 최상의 클라이언트로 출발하여, 멀티 런타임의 미래로 확장해 나갑니다.
+
+### 지금: OpenClaw, 채팅 기록의 늪에서 구하기
+
+OpenClaw는 강력합니다. 그러나 순수한 채팅은 그 역량을 담아내기엔 나쁜 그릇입니다.
+
+여러 세션, 장시간 실행되는 작업, 승인 대기, 생성된 파일, 반복되는 자동화, 여러 게이트웨이 —— 이 모든 것이 겹치는 순간, 채팅 기록은 진흙탕이 됩니다. 상태가 사라집니다. 파일이 사라집니다. 컨텍스트가 사라집니다.
+
+ClawWork는 이 문제를 해결합니다. 모든 태스크는 독립된 세션, 아티팩트, 제어, 히스토리를 가진 영속적인 워크스페이스가 되고, 3 패널 레이아웃으로 배치됩니다: 왼쪽은 태스크 목록, 가운데는 진행 중인 작업, 오른쪽은 아티팩트와 컨텍스트.
+
+## Teams
+
+에이전트 하나는 유용합니다. 잘 조율된 에이전트 팀은 하나의 노동력이 됩니다.
+
+ClawWork Teams는 여러 에이전트를 하나의 배포 가능한 단위로 묶습니다 —— 역할, 인격, 스킬, 워크플로우를 포함해서. **Coordinator** 에이전트가 태스크를 분해해 **Worker** 에이전트에게 위임하고, 각 Worker는 자신의 서브 세션에서 동작합니다. 전체 오케스트레이션을 실시간으로 확인할 수 있습니다.
+
+```
+skill → agent → team
+```
+
+### Team 구조
+
+```
+teams/clawwork-dev/
+├── TEAM.md                  # 팀 메타데이터와 워크플로우
+└── agents/
+    ├── manager/             # coordinator —— 팀을 조율
+    │   ├── IDENTITY.md      # 역할과 프롬프트
+    │   ├── SOUL.md          # 인격과 스타일
+    │   └── skills.json      # 스킬 의존성
+    ├── architect/            # worker —— 설계 담당
+    ├── frontend-dev/         # worker —— UI 구축
+    ├── core-dev/             # worker —— 핵심 로직 구축
+    └── ...
+```
+
+### Team을 얻는 세 가지 방법
+
+- **[TeamsHub](https://github.com/clawwork-ai/teamshub-community)** —— Git 네이티브 레지스트리에서 커뮤니티 제공 Team을 탐색하고 설치.
+- **직접 만들기** —— 단계별 마법사로 Agent, 아이덴티티, 스킬을 정의.
+- **AI Builder** —— 원하는 바를 설명하면 LLM이 Team 구조, 역할, 프롬프트를 설계.
+
+설치 후에는 태스크를 만들 때 Team을 고르기만 하면 됩니다. Coordinator가 그다음을 이어받습니다.
+
+## 다운로드
+
+### Homebrew (macOS)
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+### 릴리스
+
+macOS, Windows, Linux 빌드는 [Releases 페이지](https://github.com/clawwork-ai/clawwork/releases/latest)에서 제공됩니다. 앱이 스스로 업데이트합니다 —— 새 버전을 백그라운드에서 내려받고 종료 시 설치합니다.
+
+### PWA (브라우저)
+
+설치 불필요 —— 모던 브라우저에서 **[cpwa.pages.dev](https://cpwa.pages.dev)**를 열기만 하면 됩니다. 데스크톱과 모바일 모두에서 동작하며, 홈 화면에 추가할 수 있습니다.
+
+## 빠른 시작
+
+1. OpenClaw Gateway를 실행합니다.
+2. ClawWork를 열고 설정에서 gateway를 추가합니다. token, 비밀번호, 또는 페어링 코드로 인증합니다. 기본 로컬 엔드포인트: `ws://127.0.0.1:18789`.
+3. 태스크를 만들고 gateway와 에이전트를 선택한 뒤, 작업 내용을 설명합니다.
+4. 채팅: 메시지 전송, 이미지 첨부, `@`로 파일 참조, 또는 `/` 명령 사용.
+5. 태스크 실행을 지켜보고, 도구 동작을 확인하고, 출력 파일을 보관합니다.
+
+## 주요 기능
+
+### ⚡ 태스크 중심의 워크플로우
+
+- 태스크 병렬 실행, 각 태스크마다 격리된 OpenClaw 세션 —— 보관한 태스크도 나중에 다시 열 수 있음
+- gateway별 세션 카탈로그
+- 실질적으로 유용한 세션 제어: 중지, 리셋, 압축, 삭제, 동기화
+- 백그라운드 작업이 긴 하나의 스레드로 뭉개지지 않고 가독성을 유지
+- `cron`, `every`, `at` 표현식으로 태스크 예약 —— 프리셋에서 고르거나 직접 작성, 실행 히스토리 확인, 언제든 수동 트리거 가능
+- 세션을 Markdown으로 내보내서 앱 밖에 깔끔한 기록을 남길 수 있음
+
+### 👁 더 나은 가시성
+
+- 실시간 스트리밍 응답
+- 에이전트 작동 중 인라인으로 표시되는 도구 호출 카드
+- 사이드 패널의 진행 상황 및 아티팩트
+- 지출이 한눈에 —— gateway별 사용량, 세션별 비용 내역, 30일 롤링 대시보드
+
+### 🎛 더 나은 제어
+
+- 멀티 gateway 지원
+- 태스크 단위로 에이전트와 모델 전환
+- 에이전트 직접 관리 —— 앱을 떠나지 않고 생성, 편집, 삭제, 워크스페이스 파일 탐색
+- 각 gateway의 전체 도구 카탈로그 확인 —— 에이전트가 접근할 수 있는 범위를 명확히
+- 추론 수준 제어와 slash 명령
+- 민감한 실행 동작에 대한 사전 승인 프롬프트
+- 백그라운드 이벤트 알림 —— 태스크 완료, 승인 요청, gateway 연결 끊김 —— 알림을 클릭하면 해당 태스크로 이동. 이벤트별로 켜고 끌 수 있어 소음을 직접 제어.
+
+### 📂 더 나은 파일 처리
+
+- 실제로 쓸모 있는 컨텍스트: 이미지, `@` 파일 참조, 음성 입력, 감시 폴더
+- 최대 10개 폴더 감시, 변경을 자동 감지해 재색인 —— 컨텍스트는 항상 최신
+- 로컬 아티팩트 저장
+- 어시스턴트 응답 속 코드 블록과 원격 이미지를 자동 추출해 워크스페이스에 저장 —— 수동 복붙 불필요
+- 태스크, 메시지, 아티팩트를 가로지르는 전문 검색
+
+### 🖥 더 나은 데스크톱 경험
+
+- 시스템 트레이 지원
+- 전역 단축키로 불러오는 퀵 런처 창 (기본 `Alt+Space`, 커스터마이즈 가능)
+- 앱 전반의 키보드 단축키
+- 백그라운드 자동 업데이트 —— 설정에서 진행도를 보고, 종료 시 설치
+- 편안한 수준으로 UI 확대/축소, 설정은 기억됨
+- 라이트/다크 테마 + 8개 언어 지원
+
+### 🔧 디버깅
+
+- 문제가 생겼을 때 디버그 번들(로그, gateway 상태, 비식별화된 설정) 내보내기 —— 버그 신고에 유용
+- 연결된 Gateway 서버 버전을 설정에서 바로 확인
+
+## 데이터 & 아키텍처
+
+ClawWork는 단일 Gateway WebSocket 연결로 OpenClaw와 통신합니다. 태스크마다 자신의 session key로 격리되며, 모든 데이터는 사용자가 선택한 로컬 워크스페이스 디렉터리에 저장됩니다 —— 클라우드 동기화 없음, 외부 데이터베이스 없음.
+
+- **Tasks** —— 태스크마다 독립된 OpenClaw 세션에 대응, 병렬 작업이 충돌하지 않음.
+- **Messages** —— 사용자, 어시스턴트, 시스템 메시지(도구 호출 및 이미지 첨부 포함)를 모두 로컬에 영속화.
+- **Artifacts** —— 에이전트가 만들어낸 코드 블록, 이미지, 파일. 어시스턴트 출력에서 자동 추출되어 유실되지 않음.
+- **전문 검색** —— 위 모든 것을 가로질러 검색. 어느 태스크였는지 기억나지 않는 3주 전의 스니펫도 찾을 수 있음.
+
+<div align="center">
+<img src="./docs/architecture.svg" alt="ClawWork Architecture" width="840" />
+</div>
+
+## 저장소 구조
+
+```
+packages/shared/       — 프로토콜 타입, 상수 (의존성 없음)
+packages/core/         — 공유 비즈니스 로직: stores, services, ports
+packages/desktop/
+  src/main/            — Electron 메인: gateway WS, IPC, DB, artifacts, OS 연동
+  src/preload/         — 타입화된 window.clawwork 브리지
+  src/renderer/        — React UI: components, layouts, stores, hooks, i18n
+packages/pwa/          — Progressive Web App (브라우저 + 모바일)
+docs/                  — 설계 문서, 아키텍처 불변 조건
+e2e/                   — Playwright E2E 테스트 (스모크 + gateway 통합)
+scripts/               — 빌드 및 검사 스크립트
+website/               — 프로젝트 사이트 (React + Vite)
+keynote/               — 프레젠테이션 슬라이드 (Slidev)
+```
+
+## 기술 스택
+
+Electron 34, React 19, TypeScript, Tailwind CSS v4, Zustand, SQLite (Drizzle ORM + better-sqlite3), Framer Motion.
+
+## 플랫폼 참고 사항
+
+- 음성 입력은 로컬 [whisper.cpp](https://github.com/ggerganov/whisper.cpp) 바이너리와 모델이 필요합니다.
+- 자동 업데이트는 패키지 빌드에서만 동작합니다. 개발 모드에서는 건너뜁니다.
+- 컨텍스트 폴더 감시: 최대 10개 디렉터리, 깊이 4단계, 파일당 10 MB까지.
+
+## Roadmap
+
+### ✅ 출시됨
+
+- 태스크별 세션 격리를 갖춘 병렬 실행
+- 멀티 gateway 인증 (token, 비밀번호, 페어링 코드)
+- cron 예약 태스크 + 실행 히스토리
+- gateway와 세션을 가로지르는 사용량 및 비용 대시보드
+- 태스크, 메시지, 아티팩트에 걸친 전문 검색
+- Teams 및 TeamsHub —— 멀티 에이전트 편성 구축, 공유, 설치
+- Skills (ClawHub 기반) —— 탐색 및 설치
+- AI Builder —— LLM 지원 Team 생성
+- PWA 오프라인 지원과 모바일 UI ([cpwa.pages.dev](https://cpwa.pages.dev))
+- 크로스 플랫폼: macOS, Windows, Linux (AppImage + deb), 자동 업데이트 포함
+
+### 🔮 다음 순서
+
+- 대화 분기
+- 아티팩트 diff 뷰
+- 커스텀 테마
+- 반복 워크플로우를 위한 세션 템플릿
+- Skills, Teams, Adapters를 위한 확장 API 문서
+
+### 🌐 비전 —— Agent OS의 워크스페이스 계층
+
+ClawWork는 현재 OpenClaw에 최적화되어 있습니다. 우리가 향하는 미래는 워크스페이스 계층이 런타임에 종속되지 않는 세계입니다 —— 하나의 오퍼레이터 표면이 당신이 다루는 모든 에이전트를 맡는 세계.
+
+- **멀티 런타임 어댑터** —— 다른 런타임의 에이전트를 동일한 task / session / artifact 모델로 흡수
+- **더 풍부한 팀 오케스트레이션** —— coordinator / worker를 넘어서는 협업 패턴
+- **엔터프라이즈 친화적인 로컬 우선** —— 로컬 데이터 소유권을 포기하지 않으면서 더 강력한 데이터 경계와 팀 협업 패턴 제공
+
+범위가 잡힌 항목은 *다음 순서*로 올라갑니다. 이 섹션의 어떤 내용도 일정에 대한 약속이 아닙니다.
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+
+## 기여
+
+참여 방법:
+
+- 셋업과 프로젝트 구조는 [DEVELOPMENT.md](DEVELOPMENT.md)를 참고하세요
+- [Issues](https://github.com/clawwork-ai/clawwork/issues) 확인
+- [Pull Request](https://github.com/clawwork-ai/clawwork/pulls) 생성
+- 제출 전에 `pnpm check` 실행 —— lint, 아키텍처, UI 계약, 렌더러 문구, i18n, 데드 코드, 포맷팅, 타입, 테스트를 일괄 검사합니다.
+
+번역은 영문판보다 뒤처질 수 있습니다. 내용이 어긋난 부분을 발견하시면 PR을 환영합니다.
+
+## License
+
+[Apache 2.0](LICENSE)
+
+<div align="center">
+
+[OpenClaw](https://github.com/openclaw/openclaw)를 위해 만들어졌습니다. [Peter Steinberger](https://github.com/steipete)의 훌륭한 작업에 경의를 표하며.
+
+</div>

--- a/README.md
+++ b/README.md
@@ -5,17 +5,19 @@
 <td><img src="https://github.com/user-attachments/assets/3dd775d0-8441-45d9-92f5-19e843f793c4" alt="ClawWork PWA" height="420" /></td>
 </tr></table>
 
+**English** · [简体中文](./README.zh.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
+
 # ClawWork
 
-**A workspace for [OpenClaw](https://github.com/openclaw/openclaw) — desktop and mobile.**
+**The local-first workspace for the Agent OS era.**
 
-Parallel tasks, structured artifacts, scheduled automation — and files you can actually find later.
+Desktop client for [OpenClaw](https://github.com/openclaw/openclaw) — run agent tasks in parallel, keep artifacts durable, and find your files later.
 
 [![GitHub release](https://img.shields.io/github/v/release/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork/releases/latest)
 [![License](https://img.shields.io/github/license/clawwork-ai/clawwork?style=flat-square)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork)
 
-[Download](#download) · [**PWA**](https://cpwa.pages.dev) · [Quick start](#quick-start) · [Teams](#teams) · [What you get](#what-you-get) · [What it stores](#what-clawwork-stores) · [How it works](#how-it-works) · [Repo layout](#repo-layout) · [Roadmap](#roadmap) · [Contributing](#contributing) · [Keynote](https://clawwork-ai.github.io/ClawWork/keynote/)
+[Download](#download) · [**PWA**](https://cpwa.pages.dev) · [Quick start](#quick-start) · [Teams](#teams) · [What you get](#what-you-get) · [Data & architecture](#data--architecture) · [Repo layout](#repo-layout) · [Roadmap](#roadmap) · [Contributing](#contributing) · [Keynote](https://clawwork-ai.github.io/ClawWork/keynote/)
 
 </div>
 
@@ -27,6 +29,12 @@ Parallel tasks, structured artifacts, scheduled automation — and files you can
 > Official Website: https://clawwork-ai.github.io/ClawWork/
 
 ## Why ClawWork
+
+**Agents are multiplying. The bottleneck is no longer capability — it's the operator surface.**
+
+As agent runtimes proliferate, users end up juggling sessions across chat windows, web UIs, and terminals, each with its own context and no shared memory. Just as IDEs became the operator layer for code and terminals for Unix, the Agent OS needs a workspace layer. ClawWork is building that layer — starting as the best-in-class client for OpenClaw, extensible toward a multi-runtime future.
+
+### Today: OpenClaw, without the chat-history mud
 
 OpenClaw is powerful. Plain chat is a bad container for the kind of work it can do.
 
@@ -68,15 +76,6 @@ teams/clawwork-dev/
 
 Once installed, pick a team when creating a task. The coordinator takes over from there.
 
-## Why it feels better
-
-- Each task runs in its own OpenClaw session, so you can switch between parallel jobs without mixing context.
-- Streaming replies, thinking traces, tool call cards, and artifacts live in one place instead of being buried in chat history.
-- Gateway, agent, model, and thinking settings are scoped per task.
-- Files produced by the agent are saved to a local workspace and stay easy to browse later.
-- Risky exec actions can stop for approval before they run.
-- Scheduled tasks run on their own cadence without you watching.
-
 ## Download
 
 ### Homebrew (macOS)
@@ -92,7 +91,7 @@ Prebuilt macOS, Windows, and Linux builds are available on the [Releases page](h
 
 ### PWA (browser)
 
-No install required — open **[cpwa.pages.dev](https://cpwa.pages.dev)** in any modern browser. Works on desktop and mobile, installable to your home screen. See [#206](https://github.com/clawwork-ai/ClawWork/issues/206) for details and feedback.
+No install required — open **[cpwa.pages.dev](https://cpwa.pages.dev)** in any modern browser. Works on desktop and mobile, installable to your home screen.
 
 ## Quick start
 
@@ -101,7 +100,6 @@ No install required — open **[cpwa.pages.dev](https://cpwa.pages.dev)** in any
 3. Create a task, pick a gateway and agent, and describe the work.
 4. Chat: send messages, attach images, `@` files for context, or use `/` commands.
 5. Follow the task as it runs, inspect tool activity, and keep the output files.
-6. Use search, artifacts, and cron when the work stops being small.
 
 ## What you get
 
@@ -153,18 +151,14 @@ No install required — open **[cpwa.pages.dev](https://cpwa.pages.dev)** in any
 - Export a debug bundle (logs, gateway status, sanitized config) when something goes wrong — useful for bug reports
 - See which Gateway server version you're connected to right in Settings
 
-## What ClawWork stores
+## Data & architecture
 
-Everything lives in a local workspace directory you choose. No cloud sync, no external database.
+ClawWork talks to OpenClaw through a single Gateway WebSocket connection. Each task gets its own session key for isolation, and everything lives in a local workspace directory you choose — no cloud sync, no external database.
 
 - **Tasks** — each one maps to an independent OpenClaw session, so parallel work never collides.
 - **Messages** — user, assistant, and system messages, including tool calls and image attachments, all persisted locally.
 - **Artifacts** — code blocks, images, and files the agent produces. Automatically extracted from assistant output so nothing gets lost.
 - **Full-text search** — search across all of the above. Find that one code snippet from three weeks ago without remembering which task it came from.
-
-## How it works
-
-ClawWork talks to OpenClaw through a single Gateway WebSocket connection. Each task gets its own session key, which keeps concurrent work isolated. Everything — tasks, messages, artifacts, search indexes — is stored locally in your workspace directory.
 
 <div align="center">
 <img src="./docs/architecture.svg" alt="ClawWork Architecture" width="840" />
@@ -199,34 +193,36 @@ Electron 34, React 19, TypeScript, Tailwind CSS v4, Zustand, SQLite (Drizzle ORM
 
 ## Roadmap
 
-✅ Already shipping:
+### ✅ Shipped
 
-- Multi-task parallel execution
-- Multi-gateway with token, password, and pairing code auth
-- Tool call cards and approval dialogs
-- Slash commands and thinking controls
-- File context, artifact browsing, and auto-extract
-- Agent management and tools catalog
-- Scheduled (cron) tasks
-- Usage and cost dashboard
-- Native desktop notifications
-- Folder watcher with auto-reindex
-- Session export and debug bundle export
-- Auto-update
-- Tray, quick launch, and voice input
-- Gateway server version display
+- Multi-task parallel execution with per-task session isolation
+- Multi-gateway auth (token, password, pairing code)
+- Scheduled (cron) tasks with run history
+- Usage and cost dashboard across gateways and sessions
+- Full-text search across tasks, messages, and artifacts
+- Teams and TeamsHub — build, share, and install multi-agent ensembles
+- Skills via ClawHub — discovery and install
+- AI Builder — LLM-assisted team creation
 - PWA with offline support and mobile UI ([cpwa.pages.dev](https://cpwa.pages.dev))
-- Linux packages (AppImage + deb)
-- Teams: create, manage, and orchestrate multi-agent ensembles
-- TeamsHub: Git-native marketplace for discovering and installing team definitions
-- Skills: ClawHub-powered skill discovery and install
-- AI Builder: LLM-assisted team creation
+- Cross-platform: macOS, Windows, Linux (AppImage + deb), with auto-update
 
-🔮 Next up:
+### 🔮 Next up
 
 - Conversation branching
 - Artifact diff view
 - Custom themes
+- Session templates for recurring workflows
+- Extension API documentation for Skills, Teams, and Adapters
+
+### 🌐 Vision — the Workspace layer of the Agent OS
+
+ClawWork today is optimized for OpenClaw. We're building toward a future where the workspace layer is runtime-agnostic — one operator surface for every agent you touch.
+
+- **Multi-runtime adapters** — bring agents from other runtimes into the same task / session / artifact model
+- **Richer team orchestration** — coordination patterns beyond coordinator / worker
+- **Enterprise-friendly local-first** — stronger data boundaries and team collaboration patterns without giving up local data ownership
+
+Items move up into _Next up_ as they get scoped. Nothing in this section is a promise of timing.
 
 ## Star History
 
@@ -234,7 +230,7 @@ Electron 34, React 19, TypeScript, Tailwind CSS v4, Zustand, SQLite (Drizzle ORM
 
 ## Contributing
 
-The project is early and moving fast. If you want to help:
+To contribute:
 
 - Read [DEVELOPMENT.md](DEVELOPMENT.md) for setup and project structure
 - Check [Issues](https://github.com/clawwork-ai/clawwork/issues)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,250 @@
+<div align="center">
+
+<table border="0" cellspacing="0" cellpadding="0"><tr>
+<td><img src="./docs/screenshot.png" alt="ClawWork Desktop" height="420" /></td>
+<td><img src="https://github.com/user-attachments/assets/3dd775d0-8441-45d9-92f5-19e843f793c4" alt="ClawWork PWA" height="420" /></td>
+</tr></table>
+
+[English](./README.md) · [简体中文](./README.zh.md) · **繁體中文** · [日本語](./README.ja.md) · [한국어](./README.ko.md)
+
+# ClawWork
+
+**為 Agent OS 時代打造的本機優先工作區。**
+
+[OpenClaw](https://github.com/openclaw/openclaw) 的桌面客戶端 —— 讓 Agent 任務並行執行、讓 artifacts 不遺失、讓檔案不再消失。
+
+[![GitHub release](https://img.shields.io/github/v/release/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork/releases/latest)
+[![License](https://img.shields.io/github/license/clawwork-ai/clawwork?style=flat-square)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork)
+
+[下載](#下載) · [**PWA**](https://cpwa.pages.dev) · [快速開始](#快速開始) · [Teams](#teams) · [功能特性](#功能特性) · [資料與架構](#資料與架構) · [專案結構](#專案結構) · [Roadmap](#roadmap) · [貢獻](#貢獻) · [Keynote](https://clawwork-ai.github.io/ClawWork/keynote/)
+
+</div>
+
+> **⚠️ 官方儲存庫**
+> 這是 ClawWork 的**官方**專案：https://github.com/clawwork-ai/clawwork
+>
+> 我們發現了山寨儲存庫（ClawWorkAi/ClawWork）與山寨網站（clawworkai.store），未經授權使用 ClawWork 名稱。請認準上方官方連結。
+>
+> 官方網站：https://clawwork-ai.github.io/ClawWork/
+
+## 為什麼選 ClawWork
+
+**Agent 正在爆炸式增長。瓶頸不再是能力，而是操作介面。**
+
+隨著 Agent Runtime 越來越多，使用者被迫在聊天視窗、網頁 UI、終端機之間來回切換，每個都有自己的脈絡，彼此之間沒有共享記憶。正如 IDE 成為了程式碼的操作層、終端機成為了 Unix 的操作層 —— Agent OS 也需要一個工作區層。ClawWork 正在建構這一層：從 OpenClaw 的最佳客戶端起步，朝向多 Runtime 的未來演進。
+
+### 現在：OpenClaw，從此不再被聊天紀錄淹沒
+
+OpenClaw 本身很強，但純聊天是糟糕的承載容器。
+
+一旦你同時執行多個會話、長任務、審批中斷、生成的檔案、定時自動化、不同的 gateway —— 聊天紀錄就會變成一灘泥。狀態消失、檔案消失、脈絡消失。
+
+ClawWork 解決這個問題。每個任務都是一個擁有持久會話、artifacts、控制、歷史的獨立工作區，以三欄版面呈現：左邊任務列表、中間進行中的工作、右邊 artifacts 與脈絡。
+
+## Teams
+
+一個 Agent 有用，但一群協調好的 Agent 就是一支生產力。
+
+ClawWork Teams 把多個 Agent 打包成一個可部署單元 —— 角色、人格、技能、工作流程俱全。**Coordinator** Agent 拆解任務並派發給 **Worker** Agent，每個 Worker 都在自己的子會話中執行。你即時看到完整的編排過程。
+
+```
+skill → agent → team
+```
+
+### Team 結構
+
+```
+teams/clawwork-dev/
+├── TEAM.md                  # 團隊中繼資料與工作流程
+└── agents/
+    ├── manager/             # coordinator —— 協調團隊
+    │   ├── IDENTITY.md      # 角色與提示
+    │   ├── SOUL.md          # 人格與風格
+    │   └── skills.json      # 技能依賴
+    ├── architect/            # worker —— 設計方案
+    ├── frontend-dev/         # worker —— 建構 UI
+    ├── core-dev/             # worker —— 建構核心邏輯
+    └── ...
+```
+
+### 取得 Team 的三種方式
+
+- **[TeamsHub](https://github.com/clawwork-ai/teamshub-community)** —— 從 Git 原生儲存庫瀏覽並安裝社群貢獻的 Team。
+- **手動建立** —— 用分步精靈定義 Agent、身份與技能。
+- **AI Builder** —— 描述你的需求，讓 LLM 為你設計 Team 結構、角色與提示。
+
+安裝後，建立任務時挑一個 Team，Coordinator 會接管後續。
+
+## 下載
+
+### Homebrew (macOS)
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+### 發布版本
+
+macOS、Windows、Linux 的預建版本請見 [Releases 頁面](https://github.com/clawwork-ai/clawwork/releases/latest)。應用程式會自動更新 —— 新版本在背景下載，離開時安裝。
+
+### PWA (瀏覽器)
+
+無需安裝 —— 在任何現代瀏覽器中開啟 **[cpwa.pages.dev](https://cpwa.pages.dev)**。支援桌面與行動裝置，可加到主畫面。
+
+## 快速開始
+
+1. 啟動一個 OpenClaw Gateway。
+2. 開啟 ClawWork，在設定中新增 gateway。用 token、密碼或配對碼驗證。預設本機端點：`ws://127.0.0.1:18789`。
+3. 建立任務，挑選 gateway 與 agent，描述工作內容。
+4. 聊天：傳送訊息、附加圖片、用 `@` 引用檔案作為脈絡、或用 `/` 指令。
+5. 追蹤任務執行、檢視工具呼叫、保留輸出檔案。
+
+## 功能特性
+
+### ⚡ 任務優先的工作流程
+
+- 多任務並行，每個任務獨立 OpenClaw 會話 —— 封存的任務可以重新開啟
+- 依 gateway 分類的會話目錄
+- 真正有用的會話控制：停止、重置、壓縮、刪除、同步
+- 背景工作保持可讀，不會全部擠成一條長串
+- 用 `cron`、`every`、`at` 表達式排程任務 —— 從預設挑或自己寫，檢視執行歷史，隨時手動觸發
+- 匯出任意會話為 Markdown，在應用外留下乾淨的紀錄
+
+### 👁 一目了然
+
+- 即時串流回覆
+- Agent 執行時內嵌顯示工具呼叫卡片
+- 側邊欄顯示進度與 artifacts
+- 花多少錢一目了然 —— 各 gateway 用量狀態、各會話成本明細、30 天滾動儀表板
+
+### 🎛 更好的控制
+
+- 多 gateway 支援
+- 依任務切換 agent 與模型
+- 直接管理 agents —— 建立、編輯、刪除、瀏覽工作區檔案，無需離開應用
+- 瀏覽每個 gateway 的完整工具目錄，清楚知道 agent 能存取什麼
+- 思考層級控制與 slash 指令
+- 敏感操作執行前的審批確認
+- 背景事件會通知你 —— 任務完成、審批請求、gateway 斷線 —— 點擊通知跳回任務。每類事件可單獨開關，噪音自己掌握。
+
+### 📂 更好的檔案處理
+
+- 真正有用的脈絡：圖片、`@` 檔案引用、語音輸入、監視資料夾
+- 最多監視 10 個資料夾，自動偵測變化並重建索引，脈絡永遠新鮮
+- 本機 artifact 儲存
+- 助手回覆中的程式碼區塊與遠端圖片會被自動擷取並存到工作區 —— 無需手動複製貼上
+- 跨任務、訊息、artifacts 的全文搜尋
+
+### 🖥 更好的桌面體驗
+
+- 系統匣支援
+- 全域快捷鍵呼叫的快速啟動視窗（預設 `Alt+Space`，可自訂）
+- 應用內完整鍵盤快捷鍵
+- 背景自動更新 —— 在設定裡看到進度，離開時安裝
+- 依你的舒適度縮放介面，並記住偏好
+- 明暗主題 + 8 種語言
+
+### 🔧 除錯
+
+- 出問題時匯出除錯包（記錄檔、gateway 狀態、去識別化設定）—— 方便回報 bug
+- 設定裡直接顯示所連接的 Gateway 伺服器版本
+
+## 資料與架構
+
+ClawWork 透過單一 Gateway WebSocket 連線與 OpenClaw 通訊。每個任務有自己的 session key 用於隔離，所有資料都存在你選定的本機工作區目錄 —— 無雲端同步、無外部資料庫。
+
+- **Tasks** —— 每個任務對應到獨立的 OpenClaw 會話，並行工作互不衝突。
+- **Messages** —— 使用者、助手、系統訊息（含工具呼叫與圖片附件）全部本機保存。
+- **Artifacts** —— Agent 產出的程式碼區塊、圖片、檔案。從助手輸出中自動擷取，不會遺失。
+- **全文搜尋** —— 跨以上所有內容搜尋。不記得是哪個任務裡的程式碼片段？三週前的也能找回來。
+
+<div align="center">
+<img src="./docs/architecture.svg" alt="ClawWork Architecture" width="840" />
+</div>
+
+## 專案結構
+
+```
+packages/shared/       — 協定類型、常數（零依賴）
+packages/core/         — 共享商業邏輯：stores、services、ports
+packages/desktop/
+  src/main/            — Electron 主行程：gateway WS、IPC、DB、artifacts、OS 整合
+  src/preload/         — 型別化的 window.clawwork 橋接層
+  src/renderer/        — React UI：components、layouts、stores、hooks、i18n
+packages/pwa/          — Progressive Web App（瀏覽器 + 行動裝置）
+docs/                  — 設計文件、架構約束
+e2e/                   — Playwright E2E 測試（冒煙 + gateway 整合）
+scripts/               — 建置與檢查指令稿
+website/               — 專案官網（React + Vite）
+keynote/               — 簡報投影片（Slidev）
+```
+
+## 技術棧
+
+Electron 34、React 19、TypeScript、Tailwind CSS v4、Zustand、SQLite（Drizzle ORM + better-sqlite3）、Framer Motion。
+
+## 平台說明
+
+- 語音輸入需要本機 [whisper.cpp](https://github.com/ggerganov/whisper.cpp) 執行檔與模型。
+- 自動更新器僅對打包版本生效；開發模式會略過。
+- 脈絡資料夾監視：最多 10 個目錄、4 層深、單檔 10 MB 以內。
+
+## Roadmap
+
+### ✅ 已發布
+
+- 多任務並行執行，每個任務會話隔離
+- 多 gateway 驗證（token、密碼、配對碼）
+- 排程（cron）任務 + 執行歷史
+- 跨 gateway 與會話的用量與成本儀表板
+- 跨任務、訊息、artifacts 的全文搜尋
+- Teams 與 TeamsHub —— 建構、分享、安裝多 Agent 編隊
+- Skills（基於 ClawHub）—— 探索與安裝
+- AI Builder —— LLM 輔助的 Team 建立
+- PWA 離線支援與行動裝置 UI（[cpwa.pages.dev](https://cpwa.pages.dev)）
+- 跨平台：macOS、Windows、Linux (AppImage + deb)，附自動更新
+
+### 🔮 下一步
+
+- 對話分支
+- Artifact diff 檢視
+- 自訂主題
+- 定期工作流程的會話範本
+- Skills、Teams、Adapters 的擴充 API 文件
+
+### 🌐 願景 —— Agent OS 的工作區層
+
+ClawWork 目前針對 OpenClaw 最佳化。我們正朝一個未來邁進：工作區層與 runtime 無關 —— 所有 Agent 都在同一個介面裡操作。
+
+- **多 Runtime 轉接器** —— 把其他 Runtime 的 Agent 納入同一套 task / session / artifact 模型
+- **更豐富的團隊編排** —— 超越 coordinator / worker 的協作模式
+- **企業友善的本機優先** —— 更強的資料邊界與團隊協作模式，同時不放棄本機資料所有權
+
+項目成熟後會挪到 _下一步_。本節不承諾任何時間表。
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+
+## 貢獻
+
+參與方式：
+
+- 閱讀 [DEVELOPMENT.md](DEVELOPMENT.md) 了解環境設定與專案結構
+- 查看 [Issues](https://github.com/clawwork-ai/clawwork/issues)
+- 發起 [Pull Request](https://github.com/clawwork-ai/clawwork/pulls)
+- 送出前執行 `pnpm check` —— 會檢查 lint、架構、UI 合約、渲染層文案、i18n、死程式碼、格式、型別、測試。
+
+翻譯可能會落後英文版本。如果你發現內容偏離，歡迎發 PR。
+
+## License
+
+[Apache 2.0](LICENSE)
+
+<div align="center">
+
+為 [OpenClaw](https://github.com/openclaw/openclaw) 而建。致敬 [Peter Steinberger](https://github.com/steipete) 的卓越貢獻。
+
+</div>

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,250 @@
+<div align="center">
+
+<table border="0" cellspacing="0" cellpadding="0"><tr>
+<td><img src="./docs/screenshot.png" alt="ClawWork Desktop" height="420" /></td>
+<td><img src="https://github.com/user-attachments/assets/3dd775d0-8441-45d9-92f5-19e843f793c4" alt="ClawWork PWA" height="420" /></td>
+</tr></table>
+
+[English](./README.md) · **简体中文** · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
+
+# ClawWork
+
+**面向 Agent OS 时代的本地优先工作台。**
+
+[OpenClaw](https://github.com/openclaw/openclaw) 的桌面客户端 —— 让 Agent 任务并行运行、让 artifacts 不丢失、让文件不再消失。
+
+[![GitHub release](https://img.shields.io/github/v/release/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork/releases/latest)
+[![License](https://img.shields.io/github/license/clawwork-ai/clawwork?style=flat-square)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork)
+
+[下载](#下载) · [**PWA**](https://cpwa.pages.dev) · [快速开始](#快速开始) · [Teams](#teams) · [功能特性](#功能特性) · [数据与架构](#数据与架构) · [仓库结构](#仓库结构) · [Roadmap](#roadmap) · [贡献](#贡献) · [Keynote](https://clawwork-ai.github.io/ClawWork/keynote/)
+
+</div>
+
+> **⚠️ 官方仓库**
+> 这是 ClawWork 的**官方**项目：https://github.com/clawwork-ai/clawwork
+>
+> 我们发现了山寨仓库（ClawWorkAi/ClawWork）和山寨网站（clawworkai.store），未经授权使用 ClawWork 名称。请认准上方官方链接。
+>
+> 官网：https://clawwork-ai.github.io/ClawWork/
+
+## 为什么是 ClawWork
+
+**Agent 在爆炸式增长。瓶颈不再是能力，而是操作界面。**
+
+随着 Agent Runtime 越来越多，用户被迫在聊天窗口、网页 UI、终端之间来回切换，每个都有自己的上下文，彼此之间没有共享记忆。正如 IDE 成为了代码的操作层、终端成为了 Unix 的操作层 —— Agent OS 也需要一个工作台层。ClawWork 就是在建这一层：从 OpenClaw 的最佳客户端起步，向多 Runtime 未来演进。
+
+### 现在：OpenClaw，从此不再被聊天记录淹没
+
+OpenClaw 本身很强，但纯聊天是糟糕的承载容器。
+
+一旦你同时跑多个会话、长任务、审批中断、生成的文件、定时自动化、不同的 gateway —— 聊天记录就会变成一滩泥。状态消失、文件消失、上下文消失。
+
+ClawWork 解决这个问题。每个任务都是一个拥有持久会话、artifacts、控制、历史的独立工作台，以三栏布局呈现：左边任务列表、中间正在运行的工作、右边 artifacts 和上下文。
+
+## Teams
+
+一个 Agent 有用，但一群协调好的 Agent 就是一支生产力。
+
+ClawWork Teams 把多个 Agent 打包成一个可部署单元 —— 角色、人格、技能、工作流俱全。**Coordinator** Agent 拆解任务并分派给 **Worker** Agent，每个 Worker 都在自己的子会话里运行。你实时看到完整的编排过程。
+
+```
+skill → agent → team
+```
+
+### Team 结构
+
+```
+teams/clawwork-dev/
+├── TEAM.md                  # 团队元数据与工作流
+└── agents/
+    ├── manager/             # coordinator —— 协调团队
+    │   ├── IDENTITY.md      # 角色与提示
+    │   ├── SOUL.md          # 人格与风格
+    │   └── skills.json      # 技能依赖
+    ├── architect/            # worker —— 设计方案
+    ├── frontend-dev/         # worker —— 构建 UI
+    ├── core-dev/             # worker —— 构建核心逻辑
+    └── ...
+```
+
+### 获取 Team 的三种方式
+
+- **[TeamsHub](https://github.com/clawwork-ai/teamshub-community)** —— 从 Git 原生仓库浏览并安装社区贡献的 Team。
+- **手动创建** —— 用分步向导定义 Agent、身份和技能。
+- **AI Builder** —— 描述你的需求，让 LLM 为你设计 Team 结构、角色和提示。
+
+安装后，创建任务时选择一个 Team，Coordinator 会接管后续。
+
+## 下载
+
+### Homebrew (macOS)
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+### 发布版
+
+macOS、Windows、Linux 预构建版本见 [Releases 页面](https://github.com/clawwork-ai/clawwork/releases/latest)。应用自动更新 —— 新版本在后台下载，退出时安装。
+
+### PWA (浏览器)
+
+无需安装 —— 在任意现代浏览器中打开 **[cpwa.pages.dev](https://cpwa.pages.dev)**。支持桌面和移动端，可添加到主屏幕。
+
+## 快速开始
+
+1. 启动一个 OpenClaw Gateway。
+2. 打开 ClawWork，在设置中添加 gateway。用 token、密码或配对码认证。默认本地端点：`ws://127.0.0.1:18789`。
+3. 创建任务，选择 gateway 和 agent，描述工作内容。
+4. 聊天：发送消息、附加图片、用 `@` 引用文件作为上下文、或用 `/` 命令。
+5. 跟进任务执行、检查工具调用、保存输出文件。
+
+## 功能特性
+
+### ⚡ 任务优先的工作流
+
+- 多任务并行，每个任务独立 OpenClaw 会话 —— 归档的任务可以重新打开
+- 按 gateway 分类的会话目录
+- 真正有用的会话控制：停止、重置、压缩、删除、同步
+- 后台工作保持可读，不会全部挤成一条长线程
+- 用 `cron`、`every`、`at` 表达式定时任务 —— 从预设选或自己写，查看运行历史，随时手动触发
+- 导出任意会话为 Markdown，在应用外留下干净的记录
+
+### 👁 一目了然
+
+- 实时流式响应
+- Agent 工作时内联显示工具调用卡片
+- 侧边栏显示进度和 artifacts
+- 花多少钱一目了然 —— 各 gateway 用量状态、各会话成本明细、30 天滚动仪表盘
+
+### 🎛 更好的控制
+
+- 多 gateway 支持
+- 按任务切换 agent 和模型
+- 直接管理你的 agents —— 创建、编辑、删除、浏览工作区文件，无需离开应用
+- 浏览每个 gateway 的完整工具目录，清楚知道 agent 能做什么
+- 思考级别控制和 slash 命令
+- 敏感操作执行前的审批确认
+- 后台事件会通知你 —— 任务完成、审批请求、gateway 断连 —— 点击通知跳回任务。每类事件可单独开关，噪音自己控制。
+
+### 📂 更好的文件处理
+
+- 真正有用的上下文：图片、`@` 文件引用、语音输入、监视文件夹
+- 最多监视 10 个文件夹，自动检测变化并重建索引，上下文永远新鲜
+- 本地 artifact 存储
+- 助手回复中的代码块和远程图片会被自动提取并保存到工作区 —— 无需手动复制粘贴
+- 跨任务、消息、artifacts 的全文搜索
+
+### 🖥 更好的桌面体验
+
+- 系统托盘支持
+- 全局快捷键呼出的快速启动窗口（默认 `Alt+Space`，可自定义）
+- 应用内完整的键盘快捷键
+- 后台自动更新 —— 在设置里看到进度，退出时安装
+- 根据你的舒适度缩放界面，记住偏好
+- 明暗主题 + 8 种语言
+
+### 🔧 调试
+
+- 出问题时导出调试包（日志、gateway 状态、脱敏配置）—— 方便提 bug
+- 设置里直接显示连接的 Gateway 服务器版本
+
+## 数据与架构
+
+ClawWork 通过单条 Gateway WebSocket 连接与 OpenClaw 通信。每个任务有自己的 session key 用于隔离，所有数据都存在你选定的本地工作区目录 —— 无云同步、无外部数据库。
+
+- **Tasks** —— 每个任务映射到独立的 OpenClaw 会话，并行工作互不干扰。
+- **Messages** —— 用户、助手、系统消息（包括工具调用和图片附件）全部本地持久化。
+- **Artifacts** —— Agent 产出的代码块、图片、文件。从助手输出中自动提取，不会丢失。
+- **全文搜索** —— 跨以上所有内容搜索。不记得是哪个任务里的代码片段？三周前的也能找回来。
+
+<div align="center">
+<img src="./docs/architecture.svg" alt="ClawWork Architecture" width="840" />
+</div>
+
+## 仓库结构
+
+```
+packages/shared/       — 协议类型、常量（零依赖）
+packages/core/         — 共享业务逻辑：stores、services、ports
+packages/desktop/
+  src/main/            — Electron 主进程：gateway WS、IPC、DB、artifacts、OS 集成
+  src/preload/         — 类型化的 window.clawwork 桥接层
+  src/renderer/        — React UI：components、layouts、stores、hooks、i18n
+packages/pwa/          — Progressive Web App（浏览器 + 移动端）
+docs/                  — 设计文档、架构约束
+e2e/                   — Playwright E2E 测试（冒烟 + gateway 集成）
+scripts/               — 构建和检查脚本
+website/               — 项目官网（React + Vite）
+keynote/               — 演示文稿（Slidev）
+```
+
+## 技术栈
+
+Electron 34、React 19、TypeScript、Tailwind CSS v4、Zustand、SQLite（Drizzle ORM + better-sqlite3）、Framer Motion。
+
+## 平台说明
+
+- 语音输入需要本地 [whisper.cpp](https://github.com/ggerganov/whisper.cpp) 可执行文件和模型。
+- 自动更新器仅对打包版本生效；开发模式会跳过。
+- 上下文文件夹监视：最多 10 个目录、4 层深、单文件 10 MB 以内。
+
+## Roadmap
+
+### ✅ 已发布
+
+- 多任务并行执行，每个任务会话隔离
+- 多 gateway 认证（token、密码、配对码）
+- 定时（cron）任务 + 运行历史
+- 跨 gateway 和会话的用量与成本仪表盘
+- 跨任务、消息、artifacts 的全文搜索
+- Teams 和 TeamsHub —— 构建、分享、安装多 Agent 编队
+- Skills（基于 ClawHub）—— 发现与安装
+- AI Builder —— LLM 辅助的 Team 创建
+- PWA 离线支持和移动端 UI（[cpwa.pages.dev](https://cpwa.pages.dev)）
+- 跨平台：macOS、Windows、Linux (AppImage + deb)，带自动更新
+
+### 🔮 下一步
+
+- 对话分支
+- Artifact diff 视图
+- 自定义主题
+- 定期工作流的会话模板
+- Skills、Teams、Adapters 的扩展 API 文档
+
+### 🌐 愿景 —— Agent OS 的工作台层
+
+ClawWork 目前针对 OpenClaw 优化。我们正在构建一个未来：工作台层与 runtime 无关 —— 所有 Agent 都在同一个界面里操作。
+
+- **多 Runtime 适配器** —— 把其他 Runtime 的 Agent 纳入同一套 task / session / artifact 模型
+- **更丰富的团队编排** —— 超越 coordinator / worker 的协调模式
+- **企业友好的本地优先** —— 更强的数据边界和团队协作模式，同时不放弃本地数据所有权
+
+列表里的条目成熟后会挪到 _下一步_。本节不承诺任何时间表。
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+
+## 贡献
+
+参与方式：
+
+- 阅读 [DEVELOPMENT.md](DEVELOPMENT.md) 了解环境搭建和项目结构
+- 查看 [Issues](https://github.com/clawwork-ai/clawwork/issues)
+- 发起 [Pull Request](https://github.com/clawwork-ai/clawwork/pulls)
+- 提交前运行 `pnpm check` —— 会检查 lint、架构、UI 契约、渲染层文案、i18n、死代码、格式、类型、测试。
+
+翻译可能会滞后英文版本。如果你发现内容偏离，欢迎发 PR。
+
+## License
+
+[Apache 2.0](LICENSE)
+
+<div align="center">
+
+为 [OpenClaw](https://github.com/openclaw/openclaw) 而建。致敬 [Peter Steinberger](https://github.com/steipete) 的杰出工作。
+
+</div>


### PR DESCRIPTION
## Summary

Add native-speaker-oriented README translations for Simplified Chinese, Traditional Chinese, Japanese, and Korean, and compress the English README to remove duplicated prose without dropping any information.

## Type of change

- [ ] \`[Feat]\` new feature
- [ ] \`[Fix]\` bug fix
- [ ] \`[UI]\` UI or UX change
- [x] \`[Docs]\` documentation-only change
- [ ] \`[Refactor]\` internal cleanup
- [ ] \`[Build]\` CI, packaging, or tooling change
- [ ] \`[Chore]\` maintenance

## Why is this needed?

- Non-English speakers landing on the repo currently have no entry point in their native language.
- The English README had ~15–25% prose duplication: the "Why it feels better" bullets restated the "Why ClawWork" section, and "How it works" restated "What ClawWork stores". Redundant copy weakens the narrative without adding new information.
- Translations needed to read as native product READMEs, not as transliterations of English marketing phrasing, so they are written with native-speaker framing (e.g. zh 用「工作台」不用「工作空间」, ja 使用「ワークスペース」and appropriate keigo style, ko 使用「워크스페이스」with natural endings).

## What changed?

- Add \`README.zh.md\`, \`README.zh-TW.md\`, \`README.ja.md\`, \`README.ko.md\`, each with a consistent language switcher header that bolds its own language.
- Dedupe English \`README.md\`:
  - Remove the "Why it feels better" bullet block (every bullet already appeared in "Why ClawWork" or "What you get").
  - Merge "What ClawWork stores" and "How it works" into a single **Data & architecture** section (architecture diagram preserved).
  - Update TOC anchors and remove a stale issue-discussion link.
- No architecture diagrams or substantive content removed — only duplicated phrasing.

## Architecture impact

- Owning layer: n/a (documentation only)
- Cross-layer impact: none
- Invariants touched from \`docs/architecture-invariants.md\`: none
- Why those invariants remain protected: docs-only change, no code paths touched.

## Linked issues

Closes #

## Validation

- [ ] \`pnpm lint\`
- [ ] \`pnpm test\`
- [ ] \`pnpm build\`
- [ ] \`pnpm check:ui-contract\`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

\`\`\`text
Docs-only diff. pre-commit hook ran prettier + architecture check (passed: 4 rules, 0 violations).
Manual checks: language switcher consistent across all 5 files; TOC anchors map to actual headings; URLs (brew tap, cpwa.pages.dev, releases, issues) identical across translations.
\`\`\`

## Screenshots or recordings

N/A — README prose only.

## Release note

- [x] No user-facing change. Release note is \`NONE\`.
- [ ] User-facing change. Release note is included below.

\`\`\`release-note
NONE
\`\`\`

## Checklist

- [x] All commits are signed off (\`git commit -s\`)
- [x] The PR title uses at least one approved prefix: \`[Docs]\`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate