### PR TITLE
[Refactor] Unify session activity indicators

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,9 @@ export type { TranslateFn } from './services/error-classify.js';
 
 export { autoTitleIfNeeded } from './services/auto-title.js';
 
+export { deriveSessionActivity, getTaskSessionKeys } from './services/session-activity.js';
+export type { SessionActivity } from './services/session-activity.js';
+
 export { createGatewayDispatcher } from './services/gateway-dispatcher.js';
 export type { GatewayDispatcherDeps } from './services/gateway-dispatcher.js';
 

--- a/packages/core/src/services/session-activity.ts
+++ b/packages/core/src/services/session-activity.ts
@@ -1,0 +1,31 @@
+import type { ActiveTurn } from '../stores/message-store.js';
+import type { Task, TaskRoom } from '@clawwork/shared';
+
+export type SessionActivity = 'idle' | 'waiting' | 'responding' | 'tooling';
+
+export function getTaskSessionKeys(task: Pick<Task, 'sessionKey'>, room?: Pick<TaskRoom, 'performers'>): string[] {
+  return [task.sessionKey, ...(room?.performers.map((performer) => performer.sessionKey) ?? [])];
+}
+
+export function deriveSessionActivity(
+  sessionKeys: string[],
+  activeTurnBySession: Record<string, ActiveTurn | undefined>,
+  processingBySession: ReadonlySet<string>,
+): SessionActivity {
+  let waiting = false;
+  let tooling = false;
+
+  for (const sessionKey of sessionKeys) {
+    if (processingBySession.has(sessionKey)) waiting = true;
+
+    const turn = activeTurnBySession[sessionKey];
+    if (!turn || turn.finalized) continue;
+
+    if (turn.streamingText || turn.streamingThinking) return 'responding';
+    if (turn.toolCalls.length > 0) tooling = true;
+  }
+
+  if (tooling) return 'tooling';
+  if (waiting) return 'waiting';
+  return 'idle';
+}

--- a/packages/core/src/stores/message-store.ts
+++ b/packages/core/src/stores/message-store.ts
@@ -282,7 +282,7 @@ export function createMessageStore(deps: MessageStoreDeps) {
         const content = turn.streamingText;
         const thinkingContent = turn.streamingThinking || undefined;
 
-        if (!content && !thinkingContent) {
+        if (!content && !thinkingContent && turn.toolCalls.length === 0) {
           return {
             activeTurnBySession: {
               ...s.activeTurnBySession,

--- a/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
@@ -21,7 +21,7 @@ import type {
   FileReadResult,
 } from '@clawwork/shared';
 import type { PendingNewTask } from '@clawwork/core';
-import { extractDescription } from '@clawwork/core';
+import { deriveSessionActivity, extractDescription, getTaskSessionKeys } from '@clawwork/core';
 import { useTaskStore } from '../../stores/taskStore';
 import { useMessageStore } from '../../stores/messageStore';
 import { useUiStore } from '../../stores/uiStore';
@@ -80,19 +80,12 @@ export function useChatSend(opts: UseChatSendOpts) {
   const setProcessing = useMessageStore((s) => s.setProcessing);
 
   const activeRoom = useRoomStore((s) => (activeTask?.ensemble ? s.rooms[activeTask.id] : undefined));
-  const sessionKeys = useMemo(() => {
-    if (!activeTask?.sessionKey) return [];
-    return [activeTask.sessionKey, ...(activeRoom?.performers.map((p) => p.sessionKey) ?? [])];
-  }, [activeTask?.sessionKey, activeRoom?.performers]);
-
-  const isProcessing = useMessageStore((s) => sessionKeys.some((sk) => s.processingBySession.has(sk)));
-  const isStreaming = useMessageStore((s) =>
-    sessionKeys.some((sk) => {
-      const turn = s.activeTurnBySession[sk];
-      return !!turn && !turn.finalized && (!!turn.streamingText || !!turn.streamingThinking);
-    }),
+  const activity = useMessageStore((s) =>
+    activeTask
+      ? deriveSessionActivity(getTaskSessionKeys(activeTask, activeRoom), s.activeTurnBySession, s.processingBySession)
+      : 'idle',
   );
-  const isGenerating = isProcessing || isStreaming;
+  const isGenerating = activity !== 'idle';
 
   const isOffline = useUiStore((s) => {
     const gwId = activeTask?.gatewayId ?? pendingNewTask?.gatewayId;
@@ -134,14 +127,14 @@ export function useChatSend(opts: UseChatSendOpts) {
 
   useEffect(() => {
     if (!activeTask) return;
-    if (isStreaming) {
+    if (activity === 'responding' || activity === 'tooling') {
       const timer = responseTimers.current.get(activeTask.id);
       if (timer) {
         clearTimeout(timer);
         responseTimers.current.delete(activeTask.id);
       }
     }
-  }, [isStreaming, activeTask]);
+  }, [activity, activeTask]);
 
   useEffect(() => {
     const timers = responseTimers.current;

--- a/packages/desktop/src/renderer/components/CommandPalette.tsx
+++ b/packages/desktop/src/renderer/components/CommandPalette.tsx
@@ -6,7 +6,9 @@ import { cn } from '@/lib/utils';
 import { useUiStore } from '@/stores/uiStore';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
+import { useRoomStore } from '@/stores/roomStore';
 import { commandPaletteMotion, safeMotion, STAGGER_STEP } from '@/styles/design-tokens';
+import { deriveSessionActivity, getTaskSessionKeys } from '@clawwork/core';
 import ActivityBars from './ActivityBars';
 
 interface PaletteItem {
@@ -43,15 +45,18 @@ export default function CommandPalette() {
   const setActiveTask = useTaskStore((s) => s.setActiveTask);
   const tasks = useTaskStore((s) => s.tasks);
   const activeTurnBySession = useMessageStore((s) => s.activeTurnBySession);
+  const processingBySession = useMessageStore((s) => s.processingBySession);
+  const rooms = useRoomStore((s) => s.rooms);
 
-  const isTaskStreaming = useCallback(
+  const isTaskRunning = useCallback(
     (taskId: string) => {
       const t = tasks.find((task) => task.id === taskId);
       if (!t) return false;
-      const turn = activeTurnBySession[t.sessionKey];
-      return !!turn && !turn.finalized && (!!turn.streamingText || !!turn.streamingThinking);
+      return (
+        deriveSessionActivity(getTaskSessionKeys(t, rooms[t.id]), activeTurnBySession, processingBySession) !== 'idle'
+      );
     },
-    [activeTurnBySession, tasks],
+    [activeTurnBySession, processingBySession, rooms, tasks],
   );
 
   const exec = useCallback(
@@ -127,8 +132,8 @@ export default function CommandPalette() {
           id: `recent:${task.id}`,
           kind: 'task',
           label: task.title || t('common.noTitle'),
-          secondary: isTaskStreaming(task.id) ? t('commandPalette.running') : undefined,
-          running: isTaskStreaming(task.id),
+          secondary: isTaskRunning(task.id) ? t('commandPalette.running') : undefined,
+          running: isTaskRunning(task.id),
           onSelect: () =>
             exec(() => {
               setActiveTask(task.id);
@@ -152,7 +157,7 @@ export default function CommandPalette() {
           id: `active:${task.id}`,
           kind: 'task',
           label: task.title || t('common.noTitle'),
-          running: isTaskStreaming(task.id),
+          running: isTaskRunning(task.id),
           onSelect: () =>
             exec(() => {
               setActiveTask(task.id);
@@ -165,7 +170,7 @@ export default function CommandPalette() {
     }
 
     return result;
-  }, [query, recentTasks, activeTasks, actionItems, t, exec, setActiveTask, setMainView, isTaskStreaming]);
+  }, [query, recentTasks, activeTasks, actionItems, t, exec, setActiveTask, setMainView, isTaskRunning]);
 
   const flatItems = useMemo(() => sections.flatMap((s) => s.items), [sections]);
 

--- a/packages/desktop/src/renderer/hooks/useTraySync.ts
+++ b/packages/desktop/src/renderer/hooks/useTraySync.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react';
 import { useTaskStore } from '../stores/taskStore';
 import { useMessageStore } from '../stores/messageStore';
 import { useUiStore } from '../stores/uiStore';
+import { useRoomStore } from '../stores/roomStore';
+import { deriveSessionActivity, getTaskSessionKeys } from '@clawwork/core';
 import i18n from '../i18n';
 
 function formatDuration(updatedAt: string): string {
@@ -15,12 +17,19 @@ function formatDuration(updatedAt: string): string {
 export function useTraySync(): void {
   const tasks = useTaskStore((s) => s.tasks);
   const processingBySession = useMessageStore((s) => s.processingBySession);
+  const activeTurnBySession = useMessageStore((s) => s.activeTurnBySession);
   const unreadTaskIds = useUiStore((s) => s.unreadTaskIds);
+  const rooms = useRoomStore((s) => s.rooms);
 
   const prevRef = useRef<{ status: string; taskIds: string }>({ status: '', taskIds: '' });
 
   useEffect(() => {
-    const isRunning = processingBySession.size > 0;
+    const runningTasks = tasks.filter(
+      (task) =>
+        deriveSessionActivity(getTaskSessionKeys(task, rooms[task.id]), activeTurnBySession, processingBySession) !==
+        'idle',
+    );
+    const isRunning = runningTasks.length > 0;
     const hasUnread = unreadTaskIds.size > 0;
 
     let status: 'idle' | 'running' | 'unread';
@@ -28,23 +37,24 @@ export function useTraySync(): void {
     else if (hasUnread) status = 'unread';
     else status = 'idle';
 
-    const activeIds = tasks.filter((t) => processingBySession.has(t.sessionKey)).map((t) => t.id);
+    const activeIds = runningTasks.map((t) => t.id);
     const taskIdsKey = activeIds.join(',');
 
     if (prevRef.current.status === status && prevRef.current.taskIds === taskIdsKey) return;
     prevRef.current = { status, taskIds: taskIdsKey };
 
-    const activeTurnBySession = useMessageStore.getState().activeTurnBySession;
     const activeTasks = activeIds.map((id) => {
       const task = tasks.find((t) => t.id === id)!;
+      const sessionKeys = getTaskSessionKeys(task, rooms[task.id]);
+      const snippetSessionKey = sessionKeys.find((sessionKey) => activeTurnBySession[sessionKey]?.streamingText);
       return {
         taskId: id,
         title: task.title || i18n.t('common.noTitle'),
-        snippet: (activeTurnBySession[task.sessionKey]?.streamingText ?? '').slice(0, 60),
+        snippet: ((snippetSessionKey ? activeTurnBySession[snippetSessionKey]?.streamingText : '') ?? '').slice(0, 60),
         duration: formatDuration(task.updatedAt),
       };
     });
 
     window.clawwork.updateTrayStatus(status, activeTasks);
-  }, [tasks, processingBySession, unreadTaskIds]);
+  }, [tasks, processingBySession, activeTurnBySession, unreadTaskIds, rooms]);
 }

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -6,8 +6,10 @@ import { cn } from '@/lib/utils';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
 import { useUiStore } from '@/stores/uiStore';
+import { useRoomStore } from '@/stores/roomStore';
 import { motionDuration, motionEase, motion as motionPresets } from '@/styles/design-tokens';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { deriveSessionActivity, getTaskSessionKeys } from '@clawwork/core';
 import type { Task } from '@clawwork/shared';
 import ActivityBars from '@/components/ActivityBars';
 
@@ -53,10 +55,11 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
   const clearUnread = useUiStore((s) => s.clearUnread);
   const hasUnread = useUiStore((s) => s.unreadTaskIds.has(task.id));
   const setMainView = useUiStore((s) => s.setMainView);
-  const isStreaming = useMessageStore((s) => {
-    const turn = s.activeTurnBySession[task.sessionKey];
-    return !!turn && !turn.finalized && (!!turn.streamingText || !!turn.streamingThinking);
-  });
+  const room = useRoomStore((s) => s.rooms[task.id]);
+  const activity = useMessageStore((s) =>
+    deriveSessionActivity(getTaskSessionKeys(task, room), s.activeTurnBySession, s.processingBySession),
+  );
+  const isRunning = activity !== 'idle';
   const isCompleted = task.status === 'completed';
 
   const handleClick = (): void => {
@@ -92,10 +95,8 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
             >
               {task.title ? task.title[0].toUpperCase() : <MessageSquare size={14} />}
             </span>
-            {isStreaming && <ActivityBars className="absolute top-0 right-0.5 scale-50 origin-top-right" />}
-            {hasUnread && !isStreaming && (
-              <span className="absolute top-0.5 right-1 w-2 h-2 rounded-full bg-[var(--accent)]" />
-            )}
+            {isRunning && <ActivityBars className="absolute top-0 right-0.5 scale-50 origin-top-right" />}
+            {hasUnread && <span className="absolute bottom-0.5 right-1 w-2 h-2 rounded-full bg-[var(--accent)]" />}
           </motion.button>
         </TooltipTrigger>
         <TooltipContent side="right">{task.title || t('common.newTask')}</TooltipContent>
@@ -116,7 +117,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
         'focus-visible:outline-none glow-focus',
         active
           ? 'bg-[var(--state-selected)]'
-          : isStreaming
+          : isRunning
             ? 'bg-[var(--accent-dim)]'
             : isCompleted
               ? ''
@@ -149,6 +150,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
             <span
               className={cn(
                 'block truncate type-body',
+                hasUnread && 'font-medium',
                 active
                   ? 'text-[var(--text-primary)]'
                   : isCompleted
@@ -161,7 +163,8 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
           )}
         </div>
 
-        {isStreaming && <ActivityBars className="flex-shrink-0 scale-75 origin-center" />}
+        {isRunning && <ActivityBars className="flex-shrink-0 scale-75 origin-center" />}
+        {hasUnread && <span className="flex-shrink-0 w-2 h-2 rounded-full bg-[var(--accent)]" />}
       </div>
     </motion.button>
   );

--- a/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
@@ -53,7 +53,8 @@ export default function WelcomeScreen() {
   const [activeTab, setActiveTab] = useState<WelcomeTab>(() => {
     const ensemble = activeTaskEnsemble ?? pendingNewTask?.ensemble;
     const teamId = activeTaskTeamId ?? pendingNewTask?.teamId;
-    if (ensemble) return teamId ? 'team' : 'orchestrate';
+    if (teamId) return 'team';
+    if (ensemble) return 'orchestrate';
     return 'agent';
   });
 

--- a/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
@@ -36,7 +36,6 @@ export default function WelcomeScreen() {
   const loadTeams = useTeamStore((s) => s.loadTeams);
 
   const teams = useMemo(() => Object.values(teamsMap), [teamsMap]);
-  const hasTeams = teams.length > 0;
   const {
     gateways,
     selectedGwId,
@@ -55,7 +54,7 @@ export default function WelcomeScreen() {
     const ensemble = activeTaskEnsemble ?? pendingNewTask?.ensemble;
     const teamId = activeTaskTeamId ?? pendingNewTask?.teamId;
     if (ensemble) return teamId ? 'team' : 'orchestrate';
-    return hasTeams ? 'team' : 'agent';
+    return 'agent';
   });
 
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(

--- a/packages/desktop/src/renderer/layouts/MainArea/index.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/index.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { parseAgentIdFromSessionKey } from '@clawwork/shared';
+import { deriveSessionActivity, getTaskSessionKeys } from '@clawwork/core';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore, EMPTY_MESSAGES, activeTurnToMessage } from '@/stores/messageStore';
 import { useUiStore } from '@/stores/uiStore';
@@ -427,10 +428,10 @@ function ChatContent() {
   const [previewFile, setPreviewFile] = useState<{ path: string; content: string } | null>(null);
   const closeFilePreview = useCallback(() => setPreviewFile(null), []);
   const handleHighlightDone = useCallback(() => setHighlightedMessage(null), [setHighlightedMessage]);
-  const sessionKeys = useMemo(() => {
-    if (!activeTask?.sessionKey) return [];
-    return [activeTask.sessionKey, ...(activeRoom?.performers.map((performer) => performer.sessionKey) ?? [])];
-  }, [activeRoom?.performers, activeTask?.sessionKey]);
+  const sessionKeys = useMemo(
+    () => (activeTask ? getTaskSessionKeys(activeTask, activeRoom) : []),
+    [activeRoom, activeTask],
+  );
   const activeTurns = useMemo(
     () =>
       sessionKeys.reduce<Array<{ sessionKey: string; turn: (typeof activeTurnBySession)[string] }>>(
@@ -443,9 +444,9 @@ function ChatContent() {
       ),
     [activeTurnBySession, sessionKeys],
   );
-  const isProcessing = useMemo(
-    () => sessionKeys.some((sessionKey) => processingBySession.has(sessionKey)),
-    [processingBySession, sessionKeys],
+  const activity = useMemo(
+    () => deriveSessionActivity(sessionKeys, activeTurnBySession, processingBySession),
+    [activeTurnBySession, processingBySession, sessionKeys],
   );
   const timelineItems = useMemo(() => {
     const messageItems = messages.map((message) => ({
@@ -651,7 +652,9 @@ function ChatContent() {
 
               return null;
             })}
-            <AnimatePresence>{isProcessing && !hasRenderableActiveTurn && <ThinkingIndicator />}</AnimatePresence>
+            <AnimatePresence>
+              {activity === 'waiting' && !hasRenderableActiveTurn && <ThinkingIndicator />}
+            </AnimatePresence>
           </div>
         </ScrollArea>
         {showScrollButton && (

--- a/packages/desktop/test/conductor-catalog-fallback.test.tsx
+++ b/packages/desktop/test/conductor-catalog-fallback.test.tsx
@@ -86,7 +86,9 @@ vi.mock('sonner', () => ({
 }));
 
 vi.mock('@clawwork/core', () => ({
+  deriveSessionActivity: () => 'idle',
   extractDescription: (content: string) => content.slice(0, 50),
+  getTaskSessionKeys: (task: { sessionKey: string }) => [task.sessionKey],
 }));
 
 /* Build mock store functions that support both hook calls and .getState() */

--- a/packages/desktop/test/message-store.test.ts
+++ b/packages/desktop/test/message-store.test.ts
@@ -68,4 +68,30 @@ describe('message store tool call persistence', () => {
       }),
     );
   });
+
+  it('finalizes tool-call-only active turns', async () => {
+    const { useMessageStore } = await loadStore();
+    const sessionKey = 'agent:main:clawwork:task:task-1';
+
+    useMessageStore.setState({
+      messagesByTask: {},
+      activeTurnBySession: {},
+      processingBySession: new Set(),
+      highlightedMessageId: null,
+    });
+
+    useMessageStore.getState().upsertToolCall(sessionKey, 'task-1', {
+      id: 'exec-1',
+      name: 'exec',
+      status: 'done',
+      startedAt: '2026-03-16T10:00:00.000Z',
+      completedAt: '2026-03-16T10:00:02.000Z',
+    });
+    useMessageStore.getState().finalizeStream(sessionKey);
+
+    expect(useMessageStore.getState().activeTurnBySession[sessionKey]).toEqual(
+      expect.objectContaining({ finalized: true, toolCalls: [expect.objectContaining({ id: 'exec-1' })] }),
+    );
+    expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
+  });
 });

--- a/packages/desktop/test/session-activity.test.ts
+++ b/packages/desktop/test/session-activity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { deriveSessionActivity, getTaskSessionKeys, type ActiveTurn } from '@clawwork/core';
+import type { Task, TaskRoom } from '@clawwork/shared';
+
+function turn(overrides: Partial<ActiveTurn>): ActiveTurn {
+  return {
+    id: 'turn-1',
+    streamingText: '',
+    streamingThinking: '',
+    toolCalls: [],
+    finalized: false,
+    content: '',
+    timestamp: '2026-04-28T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('session activity', () => {
+  it('returns waiting for processing without renderable turn', () => {
+    expect(deriveSessionActivity(['s1'], {}, new Set(['s1']))).toBe('waiting');
+  });
+
+  it('returns responding for streaming thinking', () => {
+    expect(deriveSessionActivity(['s1'], { s1: turn({ streamingThinking: 'thinking' }) }, new Set())).toBe(
+      'responding',
+    );
+  });
+
+  it('returns tooling for tool-call-only active turns', () => {
+    expect(
+      deriveSessionActivity(
+        ['s1'],
+        {
+          s1: turn({
+            toolCalls: [{ id: 'tc-1', name: 'bash', status: 'running', startedAt: '2026-04-28T00:00:00.000Z' }],
+          }),
+        },
+        new Set(),
+      ),
+    ).toBe('tooling');
+  });
+
+  it('ignores finalized turns', () => {
+    expect(deriveSessionActivity(['s1'], { s1: turn({ finalized: true, content: 'done' }) }, new Set())).toBe('idle');
+  });
+
+  it('includes performer sessions for task rooms', () => {
+    const task = { sessionKey: 'main' } as Task;
+    const room = { performers: [{ sessionKey: 'performer' }] } as TaskRoom;
+
+    expect(getTaskSessionKeys(task, room)).toEqual(['main', 'performer']);
+  });
+});


### PR DESCRIPTION
## Summary

Unifies session activity state across the desktop sidebar, command palette, tray status, chat input, and main chat waiting indicator so running sessions are shown consistently for waiting, responding, tooling, and ensemble performer sessions.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [x] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The desktop UI previously used several local definitions for whether a session was running. That caused gaps where waiting-for-first-token, tool-call-only, or ensemble performer activity could be running without a consistent indicator in the session list, command palette, tray, or chat input.

## What changed?

- Added a core `deriveSessionActivity` helper with `idle`, `waiting`, `responding`, and `tooling` states.
- Added `getTaskSessionKeys` so task activity checks include ensemble performer sessions.
- Updated desktop session indicators and generation guards to use the shared activity derivation.
- Fixed tool-call-only active turns so `finalizeStream` marks them finalized without adding an assistant persistence path.
- Added tests for session activity derivation and tool-call-only finalization.

## Architecture impact

- Owning layer: core / renderer
- Cross-layer impact: yes. Core now owns session activity derivation; renderer consumes it for presentation and interaction state.
- Invariants touched from `docs/architecture-invariants.md`: task/session isolation and layer ownership.
- Why those invariants remain protected: session keys still come from existing task and room state, renderer does not construct raw session-key formats, and message persistence remains unchanged with assistant writes still handled by sync/promote paths.

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm lint
pnpm --filter @clawwork/core exec tsc -b
pnpm --filter @clawwork/desktop exec tsc --noEmit
pnpm --filter @clawwork/desktop exec vitest run test/session-activity.test.ts test/message-store.test.ts
```

## Screenshots or recordings

No screenshots captured. This changes session item state composition while preserving existing CSS variable-based colors and the existing `ActivityBars` indicator.

If the change touches renderer styles, layout, spacing, component states, or interaction polish, explain which tokens, variables, states, or `pnpm check:ui-contract` rules were intentionally preserved or changed.

The change preserves existing design tokens and CSS variables (`var(--accent)`, `var(--accent-dim)`, `var(--state-selected)`) and reuses the existing `ActivityBars` component. The behavior change is that running and unread can now be displayed together because they are independent states.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Session running indicators now consistently reflect waiting, responding, and tool activity across the desktop UI.
```

## Checklist

- [ ] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

## Considered and deferred

- packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx:98 [BOT-WRONG]: Running and unread are independent states, so dual indicators are intentional.

- packages/desktop/src/renderer/hooks/useTraySync.ts:53 [BOT-TASTE]: Tool-only or thinking-only tray entries may have empty snippets; this preserves existing text-first tray behavior and can be polished separately.