### PR TITLE
[Fix] Keep user message text left aligned

### DIFF
--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -281,7 +281,7 @@ const ChatMessage = memo(function ChatMessage({
         {isUser && parsedFiles && (parsedFiles.files.length > 0 || parsedFiles.text) ? (
           <div
             className={cn(
-              'inline-block max-w-full leading-relaxed rounded-2xl px-4 py-3',
+              'inline-block max-w-full text-left leading-relaxed rounded-2xl px-4 py-3',
               'bg-[var(--bg-tertiary)] text-[var(--text-primary)]',
             )}
           >

--- a/packages/desktop/test/chat-message-copy.test.tsx
+++ b/packages/desktop/test/chat-message-copy.test.tsx
@@ -121,6 +121,22 @@ describe('chat message copy actions', () => {
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(message.content);
   });
 
+  it('keeps pasted multiline user text left-aligned inside the right-aligned bubble', () => {
+    const message = buildMessage({
+      role: 'user',
+      content: 'Codex model usage\n\n- current model: `gpt-5.5`\n- total: **$16.92**',
+    });
+
+    const { container, unmount } = render(<ChatMessage message={message} />);
+    cleanups.push(unmount);
+
+    const messageColumn = container.querySelector('.text-right');
+    const bubble = messageColumn?.querySelector('.inline-block');
+
+    expect(messageColumn).not.toBeNull();
+    expect(bubble?.className).toContain('text-left');
+  });
+
   it('shows a copy button for fenced code blocks and copies only the code', async () => {
     const { container, unmount } = render(
       <StreamingMessage content={'```ts\nconst alpha = 1;\nconst beta = alpha + 1;\n```'} />,


### PR DESCRIPTION
## Summary

Fix user message bubbles so pasted multiline Markdown remains left-aligned inside the right-aligned user bubble.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Pasted multiline user messages inherited the user column's right alignment, making rendered Markdown hard to read. The message bubble should stay positioned on the right while its text content reads left-to-right normally.

## What changed?

- Added `text-left` to user text bubbles that render parsed pasted content.
- Added a regression test that ensures a right-aligned user message column still contains a left-aligned bubble.

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: the change is limited to renderer presentation and a renderer test; no protocol, persistence, IPC, or task/session behavior changed.

## Linked issues

Closes #

## Validation

- [ ] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm --filter @clawwork/desktop test -- chat-message-copy.test.tsx
pnpm exec prettier --check "packages/desktop/src/renderer/components/ChatMessage.tsx" "packages/desktop/test/chat-message-copy.test.tsx"
pnpm --filter @clawwork/desktop exec tsc --noEmit
pnpm --filter @clawwork/desktop exec tsc --noEmit -p tsconfig.test.json

Note: pnpm check was run before shipping and failed at check:dead-code due to existing unrelated knip findings:
- .agents/skills/impeccable/scripts/cleanup-deprecated.mjs
- website/** knip.json configuration hint
```

## Screenshots or recordings

No screenshot attached. The renderer change preserves existing tokens and layout classes; it only overrides inherited text alignment inside the user message bubble.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fixed pasted multiline user messages rendering with right-aligned text.
```

## Checklist

- [ ] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate