### PR TITLE
[Build] Build mac x64 package on Intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,12 @@ jobs:
           - os: macos-latest
             platform: mac
             arch: arm64
+            expected_macho_arch: arm64
             build_args: '--mac --arm64'
-          - os: macos-latest
+          - os: macos-15-intel
             platform: mac
             arch: x64
+            expected_macho_arch: x86_64
             build_args: '--mac --x64'
           - os: windows-latest
             platform: win
@@ -129,6 +131,13 @@ jobs:
 
       - name: Build Electron app
         run: pnpm --filter @clawwork/desktop build
+
+      - name: Verify macOS native addon architecture
+        if: matrix.platform == 'mac'
+        run: |
+          ADDON="packages/desktop/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+          file "$ADDON"
+          file "$ADDON" | grep -q "${{ matrix.expected_macho_arch }}"
 
       - name: Package and publish (${{ matrix.platform }})
         if: matrix.platform != 'mac'


### PR DESCRIPTION
## Summary

Build the macOS x64 release package on GitHub's Intel macOS runner and add a native addon architecture check before packaging. This prevents arm64 `better-sqlite3` binaries from being bundled into x64 Electron builds.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [x] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The release workflow used `macos-latest` for both macOS architectures. GitHub's current `macos-latest` runner is arm64, so the x64 release job could install an arm64 native `better-sqlite3` addon and package it into an x64 app, causing `dlopen` architecture mismatch failures at startup.

## What changed?

- Move the macOS x64 release matrix entry to `macos-15-intel`.
- Add `expected_macho_arch` per macOS matrix entry.
- Verify `better_sqlite3.node` reports the expected Mach-O architecture before packaging and publishing.

## Architecture impact

- Owning layer: CI / release packaging
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: this only changes GitHub Actions release packaging and does not alter application runtime code or package boundaries.

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
git diff --check -- .github/workflows/release.yml
pnpm exec prettier --check .github/workflows/release.yml
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"
pre-commit hook: node scripts/check-architecture.mjs
pre-ship --committed: no MUST-FIX findings
```

## Screenshots or recordings

No UI changes.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate