### PR TITLE
fix(debug): buffer pre-init events and flush to real logger on init

### DIFF
--- a/packages/desktop/src/main/debug/index.ts
+++ b/packages/desktop/src/main/debug/index.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow } from 'electron';
+import { sanitizeForLog } from '@clawwork/shared';
 import type { DebugEvent, LogEventInput } from '@clawwork/shared';
 import type { DebugLogger } from './logger.js';
 import { createDebugLogger } from './logger.js';
@@ -13,7 +14,7 @@ function createNoopLogger(): DebugLogger {
 
   const flushToLogger = (logger: DebugLogger): void => {
     for (const event of preInitBuffer) {
-      logger.log({ ...event, level: event.level as LogEventInput['level'] });
+      logger.log(event);
     }
     preInitBuffer.length = 0;
   };
@@ -21,30 +22,15 @@ function createNoopLogger(): DebugLogger {
   const makeBufferedLog =
     (level: 'debug' | 'info' | 'warn' | 'error') =>
     (input: LogEventInput): DebugEvent => {
-      const event: DebugEvent = {
+      const event = sanitizeForLog({
+        ...input,
         ts: new Date().toISOString(),
         level,
-        domain: input.domain,
-        event: input.event,
-        traceId: input.traceId,
-        feature: input.feature,
-        message: input.message,
-        gatewayId: input.gatewayId,
-        sessionKey: input.sessionKey,
-        taskId: input.taskId,
-        runId: input.runId,
-        requestId: input.requestId,
-        wsFrameId: input.wsFrameId,
-        seq: input.seq,
-        attempt: input.attempt,
-        durationMs: input.durationMs,
-        ok: input.ok,
-        error: input.error,
-        data: input.data,
-      };
+      } as DebugEvent);
 
-      if (preInitBuffer.length < MAX_PRE_INIT_BUFFER) {
-        preInitBuffer.push(event);
+      preInitBuffer.push(event);
+      if (preInitBuffer.length > MAX_PRE_INIT_BUFFER) {
+        preInitBuffer.shift();
       }
 
       console.warn(

--- a/packages/desktop/src/main/debug/index.ts
+++ b/packages/desktop/src/main/debug/index.ts
@@ -1,30 +1,104 @@
 import { BrowserWindow } from 'electron';
-import type { DebugEvent } from '@clawwork/shared';
+import type { DebugEvent, LogEventInput } from '@clawwork/shared';
 import type { DebugLogger } from './logger.js';
 import { createDebugLogger } from './logger.js';
 
-const noop = (): DebugEvent => ({ ts: '', level: 'debug', domain: 'app', event: '' }) as DebugEvent;
-let debugLogger: DebugLogger = {
-  debug: noop,
-  info: noop,
-  warn: noop,
-  error: noop,
-  log: noop,
-  getRecentEvents: () => [],
-  currentFilePath: () => '',
-};
+const MAX_PRE_INIT_BUFFER = 256;
+
+let debugLogger: DebugLogger;
+let isInitialized = false;
+
+function createNoopLogger(): DebugLogger {
+  const preInitBuffer: DebugEvent[] = [];
+
+  const flushToLogger = (logger: DebugLogger): void => {
+    for (const event of preInitBuffer) {
+      logger.log({ ...event, level: event.level as LogEventInput['level'] });
+    }
+    preInitBuffer.length = 0;
+  };
+
+  const makeBufferedLog =
+    (level: 'debug' | 'info' | 'warn' | 'error') =>
+    (input: LogEventInput): DebugEvent => {
+      const event: DebugEvent = {
+        ts: new Date().toISOString(),
+        level,
+        domain: input.domain,
+        event: input.event,
+        traceId: input.traceId,
+        feature: input.feature,
+        message: input.message,
+        gatewayId: input.gatewayId,
+        sessionKey: input.sessionKey,
+        taskId: input.taskId,
+        runId: input.runId,
+        requestId: input.requestId,
+        wsFrameId: input.wsFrameId,
+        seq: input.seq,
+        attempt: input.attempt,
+        durationMs: input.durationMs,
+        ok: input.ok,
+        error: input.error,
+        data: input.data,
+      };
+
+      if (preInitBuffer.length < MAX_PRE_INIT_BUFFER) {
+        preInitBuffer.push(event);
+      }
+
+      console.warn(
+        `[debug] Logger not initialized yet (pre-init event captured, buffer size: ${preInitBuffer.length}/${MAX_PRE_INIT_BUFFER}):`,
+        `[${level}] [${input.domain}] ${input.event}`,
+        input,
+      );
+      return event;
+    };
+
+  const noopLogger: DebugLogger = {
+    debug: makeBufferedLog('debug'),
+    info: makeBufferedLog('info'),
+    warn: makeBufferedLog('warn'),
+    error: makeBufferedLog('error'),
+    log: (input) => makeBufferedLog(input.level ?? 'debug')(input),
+    getRecentEvents: () => [...preInitBuffer],
+    currentFilePath: () => '',
+  };
+
+  Object.defineProperty(noopLogger, '__flush', {
+    value: flushToLogger,
+    writable: false,
+    enumerable: false,
+  });
+
+  return noopLogger;
+}
+
+debugLogger = createNoopLogger();
 
 export function initDebugLogger(debugDir: string): DebugLogger {
-  debugLogger = createDebugLogger({
+  const realLogger = createDebugLogger({
     debugDir,
     console: true,
     onEvent: broadcastDebugEvent,
   });
+
+  const noop = debugLogger as DebugLogger & { __flush?: (logger: DebugLogger) => void };
+  if (noop.__flush) {
+    noop.__flush(realLogger);
+  }
+
+  debugLogger = realLogger;
+  isInitialized = true;
   return debugLogger;
 }
 
 export function getDebugLogger(): DebugLogger {
   return debugLogger;
+}
+
+export function isDebugLoggerInitialized(): boolean {
+  return isInitialized;
 }
 
 function broadcastDebugEvent(event: DebugEvent): void {

--- a/packages/desktop/test/debug/debug-logger.test.ts
+++ b/packages/desktop/test/debug/debug-logger.test.ts
@@ -43,13 +43,37 @@ describe('debug logger pre-init behavior', () => {
 
     expect(isDebugLoggerInitialized()).toBe(false);
 
-    const tempDir = `/tmp/test-debug-${Date.now()}`;
+    const tempDir = '/tmp/test-debug';
     const realLogger = initDebugLogger(tempDir);
     expect(isDebugLoggerInitialized()).toBe(true);
 
     const recentEvents = realLogger.getRecentEvents();
     expect(recentEvents.some((e) => e.event === 'pre-init-event')).toBe(true);
     expect(recentEvents.some((e) => e.event === 'pre-init-warn')).toBe(true);
+  });
+
+  it('drops oldest events when buffer is full (keeps most recent 256)', async () => {
+    const { getDebugLogger, initDebugLogger } = await import(
+      '../../src/main/debug/index.js'
+    );
+
+    const logger = getDebugLogger();
+
+    logger.info({ domain: 'app', event: 'oldest-event' });
+    for (let i = 1; i <= 256; i++) {
+      logger.debug({ domain: 'app', event: `buffer-overflow-test-${i}` });
+    }
+
+    const events = getDebugLogger().getRecentEvents();
+    expect(events).toHaveLength(256);
+    expect(events.some((e) => e.event === 'oldest-event')).toBe(false);
+    expect(events[0].event).toBe('buffer-overflow-test-1');
+    expect(events[255].event).toBe('buffer-overflow-test-256');
+
+    const tempDir = '/tmp/test-debug';
+    const realLogger = initDebugLogger(tempDir);
+    const flushedEvents = realLogger.getRecentEvents();
+    expect(flushedEvents.some((e) => e.event === 'oldest-event')).toBe(false);
   });
 
   it('warns via console when logging before init', async () => {

--- a/packages/desktop/test/debug/debug-logger.test.ts
+++ b/packages/desktop/test/debug/debug-logger.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}));
+
+describe('debug logger pre-init behavior', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('buffers events before initDebugLogger runs', async () => {
+    const { getDebugLogger, isDebugLoggerInitialized } = await import(
+      '../../src/main/debug/index.js'
+    );
+
+    const logger = getDebugLogger();
+    const event1 = logger.info({ domain: 'app', event: 'test-event-1' });
+    const event2 = logger.error({ domain: 'gateway', event: 'test-event-2' });
+
+    expect(event1.level).toBe('info');
+    expect(event1.domain).toBe('app');
+    expect(event1.event).toBe('test-event-1');
+    expect(event2.level).toBe('error');
+    expect(event2.domain).toBe('gateway');
+
+    expect(getDebugLogger().getRecentEvents()).toHaveLength(2);
+    expect(isDebugLoggerInitialized()).toBe(false);
+  });
+
+  it('flushes buffered events to real logger after init', async () => {
+    const { getDebugLogger, initDebugLogger, isDebugLoggerInitialized } = await import(
+      '../../src/main/debug/index.js'
+    );
+
+    const logger = getDebugLogger();
+
+    logger.info({ domain: 'app', event: 'pre-init-event' });
+    logger.warn({ domain: 'gateway', event: 'pre-init-warn' });
+
+    expect(isDebugLoggerInitialized()).toBe(false);
+
+    const tempDir = `/tmp/test-debug-${Date.now()}`;
+    const realLogger = initDebugLogger(tempDir);
+    expect(isDebugLoggerInitialized()).toBe(true);
+
+    const recentEvents = realLogger.getRecentEvents();
+    expect(recentEvents.some((e) => e.event === 'pre-init-event')).toBe(true);
+    expect(recentEvents.some((e) => e.event === 'pre-init-warn')).toBe(true);
+  });
+
+  it('warns via console when logging before init', async () => {
+    const { getDebugLogger, isDebugLoggerInitialized } = await import(
+      '../../src/main/debug/index.js'
+    );
+
+    if (isDebugLoggerInitialized()) {
+      return;
+    }
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const logger = getDebugLogger();
+    logger.error({ domain: 'app', event: 'pre-init-warning-test' });
+
+    expect(warnSpy).toHaveBeenCalled();
+    const warningCall = warnSpy.mock.calls[0][0] as string;
+    expect(warningCall).toContain('[debug] Logger not initialized yet');
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- When `getDebugLogger()` is called before `initDebugLogger()`, events were silently dropped with noop stubs that returned empty `DebugEvent` objects
- This fix implements a buffered noop logger that captures up to 256 events before initialization, warns to console, and flushes all buffered events to the real logger when `initDebugLogger` is called

## Changes

### `packages/desktop/src/main/debug/index.ts`
- Replaced noop stubs with a `createNoopLogger()` factory that creates a logger with an in-memory buffer
- Added `isDebugLoggerInitialized()` export for testing
- Events logged before init are now:
  - Buffered (up to 256 events, oldest dropped first)
  - Warned to console with `[debug] Logger not initialized yet` message and buffer size
  - Flushed to the real logger when `initDebugLogger()` runs

### `packages/desktop/test/debug/debug-logger.test.ts`
- Added unit tests for pre-init buffering behavior:
  - Events are buffered before init
  - Buffered events are flushed to real logger after init
  - Buffer is capped at 256 events
  - Console warning is emitted on pre-init log calls

## Test plan

- [x] `pnpm --filter @clawwork/desktop test` passes
- [x] `pnpm lint` passes

Fixes #412