### PR TITLE
fix(settings): reject disallowed fields in settings:update instead of silently dropping them

### DIFF
--- a/packages/desktop/src/main/ipc/settings-handlers.ts
+++ b/packages/desktop/src/main/ipc/settings-handlers.ts
@@ -11,17 +11,22 @@ export function registerSettingsHandlers(): void {
     return readConfig();
   });
 
-  ipcMain.handle('settings:update', (_event, partial: Partial<AppConfig>): { ok: boolean; config: AppConfig } => {
-    const { gateways: _g, defaultGatewayId: _d, ...safePartial } = partial;
-    if (
-      safePartial.language !== undefined &&
-      !(SUPPORTED_LANGUAGE_CODES as readonly string[]).includes(safePartial.language)
-    ) {
-      delete safePartial.language;
-    }
-    const config = updateConfig(safePartial);
-    return { ok: true, config };
-  });
+  ipcMain.handle(
+    'settings:update',
+    (_event, partial: Partial<AppConfig>): { ok: boolean; config?: AppConfig; error?: string } => {
+      if ('gateways' in partial || 'defaultGatewayId' in partial) {
+        return { ok: false, error: 'use dedicated gateway handlers' };
+      }
+      if (
+        partial.language !== undefined &&
+        !(SUPPORTED_LANGUAGE_CODES as readonly string[]).includes(partial.language)
+      ) {
+        return { ok: false, error: 'unsupported language code' };
+      }
+      const config = updateConfig(partial);
+      return { ok: true, config };
+    },
+  );
 
   ipcMain.handle('settings:add-gateway', async (_event, gateway: GatewayServerConfig) => {
     const config = readConfig() ?? { workspacePath: '', gateways: [] };


### PR DESCRIPTION
## Problem

﻿settings:update destructures and discards gateways and defaultGatewayId from the incoming partial, then returns { ok: true, config }. A caller who passes updateSettings({ gateways: [...] }) gets a success response, but the gateway list is silently unchanged — a classic "the function lies about success" bug.

## Changes

- Detect disallowed fields (gateways, defaultGatewayId) explicitly and return { ok: false, error: 'use dedicated gateway handlers' }
- Detect unsupported language codes explicitly and return { ok: false, error: 'unsupported language code' }
- Update return type to include optional error field

## Verification

- pnpm check passes (lint, architecture, ui-contract, renderer-copy, i18n, dead-code, format, typecheck, tests)

Fixes #395