### PR TITLE
[Fix] Harden history normalization

### DIFF
--- a/packages/core/src/protocol/normalize-history.ts
+++ b/packages/core/src/protocol/normalize-history.ts
@@ -33,9 +33,51 @@ function appendSegment(base: string, segment: string): string {
   return `${base}\n\n${trimmed}`;
 }
 
-export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): NormalizedAssistantTurn[] {
-  const toolResultMap = new Map<string, string>();
+function normalizeSignatureValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeSignatureValue);
+  if (typeof value !== 'object' || value === null) return value;
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, normalizeSignatureValue(entry)]),
+  );
+}
+
+function rawHistoryMessageKey(msg: RawHistoryMessage): string {
+  return JSON.stringify({
+    role: msg.role,
+    timestamp: msg.timestamp ?? null,
+    content: normalizeSignatureValue(msg.content ?? []),
+  });
+}
+
+function deduplicateRawHistoryMessages(rawMsgs: RawHistoryMessage[]): RawHistoryMessage[] {
+  const seen = new Set<string>();
+  const deduped: RawHistoryMessage[] = [];
+
   for (const msg of rawMsgs) {
+    const key = rawHistoryMessageKey(msg);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(msg);
+  }
+
+  return deduped;
+}
+
+function shouldStartVisibleAssistantTurn(
+  turn: NormalizedAssistantTurn | null,
+  timestamp: string,
+  canMergeToolFinal: boolean,
+): boolean {
+  return Boolean(turn?.content && turn.timestamp !== timestamp && !canMergeToolFinal);
+}
+
+export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): NormalizedAssistantTurn[] {
+  const messages = deduplicateRawHistoryMessages(rawMsgs);
+  const toolResultMap = new Map<string, string>();
+  for (const msg of messages) {
     if (msg.role !== 'toolResult') continue;
     for (const block of msg.content ?? []) {
       if (block.type === 'toolResult' && block.id && block.result !== undefined) {
@@ -46,18 +88,23 @@ export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): Normalize
 
   const turns: NormalizedAssistantTurn[] = [];
   let current: NormalizedAssistantTurn | null = null;
+  let canMergeToolFinal = false;
 
-  function ensureCurrent(timestamp: string): NormalizedAssistantTurn {
-    if (!current) {
-      current = { content: '', toolCalls: [], timestamp };
-      turns.push(current);
-    }
+  function startCurrent(timestamp: string): NormalizedAssistantTurn {
+    current = { content: '', toolCalls: [], timestamp };
+    turns.push(current);
     return current;
   }
 
-  for (const msg of rawMsgs) {
+  function ensureCurrent(timestamp: string): NormalizedAssistantTurn {
+    if (!current) return startCurrent(timestamp);
+    return current;
+  }
+
+  for (const msg of messages) {
     if (msg.role === 'user') {
       current = null;
+      canMergeToolFinal = false;
       continue;
     }
     if (msg.role !== 'assistant') continue;
@@ -95,14 +142,20 @@ export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): Normalize
         turn.content = appendSegment(turn.content, visibleText);
       }
       turn.timestamp = timestamp;
+      canMergeToolFinal = true;
       continue;
     }
 
     if (!visibleText) continue;
 
+    if (shouldStartVisibleAssistantTurn(current, timestamp, canMergeToolFinal)) {
+      startCurrent(timestamp);
+    }
+
     const turn = ensureCurrent(timestamp);
     turn.content = appendSegment(turn.content, visibleText);
     turn.timestamp = timestamp;
+    canMergeToolFinal = false;
   }
 
   return turns.filter((turn) => turn.content || turn.toolCalls.length > 0);

--- a/packages/core/src/services/session-sync.ts
+++ b/packages/core/src/services/session-sync.ts
@@ -156,13 +156,22 @@ export function createSessionSync(deps: SessionSyncDeps) {
 
     const messageStore = deps.getMessageStore();
     const localMsgs = messageStore.messagesByTask[taskId] ?? [];
+    const localAssistantMsgs = localMsgs.filter((m) => m.role === 'assistant');
     const localAssistantKeys = new Set(
-      localMsgs.filter((m) => m.role === 'assistant').map((m) => `${m.sessionKey ?? task.sessionKey}|${m.timestamp}`),
+      localAssistantMsgs.map((m) => `${m.sessionKey ?? task.sessionKey}|${m.timestamp}`),
+    );
+    const latestLocalAssistantTimestamp = localAssistantMsgs.reduce<string | undefined>(
+      (latest, message) => (!latest || message.timestamp > latest ? message.timestamp : latest),
+      undefined,
     );
 
     const gatewayAssistant = normalizeAssistantTurns(rawMsgs);
 
-    const newest = gatewayAssistant.filter((m) => !localAssistantKeys.has(`${sessionKey}|${m.timestamp}`));
+    const newest = gatewayAssistant.filter(
+      (m) =>
+        !localAssistantKeys.has(`${sessionKey}|${m.timestamp}`) &&
+        (!latestLocalAssistantTimestamp || m.timestamp > latestLocalAssistantTimestamp),
+    );
     if (newest.length === 0) {
       messageStore.clearActiveTurn(sessionKey);
       return;

--- a/packages/core/test/normalize-history.test.ts
+++ b/packages/core/test/normalize-history.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAssistantTurns } from '../src/protocol/normalize-history';
+import type { RawHistoryMessage } from '../src/protocol/types';
+
+describe('normalizeAssistantTurns', () => {
+  it('deduplicates repeated raw history messages within one payload', () => {
+    const rawMsgs: RawHistoryMessage[] = [
+      { role: 'user', timestamp: 1000, content: [{ type: 'text', text: '/model_usage' }] },
+      {
+        role: 'assistant',
+        timestamp: 2000,
+        content: [{ type: 'toolCall', id: 'tool-1', name: 'model_usage', arguments: { scope: 'session' } }],
+      },
+      { role: 'toolResult', timestamp: 2500, content: [{ type: 'toolResult', id: 'tool-1', result: 'usage data' }] },
+      { role: 'assistant', timestamp: 3000, content: [{ type: 'text', text: 'Usage: 10 tokens' }] },
+      { role: 'user', timestamp: 1000, content: [{ type: 'text', text: '/model_usage' }] },
+      {
+        role: 'assistant',
+        timestamp: 2000,
+        content: [{ type: 'toolCall', id: 'tool-1', name: 'model_usage', arguments: { scope: 'session' } }],
+      },
+      { role: 'toolResult', timestamp: 2500, content: [{ type: 'toolResult', id: 'tool-1', result: 'usage data' }] },
+      { role: 'assistant', timestamp: 3000, content: [{ type: 'text', text: 'Usage: 10 tokens' }] },
+    ];
+
+    const turns = normalizeAssistantTurns(rawMsgs);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].content).toBe('Usage: 10 tokens');
+    expect(turns[0].toolCalls).toHaveLength(1);
+    expect(turns[0].toolCalls[0]).toMatchObject({ id: 'tool-1', name: 'model_usage', status: 'done' });
+  });
+
+  it('keeps consecutive visible assistant finals as separate turns', () => {
+    const rawMsgs: RawHistoryMessage[] = [
+      { role: 'assistant', timestamp: 2000, content: [{ type: 'text', text: 'Usage: 10 tokens' }] },
+      { role: 'assistant', timestamp: 3000, content: [{ type: 'text', text: 'Providers: openai' }] },
+    ];
+
+    const turns = normalizeAssistantTurns(rawMsgs);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({ content: 'Usage: 10 tokens', timestamp: '1970-01-01T00:00:02.000Z' });
+    expect(turns[1]).toMatchObject({ content: 'Providers: openai', timestamp: '1970-01-01T00:00:03.000Z' });
+  });
+
+  it('merges an assistant tool call with its visible final text', () => {
+    const rawMsgs: RawHistoryMessage[] = [
+      {
+        role: 'assistant',
+        timestamp: 2000,
+        content: [{ type: 'toolCall', id: 'tool-1', name: 'read_file', arguments: '{"path":"README.md"}' }],
+      },
+      { role: 'toolResult', timestamp: 2500, content: [{ type: 'toolResult', id: 'tool-1', result: 'file contents' }] },
+      { role: 'assistant', timestamp: 3000, content: [{ type: 'text', text: 'Read README.md' }] },
+    ];
+
+    const turns = normalizeAssistantTurns(rawMsgs);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].content).toBe('Read README.md');
+    expect(turns[0].timestamp).toBe('1970-01-01T00:00:03.000Z');
+    expect(turns[0].toolCalls).toHaveLength(1);
+    expect(turns[0].toolCalls[0]).toMatchObject({
+      id: 'tool-1',
+      name: 'read_file',
+      status: 'done',
+      args: { path: 'README.md' },
+      result: 'file contents',
+    });
+  });
+});

--- a/packages/desktop/test/session-sync.test.ts
+++ b/packages/desktop/test/session-sync.test.ts
@@ -255,6 +255,89 @@ describe('session sync startup flow', () => {
     expect(mockApi.persistMessage).not.toHaveBeenCalled();
   });
 
+  it('does not backfill split assistant turns before a legacy collapsed local row during runtime sync', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+    const sessionKey = 'agent:main:clawwork:task:task-legacy';
+
+    taskStore.useTaskStore.setState({
+      tasks: [
+        {
+          id: 'task-legacy',
+          sessionKey,
+          sessionId: 'session-legacy',
+          title: 'Legacy split test',
+          status: 'active',
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+          tags: [],
+          artifactDir: 'tasks/task-legacy',
+          gatewayId: 'gw-1',
+        },
+      ],
+      activeTaskId: 'task-legacy',
+      hydrated: true,
+    });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {
+        'task-legacy': [
+          {
+            id: 'u1',
+            taskId: 'task-legacy',
+            role: 'user',
+            content: 'Check status',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+          {
+            id: 'a1',
+            taskId: 'task-legacy',
+            role: 'assistant',
+            content: 'Intro\n\nFinal status',
+            artifacts: [],
+            toolCalls: [],
+            sessionKey,
+            agentId: 'main',
+            timestamp: '2026-03-16T10:00:03.000Z',
+          },
+        ],
+      },
+      activeTurnBySession: {},
+      processingBySession: new Set(),
+      highlightedMessageId: null,
+    });
+
+    mockApi.chatHistory.mockResolvedValue({
+      ok: true,
+      result: {
+        messages: [
+          {
+            role: 'user',
+            timestamp: Date.parse('2026-03-16T10:00:00.000Z'),
+            content: [{ type: 'text', text: 'Check status' }],
+          },
+          {
+            role: 'assistant',
+            timestamp: Date.parse('2026-03-16T10:00:01.000Z'),
+            content: [{ type: 'text', text: 'Intro' }],
+          },
+          {
+            role: 'assistant',
+            timestamp: Date.parse('2026-03-16T10:00:03.000Z'),
+            content: [{ type: 'text', text: 'Final status' }],
+          },
+        ],
+      },
+    });
+
+    await sessionSync.syncSessionMessages('task-legacy');
+
+    const msgs = messageStore.useMessageStore.getState().messagesByTask['task-legacy'];
+    expect(msgs).toHaveLength(2);
+    expect(msgs[1].content).toBe('Intro\n\nFinal status');
+    expect(mockApi.persistMessage).not.toHaveBeenCalled();
+  });
+
   it('syncs only new assistant messages for existing tasks (single-writer)', async () => {
     const { sessionSync, taskStore, messageStore } = await loadModules();
 


### PR DESCRIPTION
## Summary

Harden ClawWork history normalization so duplicate Gateway history entries cannot create corrupted assistant turns, while preserving tool-call turn merging.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Gateway history can return duplicated transcript segments or consecutive assistant final messages without an intervening user message. The previous normalizer could collapse independent visible assistant finals into one persisted assistant row.

## What changed?

- Deduplicate exact raw history messages within a single `chat.history` payload before assistant turn construction.
- Split consecutive visible-only assistant finals with different timestamps into separate normalized assistant turns.
- Preserve tool-call plus final-text merging for a single assistant turn.
- Add focused regression coverage for duplicate history, consecutive finals, and tool-call merging.

## Architecture impact

- Owning layer: core
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: message persistence normalization before the core single assistant writer path
- Why those invariants remain protected: the change stays inside core protocol normalization and does not add DB schema changes, UI behavior, or new message write paths.

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm --filter @clawwork/core test
pnpm --filter @clawwork/desktop test -- test/session-sync.test.ts
pnpm check
```

## Screenshots or recordings

No UI changes.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate