### PR TITLE
[Feat] Add resizable team file tree

### DIFF
--- a/packages/desktop/src/renderer/hooks/useResizePanel.ts
+++ b/packages/desktop/src/renderer/hooks/useResizePanel.ts
@@ -5,9 +5,16 @@ interface UseResizePanelOptions {
   minWidth: number;
   maxWidth: number;
   storageKey?: string;
+  side?: 'left' | 'right';
 }
 
-export function useResizePanel({ defaultWidth, minWidth, maxWidth, storageKey }: UseResizePanelOptions) {
+export function useResizePanel({
+  defaultWidth,
+  minWidth,
+  maxWidth,
+  storageKey,
+  side = 'right',
+}: UseResizePanelOptions) {
   const [width, setWidth] = useState(() => {
     if (storageKey) {
       const saved = localStorage.getItem(storageKey);
@@ -25,11 +32,11 @@ export function useResizePanel({ defaultWidth, minWidth, maxWidth, storageKey }:
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
-      const delta = startXRef.current - e.clientX;
+      const delta = side === 'right' ? startXRef.current - e.clientX : e.clientX - startXRef.current;
       const next = Math.round(Math.min(maxWidth, Math.max(minWidth, startWidthRef.current + delta)));
       setWidth(next);
     },
-    [minWidth, maxWidth],
+    [minWidth, maxWidth, side],
   );
 
   const handleMouseUp = useCallback(() => {

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -694,6 +694,8 @@
     "description": "Beschreibung",
     "detail": {
       "agents": "Agenten",
+      "agentSkillCount": "{{count}} Skills",
+      "agentSkillsLabel": "{{name}} Skills",
       "fileSaved": "Datei gespeichert",
       "fileSaveFailed": "Datei konnte nicht gespeichert werden",
       "noDescription": "Keine Beschreibung",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -694,6 +694,8 @@
     "description": "Description",
     "detail": {
       "agents": "Agents",
+      "agentSkillCount": "{{count}} skills",
+      "agentSkillsLabel": "{{name}} Skills",
       "fileSaved": "File saved",
       "fileSaveFailed": "Failed to save file",
       "noDescription": "No description",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -694,6 +694,8 @@
     "description": "Descripción",
     "detail": {
       "agents": "Agentes",
+      "agentSkillCount": "{{count}} habilidades",
+      "agentSkillsLabel": "Habilidades de {{name}}",
       "fileSaved": "Archivo guardado",
       "fileSaveFailed": "Error al guardar el archivo",
       "noDescription": "Sin descripción",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -694,6 +694,8 @@
     "description": "説明",
     "detail": {
       "agents": "エージェント",
+      "agentSkillCount": "{{count}} 個のスキル",
+      "agentSkillsLabel": "{{name}} のスキル",
       "fileSaved": "ファイルを保存しました",
       "fileSaveFailed": "ファイルの保存に失敗しました",
       "noDescription": "説明なし",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -694,6 +694,8 @@
     "description": "설명",
     "detail": {
       "agents": "에이전트",
+      "agentSkillCount": "스킬 {{count}}개",
+      "agentSkillsLabel": "{{name}} 스킬",
       "fileSaved": "파일이 저장되었습니다",
       "fileSaveFailed": "파일 저장에 실패했습니다",
       "noDescription": "설명 없음",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -694,6 +694,8 @@
     "description": "Descrição",
     "detail": {
       "agents": "Agentes",
+      "agentSkillCount": "{{count}} habilidades",
+      "agentSkillsLabel": "Habilidades de {{name}}",
       "fileSaved": "Arquivo salvo",
       "fileSaveFailed": "Falha ao salvar o arquivo",
       "noDescription": "Sem descrição",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -694,6 +694,8 @@
     "description": "描述",
     "detail": {
       "agents": "智慧體",
+      "agentSkillCount": "{{count}} 個技能",
+      "agentSkillsLabel": "{{name}} 技能",
       "fileSaved": "檔案已儲存",
       "fileSaveFailed": "檔案儲存失敗",
       "noDescription": "暫無描述",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -694,6 +694,8 @@
     "description": "描述",
     "detail": {
       "agents": "智能体",
+      "agentSkillCount": "{{count}} 个技能",
+      "agentSkillsLabel": "{{name}} 技能",
       "fileSaved": "文件已保存",
       "fileSaveFailed": "文件保存失败",
       "noDescription": "暂无描述",

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamDetailView.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamDetailView.tsx
@@ -6,6 +6,7 @@ import type { Team } from '@clawwork/shared';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import ConfirmDialog from '@/components/semantic/ConfirmDialog';
+import { useResizePanel } from '@/hooks/useResizePanel';
 import { useUiStore } from '@/stores/uiStore';
 import { cn } from '@/lib/utils';
 import TeamFileTree, { type TreeFile } from './TeamFileTree';
@@ -124,6 +125,17 @@ export default function TeamDetailView({ team, onBack, onStartChat, onEdit }: Te
   }, [team.agents, skillsMap]);
 
   const isDirty = editingContent !== null && editingContent !== fileContent;
+  const {
+    width: fileTreeWidth,
+    isDragging: isFileTreeDragging,
+    handleMouseDown: handleFileTreeResizeStart,
+  } = useResizePanel({
+    defaultWidth: 220,
+    minWidth: 192,
+    maxWidth: 420,
+    storageKey: 'clawwork:team-file-tree-width',
+    side: 'left',
+  });
 
   const loadFile = useCallback(
     async (file: TreeFile) => {
@@ -250,6 +262,9 @@ export default function TeamDetailView({ team, onBack, onStartChat, onEdit }: Te
           skills={allSkills}
           selectedFileId={selectedFile?.id ?? null}
           onSelectFile={handleSelectFile}
+          width={fileTreeWidth}
+          isDragging={isFileTreeDragging}
+          onResizeStart={handleFileTreeResizeStart}
         />
 
         <div className="flex flex-1 flex-col min-w-0">

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamFileTree.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamFileTree.tsx
@@ -168,14 +168,14 @@ export default function TeamFileTree({
               ))}
               {agent.skillCount > 0 && (
                 <TreeItem
-                  label={`${agent.skillCount} skills`}
+                  label={t('teams.detail.agentSkillCount', { count: agent.skillCount })}
                   icon={<Puzzle size={12} className={ICON_CLS} />}
                   depth={2}
                   selected={selectedFileId === `agent-skills-${agent.agentId}`}
                   onClick={() =>
                     onSelectFile({
                       id: `agent-skills-${agent.agentId}`,
-                      label: `${agent.name} Skills`,
+                      label: t('teams.detail.agentSkillsLabel', { name: agent.name }),
                       kind: 'agent-skills',
                       agentId: agent.agentId,
                       agentName: agent.name,

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamFileTree.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamFileTree.tsx
@@ -32,6 +32,9 @@ interface TeamFileTreeProps {
   skills: SkillNode[];
   selectedFileId: string | null;
   onSelectFile: (file: TreeFile) => void;
+  width: number;
+  isDragging: boolean;
+  onResizeStart: (e: React.MouseEvent) => void;
 }
 
 const ITEM_BASE =
@@ -101,105 +104,128 @@ function FolderItem({
   );
 }
 
-export default function TeamFileTree({ agents, skills, selectedFileId, onSelectFile }: TeamFileTreeProps) {
+export default function TeamFileTree({
+  agents,
+  skills,
+  selectedFileId,
+  onSelectFile,
+  width,
+  isDragging,
+  onResizeStart,
+}: TeamFileTreeProps) {
   const { t } = useTranslation();
   const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({ agents: true });
   const toggle = useCallback((key: string) => setOpenFolders((prev) => ({ ...prev, [key]: !prev[key] })), []);
 
   return (
-    <div className="w-48 flex-shrink-0 space-y-0.5 overflow-y-auto border-r border-[var(--border)] py-2 px-1">
-      <TreeItem
-        label="TEAM.md"
-        icon={<FileText size={13} className={ICON_CLS} />}
-        depth={0}
-        selected={selectedFileId === 'team-md'}
-        onClick={() => onSelectFile({ id: 'team-md', label: 'TEAM.md', kind: 'team-md' })}
-      />
+    <div className="relative flex-shrink-0 border-r border-[var(--border)]" style={{ width }}>
+      <div className="h-full space-y-0.5 overflow-y-auto py-2 px-1">
+        <TreeItem
+          label="TEAM.md"
+          icon={<FileText size={13} className={ICON_CLS} />}
+          depth={0}
+          selected={selectedFileId === 'team-md'}
+          onClick={() => onSelectFile({ id: 'team-md', label: 'TEAM.md', kind: 'team-md' })}
+        />
 
-      <FolderItem
-        label={t('teams.detail.agents')}
-        depth={0}
-        open={!!openFolders.agents}
-        onToggle={() => toggle('agents')}
-      >
-        {agents.map((agent) => (
-          <FolderItem
-            key={agent.agentId}
-            label={agent.name}
-            badge={
-              <>
-                {agent.isManager && (
-                  <span className="type-meta flex-shrink-0 rounded-full bg-[var(--bg-tertiary)] px-1.5 py-px text-[var(--accent)]">
-                    {t('teams.wizard.coordinator')}
-                  </span>
-                )}
-                {agent.model && (
-                  <span className="type-meta flex-shrink-0 truncate max-w-24 text-[var(--text-muted)]">
-                    {agent.model}
-                  </span>
-                )}
-              </>
-            }
-            depth={1}
-            open={!!openFolders[`agent-${agent.agentId}`]}
-            onToggle={() => toggle(`agent-${agent.agentId}`)}
-          >
-            {agent.files.map((file) => (
+        <FolderItem
+          label={t('teams.detail.agents')}
+          depth={0}
+          open={!!openFolders.agents}
+          onToggle={() => toggle('agents')}
+        >
+          {agents.map((agent) => (
+            <FolderItem
+              key={agent.agentId}
+              label={agent.name}
+              badge={
+                <>
+                  {agent.isManager && (
+                    <span className="type-meta flex-shrink-0 rounded-full bg-[var(--bg-tertiary)] px-1.5 py-px text-[var(--accent)]">
+                      {t('teams.wizard.coordinator')}
+                    </span>
+                  )}
+                  {agent.model && (
+                    <span className="type-meta flex-shrink-0 truncate max-w-24 text-[var(--text-muted)]">
+                      {agent.model}
+                    </span>
+                  )}
+                </>
+              }
+              depth={1}
+              open={!!openFolders[`agent-${agent.agentId}`]}
+              onToggle={() => toggle(`agent-${agent.agentId}`)}
+            >
+              {agent.files.map((file) => (
+                <TreeItem
+                  key={file.id}
+                  label={file.label}
+                  icon={<FileText size={12} className={ICON_CLS} />}
+                  depth={2}
+                  selected={selectedFileId === file.id}
+                  onClick={() => onSelectFile(file)}
+                />
+              ))}
+              {agent.skillCount > 0 && (
+                <TreeItem
+                  label={`${agent.skillCount} skills`}
+                  icon={<Puzzle size={12} className={ICON_CLS} />}
+                  depth={2}
+                  selected={selectedFileId === `agent-skills-${agent.agentId}`}
+                  onClick={() =>
+                    onSelectFile({
+                      id: `agent-skills-${agent.agentId}`,
+                      label: `${agent.name} Skills`,
+                      kind: 'agent-skills',
+                      agentId: agent.agentId,
+                      agentName: agent.name,
+                    })
+                  }
+                />
+              )}
+            </FolderItem>
+          ))}
+        </FolderItem>
+
+        <FolderItem
+          label={t('teams.detail.skills')}
+          depth={0}
+          open={!!openFolders.skills}
+          onToggle={() => toggle('skills')}
+        >
+          {skills.length === 0 ? (
+            <div className="type-meta px-2 py-1 text-[var(--text-muted)]" style={{ paddingLeft: '22px' }}>
+              {t('teams.detail.noSkills')}
+            </div>
+          ) : (
+            skills.map((skill) => (
               <TreeItem
-                key={file.id}
-                label={file.label}
-                icon={<FileText size={12} className={ICON_CLS} />}
-                depth={2}
-                selected={selectedFileId === file.id}
-                onClick={() => onSelectFile(file)}
-              />
-            ))}
-            {agent.skillCount > 0 && (
-              <TreeItem
-                label={`${agent.skillCount} skills`}
+                key={skill.id}
+                label={skill.name}
                 icon={<Puzzle size={12} className={ICON_CLS} />}
-                depth={2}
-                selected={selectedFileId === `agent-skills-${agent.agentId}`}
+                depth={1}
+                selected={selectedFileId === `skill-${skill.id}`}
                 onClick={() =>
-                  onSelectFile({
-                    id: `agent-skills-${agent.agentId}`,
-                    label: `${agent.name} Skills`,
-                    kind: 'agent-skills',
-                    agentId: agent.agentId,
-                    agentName: agent.name,
-                  })
+                  onSelectFile({ id: `skill-${skill.id}`, label: skill.name, kind: 'skill-item', skillId: skill.id })
                 }
               />
-            )}
-          </FolderItem>
-        ))}
-      </FolderItem>
-
-      <FolderItem
-        label={t('teams.detail.skills')}
-        depth={0}
-        open={!!openFolders.skills}
-        onToggle={() => toggle('skills')}
-      >
-        {skills.length === 0 ? (
-          <div className="type-meta px-2 py-1 text-[var(--text-muted)]" style={{ paddingLeft: '22px' }}>
-            {t('teams.detail.noSkills')}
-          </div>
-        ) : (
-          skills.map((skill) => (
-            <TreeItem
-              key={skill.id}
-              label={skill.name}
-              icon={<Puzzle size={12} className={ICON_CLS} />}
-              depth={1}
-              selected={selectedFileId === `skill-${skill.id}`}
-              onClick={() =>
-                onSelectFile({ id: `skill-${skill.id}`, label: skill.name, kind: 'skill-item', skillId: skill.id })
-              }
-            />
-          ))
+            ))
+          )}
+        </FolderItem>
+      </div>
+      <div
+        onMouseDown={onResizeStart}
+        className={cn(
+          'absolute top-0 right-0 bottom-0 z-10 flex w-1 translate-x-1/2 cursor-col-resize items-center justify-center',
         )}
-      </FolderItem>
+      >
+        <div
+          className={cn(
+            'h-8 w-1 rounded-full transition-colors duration-150',
+            isDragging ? 'bg-[var(--accent)]' : 'bg-transparent hover:bg-[var(--text-muted)]',
+          )}
+        />
+      </div>
     </div>
   );
 }

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamHubDetailView.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamHubDetailView.tsx
@@ -6,6 +6,7 @@ import type { TeamHubEntry, ParsedTeam, AgentFileSet } from '@clawwork/shared';
 import { extractSkillSlugs } from '@clawwork/core';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useResizePanel } from '@/hooks/useResizePanel';
 import { useUiStore } from '@/stores/uiStore';
 import { useTeamStore } from '@/stores/teamStore';
 import { cn } from '@/lib/utils';
@@ -37,6 +38,17 @@ export default function TeamHubDetailView({ entry, onBack }: TeamHubDetailViewPr
     id: 'team-md',
     label: 'TEAM.md',
     kind: 'team-md',
+  });
+  const {
+    width: fileTreeWidth,
+    isDragging: isFileTreeDragging,
+    handleMouseDown: handleFileTreeResizeStart,
+  } = useResizePanel({
+    defaultWidth: 220,
+    minWidth: 192,
+    maxWidth: 420,
+    storageKey: 'clawwork:team-file-tree-width',
+    side: 'left',
   });
 
   const installed = useMemo(
@@ -267,6 +279,9 @@ export default function TeamHubDetailView({ entry, onBack }: TeamHubDetailViewPr
               skills={allSkills}
               selectedFileId={selectedFile?.id ?? null}
               onSelectFile={setSelectedFile}
+              width={fileTreeWidth}
+              isDragging={isFileTreeDragging}
+              onResizeStart={handleFileTreeResizeStart}
             />
 
             <div className="flex flex-1 flex-col min-w-0">


### PR DESCRIPTION
## Summary

Add a resizable team file tree so longer agent names are easier to read in team detail views.

## Type of change

- [x] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The team file tree used a fixed narrow width, which truncated agent names in normal team configurations. Users need control over that split pane width when inspecting team agents and files.

## What changed?

- Extended `useResizePanel` to support left-anchored panels.
- Made `TeamFileTree` width controlled by the resize hook with persisted local storage.
- Applied the resizable tree in both installed team details and Team Hub previews.

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: three-panel layout remains the core product affordance; renderer owns UI state and presentation.
- Why those invariants remain protected: the change is renderer-only and only adjusts panel sizing behavior within an existing team detail layout.

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
```

## Screenshots or recordings

No screenshot attached. The change preserves existing CSS variables and interaction styling, reusing the existing resize handle pattern from the file browser preview panel.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Team file trees can now be resized to show longer agent names.
```

## Checklist

- [ ] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

## Considered and deferred

- packages/desktop/src/renderer/layouts/TeamsPanel/TeamDetailView.tsx:128 [BOT-NIT]: `TeamFileTree` resize config is duplicated in two callers; moving `useResizePanel` into `TeamFileTree` would reduce props, but this is a style cleanup, not a ship blocker.
- packages/desktop/src/renderer/layouts/TeamsPanel/TeamFileTree.tsx:216 [BOT-NIT]: The resize handle lacks `role="separator"` and keyboard resize support; current repo pattern in `packages/desktop/src/renderer/layouts/FileBrowser/index.tsx:355` also uses a mouse-only handle, so this is an existing UI accessibility follow-up, not a regression.