### PR TITLE
[Feat] Add shared gateway selector

### DIFF
--- a/packages/core/src/stores/team-store.ts
+++ b/packages/core/src/stores/team-store.ts
@@ -23,6 +23,7 @@ export interface TeamStoreDeps {
 export interface TeamState {
   teams: Record<string, Team>;
   loading: boolean;
+  loadedOnce: boolean;
   loadTeams(): Promise<void>;
   createTeam(params: Omit<Team, 'id' | 'createdAt' | 'updatedAt'>): Promise<string>;
   updateTeam(id: string, updates: Partial<Team>): Promise<void>;
@@ -36,6 +37,7 @@ export function createTeamStore(deps: TeamStoreDeps) {
   const store = createStore<TeamState>((set, get) => ({
     teams: {},
     loading: false,
+    loadedOnce: false,
 
     loadTeams: async () => {
       set({ loading: true });
@@ -51,7 +53,7 @@ export function createTeamStore(deps: TeamStoreDeps) {
       } catch (err) {
         console.error('[team-store] loadTeams failed:', err);
       } finally {
-        set({ loading: false });
+        set({ loading: false, loadedOnce: true });
       }
     },
 

--- a/packages/core/src/stores/team-store.ts
+++ b/packages/core/src/stores/team-store.ts
@@ -48,12 +48,12 @@ export function createTeamStore(deps: TeamStoreDeps) {
           for (const t of res.result) {
             map[t.id] = t;
           }
-          set({ teams: map });
+          set({ teams: map, loadedOnce: true });
         }
       } catch (err) {
         console.error('[team-store] loadTeams failed:', err);
       } finally {
-        set({ loading: false, loadedOnce: true });
+        set({ loading: false });
       }
     },
 

--- a/packages/desktop/src/renderer/components/GatewayInstanceSelector.tsx
+++ b/packages/desktop/src/renderer/components/GatewayInstanceSelector.tsx
@@ -1,0 +1,68 @@
+import { Check, ChevronDown, Server } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { GatewayInfo } from '@clawwork/core';
+import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+
+interface GatewayInstanceSelectorProps {
+  gateways: GatewayInfo[];
+  selectedGatewayId: string;
+  onSelectGateway: (id: string) => void;
+  className?: string;
+  buttonClassName?: string;
+  showLabel?: boolean;
+  align?: 'start' | 'center' | 'end';
+}
+
+export default function GatewayInstanceSelector({
+  gateways,
+  selectedGatewayId,
+  onSelectGateway,
+  className,
+  buttonClassName,
+  showLabel = true,
+  align = 'center',
+}: GatewayInstanceSelectorProps) {
+  const { t } = useTranslation();
+  const selectedGateway = gateways.find((gateway) => gateway.id === selectedGatewayId);
+
+  if (gateways.length <= 1 || !selectedGateway) return null;
+
+  const triggerClass = cn(
+    'type-label inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--bg-primary)] px-3 py-1.5 text-[var(--text-secondary)] cursor-pointer transition-colors hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]',
+    buttonClassName,
+  );
+
+  return (
+    <div className={cn('inline-flex items-center gap-2', className)}>
+      {showLabel && <span className="type-support text-[var(--text-muted)]">{t('common.gateway')}</span>}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button aria-label={t('settings.selectGateway')} className={triggerClass}>
+            <Server size={13} />
+            <span className="max-w-32 truncate">{selectedGateway.name}</span>
+            <ChevronDown size={12} className="opacity-60" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align={align}>
+          {gateways.map((gateway) => (
+            <DropdownMenuItem
+              key={gateway.id}
+              onClick={() => onSelectGateway(gateway.id)}
+              className={cn(gateway.id === selectedGatewayId && 'text-[var(--accent)]')}
+            >
+              <Server size={13} />
+              <span className="max-w-32 truncate">{gateway.name}</span>
+              {gateway.id === selectedGatewayId && <Check size={13} className="ml-auto" />}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/hooks/useGatewaySelector.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewaySelector.ts
@@ -17,7 +17,6 @@ interface UseGatewaySelectorResult {
   defaultAgentId: string;
   effectiveAgentId: string;
   setSelectedAgentId: (id: string) => void;
-  hasMultipleGw: boolean;
   hasMultipleAgents: boolean;
 }
 
@@ -46,10 +45,13 @@ export function useGatewaySelector(options: UseGatewaySelectorOptions = {}): Use
   );
 
   useEffect(() => {
-    if (!selectedGwId) {
-      const fallback = defaultGatewayId ?? gateways[0]?.id ?? '';
-      if (fallback) setSelectedGwId(fallback);
-    }
+    if (!gateways.length) return;
+    if (gateways.some((gw) => gw.id === selectedGwId)) return;
+    const fallback =
+      defaultGatewayId && gateways.some((gw) => gw.id === defaultGatewayId)
+        ? defaultGatewayId
+        : (gateways[0]?.id ?? '');
+    if (fallback && fallback !== selectedGwId) setSelectedGwId(fallback);
   }, [defaultGatewayId, gateways, selectedGwId]);
 
   useEffect(() => {
@@ -64,7 +66,6 @@ export function useGatewaySelector(options: UseGatewaySelectorOptions = {}): Use
     defaultAgentId,
     effectiveAgentId,
     setSelectedAgentId,
-    hasMultipleGw: gateways.length > 1,
     hasMultipleAgents: agentCatalog.length > 1,
   };
 }

--- a/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Bot, ChevronDown, ChevronRight, Server, Sparkles, Users, Compass } from 'lucide-react';
+import { Bot, ChevronRight, Sparkles, Users, Compass } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Team } from '@clawwork/shared';
 import { useTaskStore } from '@/stores/taskStore';
@@ -9,13 +9,8 @@ import { cn } from '@/lib/utils';
 import { motion as animationPresets } from '@/styles/design-tokens';
 import { motion } from 'framer-motion';
 import AgentIcon from '@/components/AgentIcon';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from '@/components/ui/dropdown-menu';
 import { useGatewaySelector } from '@/hooks/useGatewaySelector';
+import GatewayInstanceSelector from '@/components/GatewayInstanceSelector';
 import logo from '@/assets/logo.png';
 
 type WelcomeTab = 'agent' | 'team' | 'orchestrate';
@@ -37,9 +32,10 @@ export default function WelcomeScreen() {
   });
   const updateTaskMetadata = useTaskStore((s) => s.updateTaskMetadata);
   const teamsMap = useTeamStore((s) => s.teams);
+  const teamsLoadedOnce = useTeamStore((s) => s.loadedOnce);
   const loadTeams = useTeamStore((s) => s.loadTeams);
 
-  const teams = Object.values(teamsMap);
+  const teams = useMemo(() => Object.values(teamsMap), [teamsMap]);
   const hasTeams = teams.length > 0;
   const {
     gateways,
@@ -49,7 +45,6 @@ export default function WelcomeScreen() {
     defaultAgentId,
     effectiveAgentId,
     setSelectedAgentId,
-    hasMultipleGw,
     hasMultipleAgents,
   } = useGatewaySelector({
     initialGatewayId: pendingNewTask?.gatewayId,
@@ -68,6 +63,11 @@ export default function WelcomeScreen() {
   );
   const [agentExpanded, setAgentExpanded] = useState(false);
 
+  const teamsForSelectedGateway = useMemo(
+    () => teams.filter((team) => team.gatewayId === selectedGwId),
+    [teams, selectedGwId],
+  );
+
   useEffect(() => {
     loadTeams();
   }, [loadTeams]);
@@ -84,17 +84,35 @@ export default function WelcomeScreen() {
           return;
         useTaskStore.getState().setPending({ gatewayId: selectedGwId, agentId: effectiveAgentId });
       }
-    } else if (activeTab === 'team' && selectedTeamId) {
-      const team = teamsMap[selectedTeamId];
-      if (!team) return;
+    } else if (activeTab === 'team') {
+      if (!teamsLoadedOnce) return;
+      const currentTeamValid = selectedTeamId && teamsMap[selectedTeamId]?.gatewayId === selectedGwId;
+      const effectiveTeamId = currentTeamValid ? selectedTeamId : (teamsForSelectedGateway[0]?.id ?? null);
+
+      if (effectiveTeamId !== selectedTeamId) {
+        setSelectedTeamId(effectiveTeamId);
+      }
+
+      if (!effectiveTeamId) {
+        if (!defaultAgentId) return;
+        if (activeTaskId) return;
+        const prev = useTaskStore.getState().pendingNewTask;
+        if (prev?.gatewayId === selectedGwId && prev?.agentId === defaultAgentId && !prev?.ensemble && !prev?.teamId)
+          return;
+        useTaskStore.getState().setPending({ gatewayId: selectedGwId, agentId: defaultAgentId });
+        return;
+      }
+
+      const team = teamsMap[effectiveTeamId];
+      if (!team || team.gatewayId !== selectedGwId) return;
       const manager = team.agents.find((a) => a.isManager);
       const agentId = manager?.agentId ?? team.agents[0]?.agentId ?? '';
       const needsEnsemble = team.agents.length >= 2;
       if (activeTaskId) {
-        if (!!activeTaskEnsemble !== needsEnsemble || activeTaskTeamId !== selectedTeamId) {
+        if (!!activeTaskEnsemble !== needsEnsemble || activeTaskTeamId !== effectiveTeamId) {
           updateTaskMetadata(activeTaskId, {
             ensemble: needsEnsemble,
-            teamId: selectedTeamId,
+            teamId: effectiveTeamId,
           });
         }
       } else {
@@ -103,14 +121,14 @@ export default function WelcomeScreen() {
           prev?.gatewayId === team.gatewayId &&
           prev?.agentId === agentId &&
           !!prev?.ensemble === needsEnsemble &&
-          prev?.teamId === selectedTeamId
+          prev?.teamId === effectiveTeamId
         )
           return;
         useTaskStore.getState().setPending({
           gatewayId: team.gatewayId,
           agentId,
           ensemble: needsEnsemble,
-          teamId: selectedTeamId,
+          teamId: effectiveTeamId,
         });
       }
     } else if (activeTab === 'orchestrate') {
@@ -119,18 +137,17 @@ export default function WelcomeScreen() {
           updateTaskMetadata(activeTaskId, { ensemble: true, teamId: null });
         }
       } else {
-        const defaultAgent = defaultAgentId;
         const prev = useTaskStore.getState().pendingNewTask;
         if (
           prev?.gatewayId === selectedGwId &&
-          prev?.agentId === defaultAgent &&
+          prev?.agentId === defaultAgentId &&
           prev?.ensemble === true &&
           !prev?.teamId
         )
           return;
         useTaskStore.getState().setPending({
           gatewayId: selectedGwId,
-          agentId: defaultAgent,
+          agentId: defaultAgentId,
           ensemble: true,
         });
       }
@@ -141,12 +158,14 @@ export default function WelcomeScreen() {
     effectiveAgentId,
     selectedTeamId,
     teamsMap,
+    teamsLoadedOnce,
     defaultAgentId,
     agentCatalog,
     activeTaskId,
     activeTaskEnsemble,
     activeTaskTeamId,
     updateTaskMetadata,
+    teamsForSelectedGateway,
   ]);
 
   const handleSelectGateway = useCallback(
@@ -171,19 +190,18 @@ export default function WelcomeScreen() {
   const hiddenAgentCount = agentCatalog.length - MAX_VISIBLE;
 
   const visibleTabs = useMemo(() => {
-    const all: { id: WelcomeTab; label: string; icon: typeof Bot; showGwDropdown: boolean; visible: boolean }[] = [
-      { id: 'agent', label: t('mainArea.tabAgent'), icon: Bot, showGwDropdown: hasMultipleGw, visible: true },
-      { id: 'team', label: t('mainArea.tabTeam'), icon: Users, showGwDropdown: false, visible: true },
+    const all: { id: WelcomeTab; label: string; icon: typeof Bot; visible: boolean }[] = [
+      { id: 'agent', label: t('mainArea.tabAgent'), icon: Bot, visible: true },
+      { id: 'team', label: t('mainArea.tabTeam'), icon: Users, visible: true },
       {
         id: 'orchestrate',
         label: t('mainArea.tabOrchestrate'),
         icon: Sparkles,
-        showGwDropdown: hasMultipleGw,
         visible: hasMultipleAgents,
       },
     ];
     return all.filter((tab) => tab.visible);
-  }, [t, hasMultipleGw, hasMultipleAgents]);
+  }, [t, hasMultipleAgents]);
 
   return (
     <motion.div
@@ -204,16 +222,20 @@ export default function WelcomeScreen() {
               active={activeTab === tab.id}
               icon={tab.icon}
               label={tab.label}
-              showGwDropdown={tab.showGwDropdown}
-              gateways={gateways}
-              selectedGwId={selectedGwId}
               onSelectTab={() => setActiveTab(tab.id)}
-              onSelectGateway={handleSelectGateway}
             />
           ))}
         </div>
 
-        <div className="mt-6">
+        <GatewayInstanceSelector
+          gateways={gateways}
+          selectedGatewayId={selectedGwId}
+          onSelectGateway={handleSelectGateway}
+          showLabel={false}
+          className="mt-5"
+        />
+
+        <div className="mt-4">
           {activeTab === 'agent' && (
             <AgentTabContent
               agents={visibleAgents}
@@ -231,7 +253,7 @@ export default function WelcomeScreen() {
 
           {activeTab === 'team' && (
             <TeamTabContent
-              teams={teams}
+              teams={teamsForSelectedGateway}
               selectedTeamId={selectedTeamId}
               onSelect={handleSelectTeam}
               onBrowseHub={handleBrowseHub}
@@ -258,22 +280,13 @@ function TabButton({
   active,
   icon: Icon,
   label,
-  showGwDropdown,
-  gateways,
-  selectedGwId,
   onSelectTab,
-  onSelectGateway,
 }: {
   active: boolean;
   icon: typeof Bot;
   label: string;
-  showGwDropdown: boolean;
-  gateways: { id: string; name: string }[];
-  selectedGwId: string;
   onSelectTab: () => void;
-  onSelectGateway: (id: string) => void;
 }) {
-  const { t } = useTranslation();
   const baseClass = cn(
     'type-body inline-flex items-center gap-2 rounded-full transition-all',
     active
@@ -281,46 +294,11 @@ function TabButton({
       : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)]',
   );
 
-  if (!showGwDropdown || !active) {
-    return (
-      <button onClick={onSelectTab} className={cn(baseClass, 'px-6 py-2.5 cursor-pointer')}>
-        <Icon size={15} />
-        <span>{label}</span>
-        {showGwDropdown && <ChevronDown size={11} className="opacity-40 -ml-1" />}
-      </button>
-    );
-  }
-
   return (
-    <div className={cn(baseClass, 'pl-6 pr-1.5 py-1')}>
-      <span className="inline-flex items-center gap-2 py-1.5">
-        <Icon size={15} />
-        <span>{label}</span>
-      </span>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            aria-label={t('settings.selectGateway')}
-            className="p-1.5 rounded-full hover:bg-[var(--bg-hover)] cursor-pointer transition-colors ml-1"
-          >
-            <ChevronDown size={12} className="opacity-60" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="center">
-          {gateways.map((gw) => (
-            <DropdownMenuItem
-              key={gw.id}
-              onClick={() => onSelectGateway(gw.id)}
-              className={cn(gw.id === selectedGwId && 'text-[var(--accent)]')}
-            >
-              <Server size={13} />
-              <span className="max-w-32 truncate">{gw.name}</span>
-              {gw.id === selectedGwId && <span className="ml-auto">✓</span>}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+    <button onClick={onSelectTab} className={cn(baseClass, 'px-6 py-2.5 cursor-pointer')}>
+      <Icon size={15} />
+      <span>{label}</span>
+    </button>
   );
 }
 

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamHubDetailView.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamHubDetailView.tsx
@@ -9,8 +9,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { useResizePanel } from '@/hooks/useResizePanel';
 import { useUiStore } from '@/stores/uiStore';
 import { useTeamStore } from '@/stores/teamStore';
-import { cn } from '@/lib/utils';
-import { inputClass } from './utils';
+import GatewayInstanceSelector from '@/components/GatewayInstanceSelector';
 import TeamFileTree, { type TreeFile } from './TeamFileTree';
 import InstallStep from './InstallStep';
 import { useTeamHubInstall } from './useTeamHubInstall';
@@ -27,8 +26,8 @@ export default function TeamHubDetailView({ entry, onBack }: TeamHubDetailViewPr
   const teamsMap = useTeamStore((s) => s.teams);
   const loadTeams = useTeamStore((s) => s.loadTeams);
 
-  const gateways = useMemo(() => Object.entries(gatewayInfoMap), [gatewayInfoMap]);
-  const [gatewayId, setGatewayId] = useState(() => gateways[0]?.[0] ?? '');
+  const gateways = useMemo(() => Object.values(gatewayInfoMap), [gatewayInfoMap]);
+  const [gatewayId, setGatewayId] = useState(() => gateways[0]?.id ?? '');
 
   const [parsedData, setParsedData] = useState<{ parsed: ParsedTeam; agentFiles: Record<string, AgentFileSet> } | null>(
     null,
@@ -60,6 +59,11 @@ export default function TeamHubDetailView({ entry, onBack }: TeamHubDetailViewPr
     loadTeams();
     toast.success(t('teamshub.installSuccess'));
   });
+
+  useEffect(() => {
+    if (gatewayId && gateways.some((gateway) => gateway.id === gatewayId)) return;
+    setGatewayId(gateways[0]?.id ?? '');
+  }, [gatewayId, gateways]);
 
   useEffect(() => {
     let cancelled = false;
@@ -249,19 +253,14 @@ export default function TeamHubDetailView({ entry, onBack }: TeamHubDetailViewPr
                   </span>
                 ) : (
                   <>
-                    {gateways.length > 1 && (
-                      <select
-                        value={gatewayId}
-                        onChange={(e) => setGatewayId(e.target.value)}
-                        className={cn(inputClass, 'h-7 max-w-36 type-meta')}
-                      >
-                        {gateways.map(([id, gw]) => (
-                          <option key={id} value={id}>
-                            {gw.name}
-                          </option>
-                        ))}
-                      </select>
-                    )}
+                    <GatewayInstanceSelector
+                      gateways={gateways}
+                      selectedGatewayId={gatewayId}
+                      onSelectGateway={setGatewayId}
+                      showLabel={false}
+                      align="end"
+                      buttonClassName="h-8 rounded-lg px-2.5 py-1 type-meta"
+                    />
                     <Button size="sm" variant="soft" onClick={handleInstall} disabled={!gatewayId || !parsedData}>
                       <Download size={14} />
                       {t('teamshub.install')}


### PR DESCRIPTION
## Summary

Add a shared renderer gateway selector and use it from the welcome screen and Team Hub install flow so gateway switching behaves consistently across multi-gateway contexts.

## Type of change

- [x] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The gateway selector logic was embedded in the welcome tabs and Team Hub used a separate select control. Sharing the selector keeps gateway display, stale gateway fallback, and team filtering behavior aligned when users have more than one gateway.

## What changed?

- Added `GatewayInstanceSelector` for multi-gateway dropdown selection.
- Updated the welcome screen to show a single shared gateway selector and filter teams by selected gateway.
- Added gateway id fallback handling in `useGatewaySelector`.
- Added `loadedOnce` team-store state so team selection waits for a successful team load.
- Reused the shared selector in Team Hub install details.

## Architecture impact

- Owning layer: renderer / core
- Cross-layer impact: yes. A small core team-store state flag supports renderer selection timing.
- Invariants touched from `docs/architecture-invariants.md`: renderer UI state remains in renderer; core store remains the source for team state.
- Why those invariants remain protected: no main/preload boundaries changed, no protocol types forked, and no persistence or message write paths were added.

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm --filter @clawwork/core exec tsc -b
pnpm --filter @clawwork/desktop exec tsc --noEmit
```

## Screenshots or recordings

Not captured. The change affects existing gateway selection controls and preserves existing CSS variables, token classes, dropdown primitives, and component states.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Added a shared gateway selector for the welcome screen and Team Hub install flow.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate