### PR TITLE
fix(desktop): wrap GatewaysSection IPC handlers in try/finally

### DIFF
--- a/packages/desktop/src/renderer/layouts/Settings/sections/GatewaysSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GatewaysSection.tsx
@@ -480,34 +480,46 @@ export default function GatewaysSection() {
       return;
     }
     setTesting(true);
-    const auth = {
-      token: form.token || undefined,
-      password: form.password || undefined,
-    };
-    const res = await window.clawwork.testGateway(form.url, auth);
-    setTesting(false);
-    if (res.ok) {
-      toast.success(t('settings.testSuccess'));
-    } else if (res.pairingRequired) {
-      setShowPairingDialog(true);
-    } else {
-      toast.error(t('settings.testFailed'), { description: res.error });
+    try {
+      const auth = {
+        token: form.token || undefined,
+        password: form.password || undefined,
+      };
+      const res = await window.clawwork.testGateway(form.url, auth);
+      if (res.ok) {
+        toast.success(t('settings.testSuccess'));
+      } else if (res.pairingRequired) {
+        setShowPairingDialog(true);
+      } else {
+        toast.error(t('settings.testFailed'), { description: res.error });
+      }
+    } catch (err) {
+      console.error('[GatewaysSection] test failed:', err);
+      toast.error(t('errors.failed'));
+    } finally {
+      setTesting(false);
     }
   }, [form, t]);
 
   const handlePairingRetry = useCallback(async () => {
     setPairingRetrying(true);
-    const auth = {
-      token: form.token || undefined,
-      password: form.password || undefined,
-    };
-    const res = await window.clawwork.testGateway(form.url, auth);
-    setPairingRetrying(false);
-    if (res.ok) {
-      setShowPairingDialog(false);
-      toast.success(t('pairing.approved'));
-    } else {
-      toast.error(t('pairing.stillPending'), { description: res.error });
+    try {
+      const auth = {
+        token: form.token || undefined,
+        password: form.password || undefined,
+      };
+      const res = await window.clawwork.testGateway(form.url, auth);
+      if (res.ok) {
+        setShowPairingDialog(false);
+        toast.success(t('pairing.approved'));
+      } else {
+        toast.error(t('pairing.stillPending'), { description: res.error });
+      }
+    } catch (err) {
+      console.error('[GatewaysSection] pairing retry failed:', err);
+      toast.error(t('errors.failed'));
+    } finally {
+      setPairingRetrying(false);
     }
   }, [form.url, form.token, form.password, t]);
 
@@ -527,43 +539,49 @@ export default function GatewaysSection() {
     }
 
     setSaving(true);
-    if (editingId) {
-      const res = await window.clawwork.updateGateway(editingId, {
-        name: form.name.trim(),
-        url: form.url.trim(),
-        token: form.token.trim() || undefined,
-        password: form.password.trim() || undefined,
-        pairingCode: form.pairingCode.trim() || undefined,
-        authMode,
-      });
-      if (res.ok) {
-        toast.success(t('settings.gatewayUpdated'));
-        closeForm();
-        await loadGateways();
+    try {
+      if (editingId) {
+        const res = await window.clawwork.updateGateway(editingId, {
+          name: form.name.trim(),
+          url: form.url.trim(),
+          token: form.token.trim() || undefined,
+          password: form.password.trim() || undefined,
+          pairingCode: form.pairingCode.trim() || undefined,
+          authMode,
+        });
+        if (res.ok) {
+          toast.success(t('settings.gatewayUpdated'));
+          closeForm();
+          await loadGateways();
+        } else {
+          toast.error(res.error ?? t('errors.failed'));
+        }
       } else {
-        toast.error(res.error ?? t('errors.failed'));
+        const newGw: GatewayServerConfig = {
+          id: crypto.randomUUID(),
+          name: form.name.trim(),
+          url: form.url.trim(),
+          token: form.token.trim() || undefined,
+          password: form.password.trim() || undefined,
+          pairingCode: form.pairingCode.trim() || undefined,
+          authMode,
+          type: 'openclaw',
+        };
+        const res = await window.clawwork.addGateway(newGw);
+        if (res.ok) {
+          toast.success(t('settings.gatewayAdded'));
+          closeForm();
+          await loadGateways();
+        } else {
+          toast.error(res.error ?? t('errors.failed'));
+        }
       }
-    } else {
-      const newGw: GatewayServerConfig = {
-        id: crypto.randomUUID(),
-        name: form.name.trim(),
-        url: form.url.trim(),
-        token: form.token.trim() || undefined,
-        password: form.password.trim() || undefined,
-        pairingCode: form.pairingCode.trim() || undefined,
-        authMode,
-        type: 'openclaw',
-      };
-      const res = await window.clawwork.addGateway(newGw);
-      if (res.ok) {
-        toast.success(t('settings.gatewayAdded'));
-        closeForm();
-        await loadGateways();
-      } else {
-        toast.error(res.error ?? t('errors.failed'));
-      }
+    } catch (err) {
+      console.error('[GatewaysSection] save failed:', err);
+      toast.error(t('errors.failed'));
+    } finally {
+      setSaving(false);
     }
-    setSaving(false);
   }, [form, editingId, closeForm, loadGateways, t]);
 
   const handleRemove = useCallback(

--- a/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
@@ -101,7 +101,8 @@ export default function GeneralSection() {
 
   const handleNotificationToggle = useCallback(
     (key: 'taskComplete' | 'approvalRequest' | 'gatewayDisconnect', value: boolean) => {
-      void updateSettings({ notifications: { ...notifyState, [key]: value } }).catch((err: unknown) => {
+      const next = { ...notifyState, [key]: value };
+      void updateSettings({ notifications: next }).catch((err: unknown) => {
         console.error('[GeneralSection] updateSettings failed:', err);
       });
     },

--- a/packages/desktop/src/renderer/layouts/Settings/sections/SkillsSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/SkillsSection.tsx
@@ -583,18 +583,24 @@ function ClawHubTab({ gatewayId, onInstalled }: { gatewayId: string; onInstalled
   const handleInstall = useCallback(
     async (slug: string) => {
       setInstallingSlugs((prev) => new Set(prev).add(slug));
-      const res = await window.clawwork.installSkill(gatewayId, { source: 'clawhub', slug });
-      if (res.ok && res.result?.ok) {
-        toast.success(t('settings.skillHubInstalled'));
-        onInstalled();
-      } else {
-        toast.error(res.error ?? res.result?.message ?? t('settings.skillHubInstallFailed'));
+      try {
+        const res = await window.clawwork.installSkill(gatewayId, { source: 'clawhub', slug });
+        if (res.ok && res.result?.ok) {
+          toast.success(t('settings.skillHubInstalled'));
+          onInstalled();
+        } else {
+          toast.error(res.error ?? res.result?.message ?? t('settings.skillHubInstallFailed'));
+        }
+      } catch (err) {
+        console.error('[SkillsSection] install failed:', err);
+        toast.error(t('settings.skillHubInstallFailed'));
+      } finally {
+        setInstallingSlugs((prev) => {
+          const next = new Set(prev);
+          next.delete(slug);
+          return next;
+        });
       }
-      setInstallingSlugs((prev) => {
-        const next = new Set(prev);
-        next.delete(slug);
-        return next;
-      });
     },
     [gatewayId, onInstalled, t],
   );
@@ -738,22 +744,28 @@ export default function SkillsSection() {
     async (skill: SkillStatusEntry) => {
       if (!selectedGatewayId) return;
       setTogglingKeys((prev) => new Set(prev).add(skill.skillKey));
-      const newEnabled = skill.disabled;
-      const res = await window.clawwork.updateSkill(selectedGatewayId, {
-        skillKey: skill.skillKey,
-        enabled: newEnabled,
-      });
-      if (res.ok) {
-        toast.success(newEnabled ? t('settings.skillEnabled') : t('settings.skillDisabledToast'));
-        await refreshSkills();
-      } else {
+      try {
+        const newEnabled = skill.disabled;
+        const res = await window.clawwork.updateSkill(selectedGatewayId, {
+          skillKey: skill.skillKey,
+          enabled: newEnabled,
+        });
+        if (res.ok) {
+          toast.success(newEnabled ? t('settings.skillEnabled') : t('settings.skillDisabledToast'));
+          await refreshSkills();
+        } else {
+          toast.error(t('settings.skillUpdateFailed'));
+        }
+      } catch (err) {
+        console.error('[SkillsSection] toggle failed:', err);
         toast.error(t('settings.skillUpdateFailed'));
+      } finally {
+        setTogglingKeys((prev) => {
+          const next = new Set(prev);
+          next.delete(skill.skillKey);
+          return next;
+        });
       }
-      setTogglingKeys((prev) => {
-        const next = new Set(prev);
-        next.delete(skill.skillKey);
-        return next;
-      });
     },
     [selectedGatewayId, refreshSkills, t],
   );

--- a/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
@@ -65,20 +65,33 @@ export default function SystemSection() {
   );
 
   const handleChangeWorkspace = useCallback(async () => {
-    const selected = await window.clawwork.browseWorkspace();
+    let selected: string | null = null;
+    try {
+      selected = await window.clawwork.browseWorkspace();
+    } catch (err) {
+      console.error('[SystemSection] browseWorkspace failed:', err);
+      toast.error(t('errors.failed'));
+      return;
+    }
     if (!selected || selected === workspacePath) return;
     const oldPath = workspacePath;
     setChangingWorkspace(true);
-    const result = await window.clawwork.changeWorkspace(selected);
-    setChangingWorkspace(false);
-    if (result.ok) {
-      await refreshSettings().catch(() => {});
-      toast.success(t('settings.workspaceChanged'), {
-        description: t('settings.workspaceOldPathHint', { path: oldPath }),
-        duration: 8000,
-      });
-    } else {
-      toast.error(t('settings.workspaceChangeFailed', { error: result.error }));
+    try {
+      const result = await window.clawwork.changeWorkspace(selected);
+      if (result.ok) {
+        await refreshSettings().catch(() => {});
+        toast.success(t('settings.workspaceChanged'), {
+          description: t('settings.workspaceOldPathHint', { path: oldPath }),
+          duration: 8000,
+        });
+      } else {
+        toast.error(t('settings.workspaceChangeFailed', { error: result.error }));
+      }
+    } catch (err) {
+      console.error('[SystemSection] changeWorkspace failed:', err);
+      toast.error(t('settings.workspaceChangeFailed', { error: String(err) }));
+    } finally {
+      setChangingWorkspace(false);
     }
   }, [refreshSettings, workspacePath, t]);
 


### PR DESCRIPTION
## Summary

Fixes #397


coauthor: @clawwork-ai

## Problem


coauthor: @clawwork-ai

## Problem

, , and  in  all followed the pattern:



If the IPC call threw (network error, preload exception, serialization failure), the final  was never reached. The save/test button would stay permanently stuck on a greyed-out spinner, forcing the user to close and reopen Settings.

## Fix

Wrap each handler's IPC call in  so the loading flag always resets. Errors are caught, logged to console, and surfaced via .

### Changes

-  — wrapped  call
-  — wrapped  call  
-  — wrapped both  and  branches

## Verification

- [ ] 
> clawwork@ check /tmp/ClawWork
> pnpm lint && pnpm check:architecture && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm typecheck:tests && pnpm typecheck:e2e && pnpm test


> clawwork@ lint /tmp/ClawWork
> eslint . --max-warnings 0

 ELIFECYCLE  Command failed.
 WARN   Local package.json exists, but node_modules missing, did you mean to install?
 ELIFECYCLE  Command failed with exit code 1.
 WARN   Local package.json exists, but node_modules missing, did you mean to install? passes
- [ ] Manual: simulate IPC failure → button recovers instead of staying stuck

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update