### PR TITLE
[Feat] Redesign default theme palette and group tasks by time

### DIFF
--- a/keynote/components/DeckMiniPanel.vue
+++ b/keynote/components/DeckMiniPanel.vue
@@ -18,7 +18,11 @@ withDefaults(
 </script>
 
 <template>
-  <div class="cw-mini-panel" :class="{ 'cw-mini-panel--neutral': neutral, 'cw-mini-panel--compact': compact }" :data-tone="tone">
+  <div
+    class="cw-mini-panel"
+    :class="{ 'cw-mini-panel--neutral': neutral, 'cw-mini-panel--compact': compact }"
+    :data-tone="tone"
+  >
     <strong class="cw-mini-panel-title">{{ t(title) }}</strong>
     <p v-if="body" class="cw-mini-panel-copy">{{ t(body) }}</p>
     <p v-else-if="$slots.default" class="cw-mini-panel-copy"><slot /></p>

--- a/packages/desktop/src/renderer/context/ThemeProvider.tsx
+++ b/packages/desktop/src/renderer/context/ThemeProvider.tsx
@@ -17,6 +17,13 @@ function resolveThemeMode(theme: Theme): 'dark' | 'light' {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
+function coerceTheme(raw: unknown): Theme {
+  if (raw === 'dark' || raw === 'light' || raw === 'auto') return raw;
+  if (raw === 'aurora-dark' || raw === 'polish-dark' || raw === 'liquid-dark') return 'dark';
+  if (raw === 'aurora' || raw === 'polish' || raw === 'liquid') return 'light';
+  return 'auto';
+}
+
 export function ThemeProvider({ children }: PropsWithChildren) {
   const theme = useUiStore((s) => s.theme);
   const setTheme = useUiStore((s) => s.setTheme);
@@ -41,8 +48,9 @@ export function ThemeProvider({ children }: PropsWithChildren) {
 
     let waitingForHydration = false;
     if (settingsTheme) {
-      if (theme !== settingsTheme) {
-        setTheme(settingsTheme);
+      const safeTheme = coerceTheme(settingsTheme);
+      if (theme !== safeTheme) {
+        setTheme(safeTheme);
         waitingForHydration = true;
       }
     }

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -324,6 +324,10 @@
     "dashboard": "Dashboard",
     "emptyHint": "Klicken Sie auf \"Neue Aufgabe\"",
     "expandNav": "Seitenleiste ausklappen",
+    "groupLast7Days": "Letzte 7 Tage",
+    "groupOlder": "Älter",
+    "groupToday": "Heute",
+    "groupYesterday": "Gestern",
     "scheduledTasks": "Geplant",
     "searchTasks": "Aufgaben suchen…",
     "updateAvailable": "Update verfuegbar"

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -324,6 +324,10 @@
     "dashboard": "Dashboard",
     "emptyHint": "Click \"New Task\" to start",
     "expandNav": "Expand sidebar",
+    "groupLast7Days": "Previous 7 Days",
+    "groupOlder": "Older",
+    "groupToday": "Today",
+    "groupYesterday": "Yesterday",
     "scheduledTasks": "Scheduled",
     "searchTasks": "Search tasks…",
     "updateAvailable": "Update available"

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -324,6 +324,10 @@
     "dashboard": "Panel",
     "emptyHint": "Haz clic en “Nueva tarea” para comenzar",
     "expandNav": "Expandir barra lateral",
+    "groupLast7Days": "Últimos 7 días",
+    "groupOlder": "Anterior",
+    "groupToday": "Hoy",
+    "groupYesterday": "Ayer",
     "scheduledTasks": "Programadas",
     "searchTasks": "Buscar tareas…",
     "updateAvailable": "Actualización disponible"

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -324,6 +324,10 @@
     "dashboard": "ダッシュボード",
     "emptyHint": "「新規タスク」をクリックして開始",
     "expandNav": "サイドバーを展開",
+    "groupLast7Days": "過去 7 日",
+    "groupOlder": "以前",
+    "groupToday": "今日",
+    "groupYesterday": "昨日",
     "scheduledTasks": "スケジュール",
     "searchTasks": "タスクを検索…",
     "updateAvailable": "アップデートがあります"

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -324,6 +324,10 @@
     "dashboard": "대시보드",
     "emptyHint": "\"새 작업\"을 클릭하여 시작하세요",
     "expandNav": "사이드바 펼치기",
+    "groupLast7Days": "지난 7일",
+    "groupOlder": "이전",
+    "groupToday": "오늘",
+    "groupYesterday": "어제",
     "scheduledTasks": "예약 작업",
     "searchTasks": "작업 검색…",
     "updateAvailable": "업데이트 가능"

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -324,6 +324,10 @@
     "dashboard": "Painel",
     "emptyHint": "Clique em \"Nova Tarefa\" para começar",
     "expandNav": "Expandir barra lateral",
+    "groupLast7Days": "Últimos 7 dias",
+    "groupOlder": "Anterior",
+    "groupToday": "Hoje",
+    "groupYesterday": "Ontem",
     "scheduledTasks": "Agendadas",
     "searchTasks": "Buscar tarefas…",
     "updateAvailable": "Atualização disponível"

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -324,6 +324,10 @@
     "dashboard": "儀表板",
     "emptyHint": "點擊「新任務」開始",
     "expandNav": "展開側邊欄",
+    "groupLast7Days": "前 7 天",
+    "groupOlder": "更早",
+    "groupToday": "今天",
+    "groupYesterday": "昨天",
     "scheduledTasks": "排程任務",
     "searchTasks": "搜尋任務…",
     "updateAvailable": "有可用更新"

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -324,6 +324,10 @@
     "dashboard": "仪表盘",
     "emptyHint": "点击「新任务」开始",
     "expandNav": "展开侧栏",
+    "groupLast7Days": "前 7 天",
+    "groupOlder": "更早",
+    "groupToday": "今天",
+    "groupYesterday": "昨天",
     "scheduledTasks": "定时任务",
     "searchTasks": "搜索任务…",
     "updateAvailable": "有新版本可用"

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent, useState, useRef, useEffect, useCallback } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
-import { MessageSquare, Circle } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { useTaskStore } from '@/stores/taskStore';
@@ -115,7 +115,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
         'group titlebar-no-drag w-full rounded-md text-left transition-all relative',
         'focus-visible:outline-none glow-focus',
         active
-          ? 'glow-selected bg-[var(--bg-elevated)]'
+          ? 'bg-[var(--state-selected)]'
           : isStreaming
             ? 'bg-[var(--accent-dim)]'
             : isCompleted
@@ -124,10 +124,6 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
       )}
     >
       <div className="flex items-center gap-2 px-3 h-9">
-        {hasUnread && !active && (
-          <Circle size={6} className="flex-shrink-0 fill-[var(--accent)] text-[var(--accent)]" />
-        )}
-
         <div className="flex-1 min-w-0">
           {editing ? (
             <input

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -42,8 +42,36 @@ import {
 } from '@/components/ui/dialog';
 import { exportToFiles, exportToLocal } from '@/lib/export-session';
 import TaskItem from './TaskItem';
-import type { TaskStatus } from '@clawwork/shared';
+import type { Task, TaskStatus } from '@clawwork/shared';
 import EmptyState from '@/components/semantic/EmptyState';
+
+function groupTasksByTime(tasks: Task[]): {
+  today: Task[];
+  yesterday: Task[];
+  last7Days: Task[];
+  older: Task[];
+} {
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const startOfTodayMs = startOfToday.getTime();
+  const startOfYesterdayMs = startOfTodayMs - MS_PER_DAY;
+  const startOf7DaysAgoMs = startOfTodayMs - 7 * MS_PER_DAY;
+
+  const today: Task[] = [];
+  const yesterday: Task[] = [];
+  const last7Days: Task[] = [];
+  const older: Task[] = [];
+
+  for (const task of tasks) {
+    const t = new Date(task.updatedAt).getTime();
+    if (t >= startOfTodayMs) today.push(task);
+    else if (t >= startOfYesterdayMs) yesterday.push(task);
+    else if (t >= startOf7DaysAgoMs) last7Days.push(task);
+    else older.push(task);
+  }
+  return { today, yesterday, last7Days, older };
+}
 
 type ConfirmAction = 'reset' | 'delete' | null;
 
@@ -261,6 +289,26 @@ export default function LeftNav() {
   const visibleTasks = useMemo(() => tasks.filter((t) => t.status !== 'archived'), [tasks]);
   const activeTasks = useMemo(() => visibleTasks.filter((t) => t.status === 'active'), [visibleTasks]);
   const completedTasks = useMemo(() => visibleTasks.filter((t) => t.status === 'completed'), [visibleTasks]);
+  const activeGroups = useMemo(() => groupTasksByTime(activeTasks), [activeTasks]);
+
+  const renderTaskGroup = (groupTasks: Task[], label: string) => {
+    if (groupTasks.length === 0) return null;
+    return (
+      <>
+        <p className="type-meta px-3 py-1.5 text-[var(--text-muted)] mt-2">{label}</p>
+        {groupTasks.map((task) => (
+          <TaskItem
+            key={task.id}
+            task={task}
+            active={task.id === activeTaskId}
+            onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
+            editing={editingTaskId === task.id}
+            onEditDone={() => setEditingTaskId(null)}
+          />
+        ))}
+      </>
+    );
+  };
 
   const CollapseToggleButton = (
     <Tooltip>
@@ -501,37 +549,11 @@ export default function LeftNav() {
               className="px-3 py-1"
             >
               {visibleTasks.length === 0 && <EmptyState title={t('leftNav.emptyHint')} className="py-8" />}
-              {activeTasks.length > 0 && (
-                <>
-                  {activeTasks.map((task) => (
-                    <TaskItem
-                      key={task.id}
-                      task={task}
-                      active={task.id === activeTaskId}
-                      onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
-                      editing={editingTaskId === task.id}
-                      onEditDone={() => setEditingTaskId(null)}
-                    />
-                  ))}
-                </>
-              )}
-              {completedTasks.length > 0 && (
-                <>
-                  <p className="type-meta px-3 py-1.5 text-[var(--text-muted)] mt-2">
-                    {t('common.completed')} ({completedTasks.length})
-                  </p>
-                  {completedTasks.map((task) => (
-                    <TaskItem
-                      key={task.id}
-                      task={task}
-                      active={task.id === activeTaskId}
-                      onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
-                      editing={editingTaskId === task.id}
-                      onEditDone={() => setEditingTaskId(null)}
-                    />
-                  ))}
-                </>
-              )}
+              {renderTaskGroup(activeGroups.today, t('leftNav.groupToday'))}
+              {renderTaskGroup(activeGroups.yesterday, t('leftNav.groupYesterday'))}
+              {renderTaskGroup(activeGroups.last7Days, t('leftNav.groupLast7Days'))}
+              {renderTaskGroup(activeGroups.older, t('leftNav.groupOlder'))}
+              {renderTaskGroup(completedTasks, `${t('common.completed')} (${completedTasks.length})`)}
             </motion.div>
           </ScrollArea>
         </div>

--- a/packages/desktop/src/renderer/styles/theme.css
+++ b/packages/desktop/src/renderer/styles/theme.css
@@ -28,45 +28,68 @@
   :root,
   :root[data-theme='dark'],
   [data-theme='dark'] {
-    --bg-primary: #1c1c1c;
-    --bg-secondary: #242424;
-    --bg-tertiary: #2a2a2a;
-    --bg-hover: #333333;
-    --accent: #0ffd0d;
-    --accent-foreground: #041204;
-    --accent-dim: rgba(15, 253, 13, 0.15);
-    --text-primary: #f3f4f4;
-    --text-secondary: #9ca3af;
-    --text-muted: #6b7280;
+    --bg-primary: #13131c;
+    --bg-secondary: #1a1a25;
+    --bg-tertiary: #20202d;
+    --bg-hover: #292936;
+    --bg-elevated: #1f1f2c;
+
+    --accent: #8088fb;
+    --accent-hover: #9097ff;
+    --accent-foreground: #0e0e18;
+    --accent-dim: rgba(128, 136, 251, 0.16);
+    --accent-soft: rgba(128, 136, 251, 0.1);
+    --accent-soft-hover: rgba(128, 136, 251, 0.18);
+
+    --text-primary: #f1f1f8;
+    --text-secondary: #b0b0bf;
+    --text-muted: #797987;
+
     --border: rgba(255, 255, 255, 0.08);
-    --border-accent: rgba(15, 253, 93, 0.15);
-    --scrollbar-thumb: #444444;
+    --border-subtle: rgba(255, 255, 255, 0.05);
+    --border-accent: rgba(128, 136, 251, 0.3);
+
+    --scrollbar-thumb: #383846;
     --scrollbar-track: transparent;
-    --danger: #f87171;
-    --danger-bg: rgba(248, 113, 113, 0.1);
-    --warning: #f59e0b;
-    --info: #3b82f6;
-    /* Premium depth tokens */
-    --accent-hover: #0de00b;
-    --accent-soft: rgba(15, 253, 13, 0.1);
-    --accent-soft-hover: rgba(15, 253, 13, 0.18);
-    --bg-elevated: #2f2f2f;
-    --ring-accent: rgba(15, 253, 13, 0.4);
-    --glow-accent: rgba(15, 253, 13, 0.06);
-    --shadow-elevated: 0 2px 12px rgba(0, 0, 0, 0.4);
-    --shadow-card: 0 1px 4px rgba(0, 0, 0, 0.3);
-    --shadow-floating: 0 10px 28px rgba(0, 0, 0, 0.45);
-    --shadow-dialog: 0 18px 48px rgba(0, 0, 0, 0.5);
-    --overlay-scrim: rgba(0, 0, 0, 0.5);
-    --border-subtle: rgba(255, 255, 255, 0.06);
+
+    --danger: #f07079;
+    --danger-bg: rgba(240, 112, 121, 0.12);
+    --warning: #e6b35a;
+    --info: #6aa9ed;
+
+    --ring-accent: rgba(128, 136, 251, 0.4);
+    --glow-accent: rgba(128, 136, 251, 0.08);
+
+    --elev-1: 0 0 0 0.5px rgba(0, 0, 0, 0.35), 0 1px 1px rgba(0, 0, 0, 0.25), 0 2px 3px rgba(0, 0, 0, 0.2);
+    --elev-2:
+      0 0 0 0.5px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.3), 0 4px 10px rgba(0, 0, 0, 0.28),
+      0 12px 28px rgba(0, 0, 0, 0.25);
+    --elev-3:
+      0 0 0 0.5px rgba(0, 0, 0, 0.45), 0 2px 4px rgba(0, 0, 0, 0.35), 0 12px 24px rgba(0, 0, 0, 0.35),
+      0 32px 64px rgba(0, 0, 0, 0.4);
+    --inner-rim: inset 0 1px 0 rgba(255, 255, 255, 0.07);
+
+    --shadow-card: var(--elev-1);
+    --shadow-elevated: var(--elev-2);
+    --shadow-floating: var(--elev-3);
+    --shadow-dialog: var(--elev-3);
+    --shadow-card-layered: var(--elev-1);
+    --shadow-elevated-layered: var(--elev-2);
+    --shadow-floating-layered: var(--elev-3);
+    --shadow-inset-soft: var(--inner-rim);
+    --shadow-inset-card: var(--inner-rim);
+    --overlay-scrim: rgba(0, 0, 0, 0.55);
+
     --surface-page: var(--bg-primary);
     --surface-panel: var(--bg-secondary);
     --surface-card: var(--bg-secondary);
     --surface-elevated-bg: var(--bg-elevated);
     --surface-floating-bg: var(--bg-elevated);
     --surface-dialog-bg: var(--bg-elevated);
+
     --state-hover: var(--bg-hover);
     --state-selected: var(--accent-dim);
+
     --motion-duration-fast: 100ms;
     --motion-duration-normal: 150ms;
     --motion-duration-moderate: 200ms;
@@ -75,75 +98,90 @@
     --motion-ease-enter: cubic-bezier(0, 0, 0.2, 1);
     --motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
 
-    /* Glass + depth */
-    --glass-bg: rgba(28, 28, 28, 0.9);
-    --glass-bg-heavy: rgba(28, 28, 28, 0.96);
+    --glass-bg: rgba(26, 26, 37, 0.72);
+    --glass-bg-heavy: rgba(26, 26, 37, 0.88);
     --glass-border: rgba(255, 255, 255, 0.06);
     --glass-highlight: rgba(255, 255, 255, 0.04);
     --glass-blur: 24px;
     --glass-blur-heavy: 40px;
-    --glass-saturate: 180%;
-    --shadow-inset-soft: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-    --shadow-inset-card: inset 0 1px 0 rgba(255, 255, 255, 0.06), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
-    --shadow-card-layered: 0 1px 2px rgba(0, 0, 0, 0.2), 0 4px 8px rgba(0, 0, 0, 0.15);
-    --shadow-floating-layered:
-      0 2px 4px rgba(0, 0, 0, 0.15), 0 8px 24px rgba(0, 0, 0, 0.25), 0 16px 48px rgba(0, 0, 0, 0.15);
-    --shadow-elevated-layered: 0 1px 3px rgba(0, 0, 0, 0.2), 0 4px 12px rgba(0, 0, 0, 0.25);
+    --glass-saturate: 170%;
 
-    /* 3-layer glow */
-    --glow-ring: 0 0 0 1px rgba(15, 253, 13, 0.35);
-    --glow-diffuse: 0 0 12px 2px rgba(15, 253, 13, 0.12);
-    --glow-inset: inset 0 0 8px rgba(15, 253, 13, 0.06);
+    --glow-ring: 0 0 0 1px rgba(128, 136, 251, 0.45);
+    --glow-diffuse: 0 0 0 4px rgba(128, 136, 251, 0.12);
+    --glow-inset: inset 0 0 0 1px rgba(128, 136, 251, 0);
+    --glow-pulse-mid: rgba(128, 136, 251, 0.18);
 
-    /* Tool colors */
-    --tool-read: rgba(59, 130, 246, 0.8);
-    --tool-write: rgba(245, 158, 11, 0.8);
-    --tool-exec: rgba(15, 253, 13, 0.8);
-    --tool-think: rgba(168, 85, 247, 0.8);
-    --tool-web: rgba(6, 182, 212, 0.8);
-    --tool-default: rgba(156, 163, 175, 0.6);
+    --tool-read: rgba(106, 169, 237, 0.9);
+    --tool-write: rgba(230, 179, 90, 0.9);
+    --tool-exec: rgba(128, 136, 251, 0.9);
+    --tool-think: rgba(186, 130, 240, 0.9);
+    --tool-web: rgba(80, 192, 210, 0.9);
+    --tool-default: rgba(160, 160, 176, 0.7);
   }
 
   :root[data-theme='light'] {
-    --bg-primary: #fafafa;
-    --bg-secondary: #ffffff;
-    --bg-tertiary: #f3f4f6;
-    --bg-hover: #e5e7eb;
-    --accent: #0b8a0a;
-    --accent-foreground: #ffffff;
-    --accent-dim: rgba(11, 138, 10, 0.1);
-    --text-primary: #111827;
-    --text-secondary: #6b7280;
-    --text-muted: #9ca3af;
-    --border: rgba(0, 0, 0, 0.08);
-    --border-accent: rgba(11, 138, 10, 0.15);
-    --scrollbar-thumb: #d1d5db;
-    --scrollbar-track: transparent;
-    --danger: #dc2626;
-    --danger-bg: rgba(220, 38, 38, 0.08);
-    --warning: #f59e0b;
-    --info: #3b82f6;
-    /* Premium depth tokens */
-    --accent-hover: #0a7a09;
-    --accent-soft: rgba(11, 138, 10, 0.08);
-    --accent-soft-hover: rgba(11, 138, 10, 0.14);
+    --bg-primary: #f4f3ef;
+    --bg-secondary: #fbfaf7;
+    --bg-tertiary: #efeee9;
+    --bg-hover: #e9e8e2;
     --bg-elevated: #ffffff;
-    --ring-accent: rgba(11, 138, 10, 0.3);
-    --glow-accent: rgba(11, 138, 10, 0.04);
-    --shadow-elevated: 0 2px 12px rgba(0, 0, 0, 0.08);
-    --shadow-card: 0 1px 4px rgba(0, 0, 0, 0.06);
-    --shadow-floating: 0 10px 28px rgba(0, 0, 0, 0.14);
-    --shadow-dialog: 0 18px 48px rgba(0, 0, 0, 0.18);
-    --overlay-scrim: rgba(0, 0, 0, 0.5);
-    --border-subtle: rgba(0, 0, 0, 0.06);
+
+    --accent: #5860ea;
+    --accent-hover: #474fdb;
+    --accent-foreground: #ffffff;
+    --accent-dim: rgba(88, 96, 234, 0.1);
+    --accent-soft: rgba(88, 96, 234, 0.07);
+    --accent-soft-hover: rgba(88, 96, 234, 0.13);
+
+    --text-primary: #17171c;
+    --text-secondary: #3a3a42;
+    --text-muted: #6e6e7a;
+
+    --border: rgba(23, 23, 28, 0.07);
+    --border-subtle: rgba(23, 23, 28, 0.045);
+    --border-accent: rgba(88, 96, 234, 0.22);
+
+    --scrollbar-thumb: #d0d0cb;
+    --scrollbar-track: transparent;
+
+    --danger: #d9434b;
+    --danger-bg: rgba(217, 67, 75, 0.08);
+    --warning: #c48a18;
+    --info: #2f7bd1;
+
+    --ring-accent: rgba(88, 96, 234, 0.3);
+    --glow-accent: rgba(88, 96, 234, 0.06);
+
+    --elev-1: 0 0 0 0.5px rgba(23, 23, 28, 0.06), 0 1px 1px rgba(23, 23, 28, 0.03), 0 2px 3px rgba(23, 23, 28, 0.02);
+    --elev-2:
+      0 0 0 0.5px rgba(23, 23, 28, 0.07), 0 1px 1px rgba(23, 23, 28, 0.04), 0 4px 10px rgba(23, 23, 28, 0.04),
+      0 12px 28px rgba(23, 23, 28, 0.05);
+    --elev-3:
+      0 0 0 0.5px rgba(23, 23, 28, 0.08), 0 2px 4px rgba(23, 23, 28, 0.06), 0 12px 24px rgba(23, 23, 28, 0.08),
+      0 32px 64px rgba(23, 23, 28, 0.12);
+    --inner-rim: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+
+    --shadow-card: var(--elev-1);
+    --shadow-elevated: var(--elev-2);
+    --shadow-floating: var(--elev-3);
+    --shadow-dialog: var(--elev-3);
+    --shadow-card-layered: var(--elev-1);
+    --shadow-elevated-layered: var(--elev-2);
+    --shadow-floating-layered: var(--elev-3);
+    --shadow-inset-soft: var(--inner-rim);
+    --shadow-inset-card: var(--inner-rim);
+    --overlay-scrim: rgba(23, 23, 28, 0.28);
+
     --surface-page: var(--bg-primary);
     --surface-panel: var(--bg-secondary);
     --surface-card: var(--bg-secondary);
     --surface-elevated-bg: var(--bg-elevated);
     --surface-floating-bg: var(--bg-elevated);
     --surface-dialog-bg: var(--bg-elevated);
+
     --state-hover: var(--bg-hover);
     --state-selected: var(--accent-dim);
+
     --motion-duration-fast: 100ms;
     --motion-duration-normal: 150ms;
     --motion-duration-moderate: 200ms;
@@ -152,33 +190,25 @@
     --motion-ease-enter: cubic-bezier(0, 0, 0.2, 1);
     --motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
 
-    /* Glass + depth */
-    --glass-bg: rgba(250, 250, 250, 0.92);
-    --glass-bg-heavy: rgba(255, 255, 255, 0.97);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-highlight: rgba(255, 255, 255, 0.5);
-    --glass-blur: 20px;
-    --glass-blur-heavy: 32px;
-    --glass-saturate: 150%;
-    --shadow-inset-soft: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-    --shadow-inset-card: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 -1px 0 rgba(0, 0, 0, 0.03);
-    --shadow-card-layered: 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 8px rgba(0, 0, 0, 0.03);
-    --shadow-floating-layered:
-      0 2px 4px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.08), 0 16px 48px rgba(0, 0, 0, 0.06);
-    --shadow-elevated-layered: 0 1px 3px rgba(0, 0, 0, 0.04), 0 4px 12px rgba(0, 0, 0, 0.06);
+    --glass-bg: rgba(251, 250, 247, 0.72);
+    --glass-bg-heavy: rgba(251, 250, 247, 0.88);
+    --glass-border: rgba(23, 23, 28, 0.06);
+    --glass-highlight: rgba(255, 255, 255, 0.6);
+    --glass-blur: 22px;
+    --glass-blur-heavy: 36px;
+    --glass-saturate: 160%;
 
-    /* 3-layer glow */
-    --glow-ring: 0 0 0 1px rgba(11, 138, 10, 0.3);
-    --glow-diffuse: 0 0 12px 2px rgba(11, 138, 10, 0.08);
-    --glow-inset: inset 0 0 8px rgba(11, 138, 10, 0.04);
+    --glow-ring: 0 0 0 1px rgba(88, 96, 234, 0.35);
+    --glow-diffuse: 0 0 0 4px rgba(88, 96, 234, 0.1);
+    --glow-inset: inset 0 0 0 1px rgba(88, 96, 234, 0);
+    --glow-pulse-mid: rgba(88, 96, 234, 0.18);
 
-    /* Tool colors */
-    --tool-read: rgba(37, 99, 235, 0.85);
-    --tool-write: rgba(217, 119, 6, 0.85);
-    --tool-exec: rgba(11, 138, 10, 0.85);
-    --tool-think: rgba(147, 51, 234, 0.85);
-    --tool-web: rgba(8, 145, 178, 0.85);
-    --tool-default: rgba(107, 114, 128, 0.6);
+    --tool-read: rgba(47, 123, 209, 0.85);
+    --tool-write: rgba(196, 138, 24, 0.9);
+    --tool-exec: rgba(88, 96, 234, 0.85);
+    --tool-think: rgba(154, 85, 217, 0.85);
+    --tool-web: rgba(15, 148, 168, 0.85);
+    --tool-default: rgba(120, 120, 135, 0.7);
   }
 
   html,
@@ -581,7 +611,7 @@
   50% {
     box-shadow:
       var(--glow-ring),
-      0 0 18px 4px rgba(15, 253, 13, 0.18),
+      0 0 18px 4px var(--glow-pulse-mid),
       var(--glow-inset);
   }
 }


### PR DESCRIPTION
## Summary

Default light/dark themes adopt a refined indigo-accent palette with a clearer 3-layer elevation system. Left-nav active tasks are now bucketed by `updatedAt` into Today / Yesterday / Previous 7 Days / Older. `ThemeProvider` migrates legacy persisted theme values on hydration so existing users aren't stuck on removed variants.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

After a full day of real usage the previous light/dark pair felt muddy: insufficient contrast between surface, elevated, and overlay layers, and a noisy selected-item highlight. This pass replaces the palette with the Polish-dark/Polish-light tones, consolidates to just `auto` / `dark` / `light`, and removes the now-redundant alternative themes (aurora / polish / liquid).

The task list had grown dense enough that a flat chronological list became hard to scan. Time bucketing matches how the user actually recalls work (today vs. older), and mirrors the pattern already used in the PWA's task list.

## What changed?

- `theme.css`: refreshed dark + light tokens (backgrounds, borders, accents, `--state-selected`) and tightened the 3-layer elevation scale.
- `ThemeProvider.tsx`: added `coerceTheme()` to map legacy stored values (`aurora` / `aurora-dark` / `polish` / `polish-dark` / `liquid` / `liquid-dark`) onto the supported `dark` / `light` / `auto` trio during hydration; canonical value is written back via the existing settings-sync effect.
- `LeftNav/index.tsx`: extracted `groupTasksByTime()` and `renderTaskGroup()`; active tasks now render in Today / Yesterday / Previous 7 Days / Older buckets.
- `LeftNav/TaskItem.tsx`: dropped the standalone unread `Circle` indicator and switched selected-state background from `--bg-elevated` to the shared `--state-selected` token (already used by `ListItem`).
- i18n: added `leftNav.groupToday / groupYesterday / groupLast7Days / groupOlder` across all 8 locales.
- `keynote/DeckMiniPanel.vue`: formatting-only line break for readability.

## Architecture impact

- Owning layer: renderer (desktop) + keynote formatting
- Cross-layer impact: none — no changes to shared protocol, core stores, main process, or preload bridge
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: no package-boundary imports moved, no new main-process surface, no session-key or persistence path changes

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
Author ran the updated themes for a full workday in real usage before landing; theme switch verified in both dark and light modes; time-bucket labels render across all 8 locale files. Automated gates (pnpm check) run in CI.
```

## Screenshots or recordings

Visual changes are constrained to the renderer surface tokens and the left-nav list layout. Preserved rules: `bg-[var(--state-selected)]` usage now matches `ListItem.tsx:32` (single canonical selected-state token), and the `.glow-selected` utility remains in the stylesheet for the editing-input affordance at `TaskItem.tsx:80`.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
UI: Refreshed default light and dark themes, consolidated to auto / light / dark (legacy theme choices migrate automatically on startup), and grouped left-nav active tasks by Today / Yesterday / Previous 7 Days / Older.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

## Considered and deferred

- LeftNav/index.tsx:292 [BOT-NIT]: Midnight bucket drift. activeGroups useMemo depends on activeTasks reference; past midnight stays stale until next mutation. 4 AM session reset tolerates this.
- LeftNav/index.tsx:46 [BOT-SCOPE]: groupTasksByTime overlaps with PWA groupByTime at packages/pwa/src/components/TaskList.tsx:15. Cross-package dedup deferred to standalone refactor.
- LeftNav/index.tsx:294 [BOT-SCOPE]: renderTaskGroup concept overlaps with Dashboard SectionHeader. Defer extraction until 3rd caller.
- [BOT-SCOPE]: groupTasksByTime and coerceTheme lack dedicated unit tests. Existing theme-provider tests cover hydration indirectly; follow up in test-hardening PR.
