### PR TITLE
fix: persist deviceId on first call when no config exists

### DIFF
--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -201,15 +201,10 @@ export function buildGatewayAuth(gw: GatewayServerConfig): GatewayAuth {
 }
 
 export function ensureDeviceId(): string {
-  const config = readConfig();
-  if (config?.deviceId) return config.deviceId;
+  const existing = readConfig()?.deviceId;
+  if (existing) return existing;
   const deviceId = randomUUID();
-  const updated = config ?? {
-    workspacePath: getDefaultWorkspacePath(),
-    gateways: [],
-  };
-  updated.deviceId = deviceId;
-  writeConfig(updated);
+  updateConfig({ deviceId });
   return deviceId;
 }
 

--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -204,10 +204,12 @@ export function ensureDeviceId(): string {
   const config = readConfig();
   if (config?.deviceId) return config.deviceId;
   const deviceId = randomUUID();
-  if (config) {
-    config.deviceId = deviceId;
-    writeConfig(config);
-  }
+  const updated = config ?? {
+    workspacePath: getDefaultWorkspacePath(),
+    gateways: [],
+  };
+  updated.deviceId = deviceId;
+  writeConfig(updated);
   return deviceId;
 }
 

--- a/packages/desktop/test/workspace-config.test.ts
+++ b/packages/desktop/test/workspace-config.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CONFIG_FILE_NAME, DEFAULT_WORKSPACE_DIR } from '@clawwork/shared';
+
+const electronMock = vi.hoisted(() => {
+  const state = { userData: '' };
+  return {
+    state,
+    getPath: vi.fn((name: string) => {
+      if (name === 'userData') return state.userData;
+      throw new Error(`unexpected app path: ${name}`);
+    }),
+    isEncryptionAvailable: vi.fn(() => false),
+    encryptString: vi.fn((value: string) => Buffer.from(value)),
+    decryptString: vi.fn((value: Buffer) => value.toString('utf8')),
+  };
+});
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: electronMock.getPath,
+  },
+  safeStorage: {
+    isEncryptionAvailable: electronMock.isEncryptionAvailable,
+    encryptString: electronMock.encryptString,
+    decryptString: electronMock.decryptString,
+  },
+}));
+
+import { ensureDeviceId, readConfig } from '../src/main/workspace/config.js';
+
+describe('workspace config', () => {
+  let userDataDir: string;
+
+  beforeEach(() => {
+    userDataDir = mkdtempSync(join(tmpdir(), 'clawwork-config-'));
+    electronMock.state.userData = userDataDir;
+  });
+
+  afterEach(() => {
+    rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it('persists deviceId on first call when no config exists', () => {
+    const first = ensureDeviceId();
+    const second = ensureDeviceId();
+    const persisted = readConfig();
+    const raw = JSON.parse(readFileSync(join(userDataDir, CONFIG_FILE_NAME), 'utf8'));
+
+    expect(second).toBe(first);
+    expect(persisted?.deviceId).toBe(first);
+    expect(raw.deviceId).toBe(first);
+    expect(raw.workspacePath).toBe(join(homedir(), DEFAULT_WORKSPACE_DIR));
+    expect(raw.gateways).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

On first launch, before a config file exists, `ensureDeviceId()` generates a random UUID but only persists it when config is non-null. When `readConfig()` returns null (no config file yet), the function returns a fresh UUID without writing it, so every subsequent call produces a different device ID until something else writes the config.

## Fix

When config is null, construct a minimal `AppConfig` with `workspacePath: getDefaultWorkspacePath()`, `gateways: []`, and the new `deviceId`, then always call `writeConfig(...)` before returning.

## Verification

- `pnpm check` passes (40 test files, 243 tests)
- Manual: delete config file, trigger `ensureDeviceId()` twice → same UUID both times

Fixes #383