### PR TITLE
fix(desktop): show error toast when PairMobileDialog handleGenerate fails

### DIFF
--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -515,6 +515,7 @@
     "pairExpiresIn": "Laeuft in {{seconds}}s ab",
     "pairFailed": "Kopplungscode konnte nicht erzeugt werden",
     "pairGenerate": "QR-Code erzeugen",
+    "pairGenerateFailed": "QR-Code konnte nicht generiert werden. Bitte versuche es erneut.",
     "pairingCode": "Kopplungscode",
     "pairingCodePlaceholder": "Kopplungscode einfuegen",
     "pairingCodeRequired": "Kopplungscode ist erforderlich",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -515,6 +515,7 @@
     "pairExpiresIn": "Expires in {{seconds}}s",
     "pairFailed": "Failed to generate pairing code",
     "pairGenerate": "Generate QR Code",
+    "pairGenerateFailed": "Failed to generate QR code. Please try again.",
     "pairingCode": "Pairing Code",
     "pairingCodePlaceholder": "Paste pairing code",
     "pairingCodeRequired": "Pairing code is required",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -515,6 +515,7 @@
     "pairExpiresIn": "Expira en {{seconds}}s",
     "pairFailed": "No se pudo generar el codigo de vinculacion",
     "pairGenerate": "Generar codigo QR",
+    "pairGenerateFailed": "No se pudo generar el código QR. Inténtalo de nuevo.",
     "pairingCode": "Código de vinculación",
     "pairingCodePlaceholder": "Pega el código de vinculación",
     "pairingCodeRequired": "El código de vinculación es obligatorio",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -515,6 +515,7 @@
     "pairExpiresIn": "{{seconds}}秒後に期限切れ",
     "pairFailed": "ペアリングコードを生成できませんでした",
     "pairGenerate": "QR コードを生成",
+    "pairGenerateFailed": "QR コードの生成に失敗しました。もう一度お試しください。",
     "pairingCode": "ペアリングコード",
     "pairingCodePlaceholder": "ペアリングコードを貼り付け",
     "pairingCodeRequired": "ペアリングコードは必須です",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -515,6 +515,7 @@
     "pairExpiresIn": "{{seconds}}초 후 만료",
     "pairFailed": "페어링 코드를 생성하지 못했습니다",
     "pairGenerate": "QR 코드 생성",
+    "pairGenerateFailed": "QR 코드 생성에 실패했습니다. 다시 시도해 주세요.",
     "pairingCode": "페어링 코드",
     "pairingCodePlaceholder": "페어링 코드를 붙여넣으세요",
     "pairingCodeRequired": "페어링 코드를 입력해 주세요",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -515,6 +515,7 @@
     "pairExpiresIn": "Expira em {{seconds}}s",
     "pairFailed": "Falha ao gerar o codigo de pareamento",
     "pairGenerate": "Gerar codigo QR",
+    "pairGenerateFailed": "Falha ao gerar o QR code. Tente novamente.",
     "pairingCode": "Código de Pareamento",
     "pairingCodePlaceholder": "Cole o código de pareamento",
     "pairingCodeRequired": "O código de pareamento é obrigatório",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -515,6 +515,7 @@
     "pairExpiresIn": "{{seconds}} 秒後過期",
     "pairFailed": "產生配對碼失敗",
     "pairGenerate": "產生 QR Code",
+    "pairGenerateFailed": "產生 QR 碼失敗，請重試。",
     "pairingCode": "配對碼",
     "pairingCodePlaceholder": "貼上配對碼",
     "pairingCodeRequired": "請輸入配對碼",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -515,6 +515,7 @@
     "pairExpiresIn": "{{seconds}} 秒后过期",
     "pairFailed": "生成配对码失败",
     "pairGenerate": "生成二维码",
+    "pairGenerateFailed": "生成二维码失败，请重试。",
     "pairingCode": "配对码",
     "pairingCodePlaceholder": "粘贴配对码",
     "pairingCodeRequired": "配对码不能为空",

--- a/packages/desktop/src/renderer/layouts/Settings/components/PairMobileDialog.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/components/PairMobileDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { Smartphone, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -113,11 +114,14 @@ export default function PairMobileDialog({
             return prev - 1;
           });
         }, 1000);
+      } catch (err) {
+        console.error('[PairMobileDialog] handleGenerate failed:', err);
+        toast.error(t('settings.pairGenerateFailed'));
       } finally {
         setGenerating(false);
       }
     },
-    [gatewayConfigs, selectedGatewayId, shareIdentity],
+    [gatewayConfigs, selectedGatewayId, shareIdentity, t],
   );
 
   return (

--- a/packages/desktop/src/renderer/layouts/Settings/components/PairMobileDialog.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/components/PairMobileDialog.tsx
@@ -117,6 +117,12 @@ export default function PairMobileDialog({
       } catch (err) {
         console.error('[PairMobileDialog] handleGenerate failed:', err);
         toast.error(t('settings.pairGenerateFailed'));
+        setQrData(null);
+        if (timerRef.current) {
+          clearInterval(timerRef.current);
+          timerRef.current = null;
+        }
+        setCountdown(0);
       } finally {
         setGenerating(false);
       }


### PR DESCRIPTION
## Summary

Closes #403. `PairMobileDialog.handleGenerate` had a `try { ... } finally { setGenerating(false); }` with no `catch`. If `window.clawwork.getSettings()` or `window.clawwork.getDeviceId()` threw, the spinner reset but the user saw an idle button, no QR code, and no error message — couldn't tell whether generation succeeded silently or failed. Add a catch arm that logs the error and surfaces a toast.

## Changes

- `packages/desktop/src/renderer/layouts/Settings/components/PairMobileDialog.tsx`:
  - Add `import { toast } from 'sonner';` (matches the rest of the renderer codebase pattern, e.g. `platform/index.ts:23`, `stores/approvalStore.ts:4`).
  - Add a `catch (err)` arm before `finally` that logs the error and calls `toast.error(t('settings.pairGenerateFailed'))`.
  - Add `t` to the `useCallback` dependency array.
- `packages/desktop/src/renderer/i18n/locales/*.json` (8 files): add the new `settings.pairGenerateFailed` key with translations for en, zh, zh-TW, ja, ko, de, es, pt.

The diff comes out to 9 files / 13 insertions because the locale files only get one key added each plus the `scripts/sort-i18n.mjs` pre-commit hook re-sorted the keys. The TSX change itself is one import + 3 lines of catch + one dep array entry.

## Why this matters

The maintainer description spelled it out exactly: spinner returns to idle with no QR code and no error — user has no signal whether to retry, refile, or wait. A toast on failure is the standard fix and matches how the rest of the desktop renderer surfaces async failures.

## Verification

- `pnpm tsc --noEmit -p tsconfig.json`: same 32 pre-existing errors as `upstream/main`; none in `PairMobileDialog.tsx` or any locale file.
- pre-commit ran prettier + eslint --fix + scripts/sort-i18n.mjs cleanly, plus `check-architecture.mjs` reports `4 rules, 0 violations`.
- Manual repro path (per the issue): if `getSettings`/`getDeviceId` throws, the user now sees a toast and no lingering spinner.

This contribution was developed with AI assistance (Claude Code).
