### PR TITLE
[Fix] Replace silent-swallow .catch in AgentsSection avatar paths

### DIFF
--- a/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
@@ -830,7 +830,9 @@ export default function AgentsSection() {
       });
       if (res.ok) {
         if (isNewUpload) {
-          window.clawwork.saveAgentAvatar(selectedGatewayId, editingAgentId, form.avatar).catch(() => {});
+          window.clawwork
+            .saveAgentAvatar(selectedGatewayId, editingAgentId, form.avatar)
+            .catch((err) => console.error('[AgentsSection] saveAgentAvatar (update) failed:', err));
         }
         const parsed = parseIdentityMd(form.identityRaw);
         const newContent = serializeIdentityMd(form.description.trim() || undefined, parsed.body, form.identityRaw);
@@ -865,7 +867,9 @@ export default function AgentsSection() {
         const created = res.result as Record<string, unknown> | undefined;
         const newAgentId = (created?.agentId as string) ?? '';
         if (isNewUpload && newAgentId) {
-          window.clawwork.saveAgentAvatar(selectedGatewayId, newAgentId, form.avatar).catch(() => {});
+          window.clawwork
+            .saveAgentAvatar(selectedGatewayId, newAgentId, form.avatar)
+            .catch((err) => console.error('[AgentsSection] saveAgentAvatar (create) failed:', err));
         }
         if (newAgentId && form.description.trim()) {
           const content = serializeIdentityMd(form.description.trim(), '');
@@ -894,7 +898,9 @@ export default function AgentsSection() {
       deleteFiles,
     });
     if (res.ok) {
-      window.clawwork.deleteAgentAvatar(selectedGatewayId, deletingAgentId).catch(() => {});
+      window.clawwork
+        .deleteAgentAvatar(selectedGatewayId, deletingAgentId)
+        .catch((err) => console.error('[AgentsSection] deleteAgentAvatar failed:', err));
       toast.success(t('settings.agentDeleted'));
       if (expandedFilesAgentId === deletingAgentId) {
         setExpandedFilesAgentId(null);

--- a/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
@@ -830,9 +830,14 @@ export default function AgentsSection() {
       });
       if (res.ok) {
         if (isNewUpload) {
-          window.clawwork
-            .saveAgentAvatar(selectedGatewayId, editingAgentId, form.avatar)
-            .catch((err) => console.error('[AgentsSection] saveAgentAvatar (update) failed:', err));
+          try {
+            const avatarRes = await window.clawwork.saveAgentAvatar(selectedGatewayId, editingAgentId, form.avatar);
+            if (!avatarRes.ok) {
+              console.error('[AgentsSection] saveAgentAvatar (update) failed:', avatarRes.error);
+            }
+          } catch (err) {
+            console.error('[AgentsSection] saveAgentAvatar (update) rejected:', err);
+          }
         }
         const parsed = parseIdentityMd(form.identityRaw);
         const newContent = serializeIdentityMd(form.description.trim() || undefined, parsed.body, form.identityRaw);
@@ -867,9 +872,14 @@ export default function AgentsSection() {
         const created = res.result as Record<string, unknown> | undefined;
         const newAgentId = (created?.agentId as string) ?? '';
         if (isNewUpload && newAgentId) {
-          window.clawwork
-            .saveAgentAvatar(selectedGatewayId, newAgentId, form.avatar)
-            .catch((err) => console.error('[AgentsSection] saveAgentAvatar (create) failed:', err));
+          try {
+            const avatarRes = await window.clawwork.saveAgentAvatar(selectedGatewayId, newAgentId, form.avatar);
+            if (!avatarRes.ok) {
+              console.error('[AgentsSection] saveAgentAvatar (create) failed:', avatarRes.error);
+            }
+          } catch (err) {
+            console.error('[AgentsSection] saveAgentAvatar (create) rejected:', err);
+          }
         }
         if (newAgentId && form.description.trim()) {
           const content = serializeIdentityMd(form.description.trim(), '');
@@ -898,9 +908,14 @@ export default function AgentsSection() {
       deleteFiles,
     });
     if (res.ok) {
-      window.clawwork
-        .deleteAgentAvatar(selectedGatewayId, deletingAgentId)
-        .catch((err) => console.error('[AgentsSection] deleteAgentAvatar failed:', err));
+      try {
+        const avatarRes = await window.clawwork.deleteAgentAvatar(selectedGatewayId, deletingAgentId);
+        if (!avatarRes.ok) {
+          console.error('[AgentsSection] deleteAgentAvatar failed:', avatarRes.error);
+        }
+      } catch (err) {
+        console.error('[AgentsSection] deleteAgentAvatar rejected:', err);
+      }
       toast.success(t('settings.agentDeleted'));
       if (expandedFilesAgentId === deletingAgentId) {
         setExpandedFilesAgentId(null);


### PR DESCRIPTION
## Summary

Closes #402.

`AgentsSection` had three remaining `.catch(() => {})` call sites that silently dropped errors from avatar persistence. This PR replaces them with `console.error` calls following the convention used in `SystemSection.tsx`.

## Changes

`packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx`:

- Line 833 (update path): `saveAgentAvatar` errors now logged as `[AgentsSection] saveAgentAvatar (update) failed:`
- Line 868 (create path): `saveAgentAvatar` errors now logged as `[AgentsSection] saveAgentAvatar (create) failed:`
- Line 897 (delete path): `deleteAgentAvatar` errors now logged as `[AgentsSection] deleteAgentAvatar failed:`

## Verification

- `pnpm lint` — clean
- `pnpm exec prettier --check packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx` — passes
- Repo-wide grep for `.catch(() => {})` in `renderer/layouts/Settings/` — no remaining hits
- Convention matches existing usage in `SystemSection.tsx`

I deferred adding a `toast.error` so the change stays narrowly scoped to fixing the silent swallow; happy to follow up with a separate PR adding user-visible error surfaces if desired.