### PR TITLE
[Fix] Apply model slash commands through session patch

### DIFF
--- a/packages/core/src/services/chat-composer.ts
+++ b/packages/core/src/services/chat-composer.ts
@@ -12,7 +12,7 @@ interface TaskRef {
 }
 
 export interface ChatComposerDeps {
-  gateway: Pick<GatewayTransportPort, 'sendMessage' | 'abortChat'>;
+  gateway: Pick<GatewayTransportPort, 'sendMessage' | 'abortChat' | 'patchSession'>;
 
   getTaskStore: () => {
     tasks: TaskRef[];
@@ -164,14 +164,28 @@ export function createChatComposer(deps: ChatComposerDeps) {
 
       if (!isMentionSend) {
         if (options.presetModel) {
-          await deps.gateway.sendMessage(task.gatewayId, task.sessionKey, `/model ${options.presetModel}`);
+          const modelRes = await deps.gateway.patchSession(task.gatewayId, task.sessionKey, {
+            model: options.presetModel,
+          });
+          if (!modelRes.ok) {
+            store.setProcessing(task.sessionKey, false);
+            emitError(task.id, 'gateway', 'send', modelRes.error || deps.translate('errors.sendFailed'));
+            return { ok: false, taskId: task.id };
+          }
           deps.getTaskStore().updateTaskMetadata(task.id, {
             model: options.presetModel,
             modelProvider: deps.getModelProvider?.(task.gatewayId, options.presetModel),
           });
         }
         if (options.presetThinking && options.presetThinking !== 'off') {
-          await deps.gateway.sendMessage(task.gatewayId, task.sessionKey, `/think ${options.presetThinking}`);
+          const thinkingRes = await deps.gateway.patchSession(task.gatewayId, task.sessionKey, {
+            thinkingLevel: options.presetThinking,
+          });
+          if (!thinkingRes.ok) {
+            store.setProcessing(task.sessionKey, false);
+            emitError(task.id, 'gateway', 'send', thinkingRes.error || deps.translate('errors.sendFailed'));
+            return { ok: false, taskId: task.id };
+          }
           deps.getTaskStore().updateTaskMetadata(task.id, { thinkingLevel: options.presetThinking });
         }
       }
@@ -323,7 +337,8 @@ export function createChatComposer(deps: ChatComposerDeps) {
       }
       case 'model': {
         if (!arg) return { ok: false };
-        await deps.gateway.sendMessage(task.gatewayId, task.sessionKey, `/model ${arg}`);
+        const res = await deps.gateway.patchSession(task.gatewayId, task.sessionKey, { model: arg });
+        if (!res.ok) return { ok: false };
         deps.getTaskStore().updateTaskMetadata(taskId, {
           model: arg,
           modelProvider: deps.getModelProvider?.(task.gatewayId, arg),
@@ -332,7 +347,8 @@ export function createChatComposer(deps: ChatComposerDeps) {
       }
       case 'think': {
         if (!arg) return { ok: false };
-        await deps.gateway.sendMessage(task.gatewayId, task.sessionKey, `/think ${arg}`);
+        const res = await deps.gateway.patchSession(task.gatewayId, task.sessionKey, { thinkingLevel: arg });
+        if (!res.ok) return { ok: false };
         deps.getTaskStore().updateTaskMetadata(taskId, { thinkingLevel: arg });
         return { ok: true };
       }

--- a/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
@@ -406,6 +406,14 @@ export function useChatSend(opts: UseChatSendOpts) {
       }));
       const allAttachments = [...gatewayAttachments, ...extraAttachments];
 
+      const slashMatch = finalContent.trim().match(/^\/(model|think)\s+(.+)$/);
+      if (slashMatch && allAttachments.length === 0 && !msgAttachments?.length) {
+        const command = slashMatch[1] as 'model' | 'think';
+        const result = await composer.applySlashCommand(task.id, command, slashMatch[2].trim());
+        if (!result.ok) toast.error(t('errors.sendFailed'));
+        return;
+      }
+
       const titleHint =
         content ||
         (localFileMentions.length ? `[@${localFileMentions[0].fileName}]` : '') ||

--- a/packages/desktop/test/use-chat-send.test.tsx
+++ b/packages/desktop/test/use-chat-send.test.tsx
@@ -22,6 +22,8 @@ const mocks = vi.hoisted(() => {
 
   return {
     abort: vi.fn(async () => {}),
+    applySlashCommand: vi.fn(async () => ({ ok: true })),
+    send: vi.fn(async () => ({ ok: true, taskId: 'task-1' })),
     taskState: {
       tasks: [activeTask],
       activeTaskId: 'task-1',
@@ -59,6 +61,8 @@ vi.mock('sonner', () => ({
 vi.mock('../src/renderer/platform', () => ({
   composer: {
     abort: mocks.abort,
+    applySlashCommand: mocks.applySlashCommand,
+    send: mocks.send,
   },
   useTaskStore: <T,>(selector?: (state: typeof mocks.taskState) => T) =>
     selector ? selector(mocks.taskState) : mocks.taskState,
@@ -92,7 +96,7 @@ function render(ui: ReactElement): { container: HTMLDivElement; unmount: () => v
   };
 }
 
-function Harness() {
+function Harness({ initialValue = '' }: { initialValue?: string }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const chat = useChatSend({
     textareaRef,
@@ -112,9 +116,12 @@ function Harness() {
 
   return (
     <>
-      <textarea ref={textareaRef} />
+      <textarea ref={textareaRef} defaultValue={initialValue} />
       <button type="button" onClick={() => void chat.handleAbort()}>
         abort
+      </button>
+      <button type="button" onClick={() => void chat.handleSend()}>
+        send
       </button>
       <div data-testid="aborting">{chat.aborting ? 'aborting' : 'idle'}</div>
     </>
@@ -126,6 +133,8 @@ describe('useChatSend abort flow', () => {
     vi.useFakeTimers();
     document.body.innerHTML = '';
     mocks.abort.mockClear();
+    mocks.applySlashCommand.mockClear();
+    mocks.send.mockClear();
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   });
 
@@ -156,5 +165,18 @@ describe('useChatSend abort flow', () => {
     });
 
     expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('routes model slash input through the local command path', async () => {
+    const { container } = render(<Harness initialValue="/model public/deepseek-v4-pro" />);
+    const buttons = container.querySelectorAll('button');
+
+    await act(async () => {
+      buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.applySlashCommand).toHaveBeenCalledWith('task-1', 'model', 'public/deepseek-v4-pro');
+    expect(mocks.send).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Route model and thinking slash commands through session patching instead of sending them as chat messages.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Model and thinking changes are session configuration updates, not user chat content. Sending them through the normal chat path can pollute the conversation stream and trigger unnecessary message send behavior.

## What changed?

- Updated `ChatComposer` to call `gateway.patchSession` for preset model and thinking changes.
- Routed pure `/model ...` and `/think ...` input through `composer.applySlashCommand` when no attachments are present.
- Added renderer hook coverage to ensure model slash input does not call the normal send path.

## Architecture impact

- Owning layer: core / renderer
- Cross-layer impact: yes, renderer command handling now invokes the core composer slash command path, which uses the existing gateway transport port.
- Invariants touched from `docs/architecture-invariants.md`: message send path and gateway session metadata updates.
- Why those invariants remain protected: slash model/thinking commands no longer add a user message or create a new message write path; session metadata is updated through the gateway transport and task metadata store only.

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
```

## Screenshots or recordings

Not applicable. This is command routing behavior without visual changes.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fixed model and thinking slash commands so they update the session instead of being sent as chat messages.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate