### PR TITLE
[Chore] Remove tray disconnect indicator

### DIFF
--- a/packages/desktop/src/main/tray.ts
+++ b/packages/desktop/src/main/tray.ts
@@ -5,7 +5,7 @@ import { getDebugLogger } from './debug/index.js';
 import { readConfig, updateConfig } from './workspace/config.js';
 import { getMainWindow } from './window-manager.js';
 
-export type TrayStatus = 'idle' | 'running' | 'unread' | 'disconnected';
+export type TrayStatus = 'idle' | 'running' | 'unread';
 
 export interface TrayTaskInfo {
   taskId: string;
@@ -148,10 +148,6 @@ export function updateTrayStatus(state: TrayState): void {
     case 'unread':
       tray.setTitle('●');
       tray.setToolTip('ClawWork — new results');
-      break;
-    case 'disconnected':
-      tray.setTitle('⚠');
-      tray.setToolTip('ClawWork — disconnected');
       break;
     default:
       tray.setTitle('');

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -468,7 +468,7 @@ export interface ClawWorkAPI {
   compactSession: (gatewayId: string, sessionKey: string, maxLines?: number) => Promise<IpcResult>;
 
   updateTrayStatus: (
-    status: 'idle' | 'running' | 'unread' | 'disconnected',
+    status: 'idle' | 'running' | 'unread',
     tasks?: { taskId: string; title: string; snippet: string; duration: string }[],
   ) => void;
   getTrayEnabled: () => Promise<boolean>;

--- a/packages/desktop/src/renderer/hooks/useTraySync.ts
+++ b/packages/desktop/src/renderer/hooks/useTraySync.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useTaskStore } from '../stores/taskStore';
-import { useUiStore } from '../stores/uiStore';
 import { useMessageStore } from '../stores/messageStore';
+import { useUiStore } from '../stores/uiStore';
 import i18n from '../i18n';
 
 function formatDuration(updatedAt: string): string {
@@ -15,19 +15,16 @@ function formatDuration(updatedAt: string): string {
 export function useTraySync(): void {
   const tasks = useTaskStore((s) => s.tasks);
   const processingBySession = useMessageStore((s) => s.processingBySession);
-  const gatewayStatusMap = useUiStore((s) => s.gatewayStatusMap);
   const unreadTaskIds = useUiStore((s) => s.unreadTaskIds);
 
   const prevRef = useRef<{ status: string; taskIds: string }>({ status: '', taskIds: '' });
 
   useEffect(() => {
-    const anyDisconnected = Object.values(gatewayStatusMap).some((s) => s === 'disconnected');
     const isRunning = processingBySession.size > 0;
     const hasUnread = unreadTaskIds.size > 0;
 
-    let status: 'idle' | 'running' | 'unread' | 'disconnected';
-    if (anyDisconnected) status = 'disconnected';
-    else if (isRunning) status = 'running';
+    let status: 'idle' | 'running' | 'unread';
+    if (isRunning) status = 'running';
     else if (hasUnread) status = 'unread';
     else status = 'idle';
 
@@ -49,5 +46,5 @@ export function useTraySync(): void {
     });
 
     window.clawwork.updateTrayStatus(status, activeTasks);
-  }, [tasks, processingBySession, gatewayStatusMap, unreadTaskIds]);
+  }, [tasks, processingBySession, unreadTaskIds]);
 }


### PR DESCRIPTION
## Summary

Remove the tray-level gateway disconnect indicator so ClawWork no longer shows a warning marker in the macOS menu bar when a gateway is disconnected.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [x] `[Chore]` maintenance

## Why is this needed?

The tray warning state adds noise without enough actionable context. This keeps the tray focused on task activity and unread results instead of surfacing gateway disconnect state there.

## What changed?

- Removed `disconnected` from the tray status model.
- Removed the warning title and disconnected tooltip branch from the main-process tray updater.
- Stopped `useTraySync` from deriving tray status from gateway connection state.
- Narrowed the preload `updateTrayStatus` type to `idle`, `running`, and `unread`.

## Architecture impact

- Owning layer: main / preload / renderer
- Cross-layer impact: yes — the tray status IPC surface is narrowed across renderer, preload typing, and main-process handling.
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: this change only removes a tray presentation state and does not affect task/session identity, Gateway routing, persistence, or message write paths.

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
```

## Screenshots or recordings

Native macOS tray/menu bar state was not captured with the available tooling. No renderer styles, layout tokens, spacing, component states, or interaction polish were changed.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Removed the tray warning indicator for disconnected gateways.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
