### PR TITLE
[Feat] Persist team skill bindings

### DIFF
--- a/packages/core/src/services/team-installer.ts
+++ b/packages/core/src/services/team-installer.ts
@@ -26,7 +26,7 @@ export interface InstallerDeps {
     source?: string;
     version?: string;
     hubSlug?: string;
-    agents: Array<{ agentId: string; role?: string; isManager?: boolean }>;
+    agents: Array<{ agentId: string; role?: string; isManager?: boolean; skills?: string[] }>;
     createdAt: string;
     updatedAt: string;
   }) => Promise<IpcResult>;
@@ -175,6 +175,7 @@ export async function* installTeam(
       agentId: agentMap.get(a.id)!,
       role: a.role,
       isManager: a.role === 'coordinator',
+      skills: (skillsByAgent.get(a.id) ?? []).map((skill) => skill.id),
     }));
 
   if (teamAgents.length === 0) {

--- a/packages/core/src/stores/team-store.ts
+++ b/packages/core/src/stores/team-store.ts
@@ -13,7 +13,7 @@ export interface TeamStoreDeps {
     source?: string;
     version?: string;
     hubSlug?: string;
-    agents: Array<{ agentId: string; role?: string; isManager?: boolean }>;
+    agents: Array<{ agentId: string; role?: string; isManager?: boolean; skills?: string[] }>;
     createdAt: string;
     updatedAt: string;
   }) => Promise<IpcResult>;

--- a/packages/core/test/team-installer.test.ts
+++ b/packages/core/test/team-installer.test.ts
@@ -220,6 +220,33 @@ describe('installTeam', () => {
     expect(events.map((e) => e.type)).toContain('done');
   });
 
+  it('persists skill bindings on team agents', async () => {
+    const parsed = makeParsed();
+    const files: Record<string, AgentFileSet> = {
+      manager: {
+        skillsJson: JSON.stringify({ version: 1, skills: { plan: { source: 'x', sourceType: 'clawhub' } } }),
+      },
+      dev: {
+        skillsJson: JSON.stringify({
+          version: 1,
+          skills: {
+            code: { source: 'x', sourceType: 'clawhub' },
+            review: { source: 'x', sourceType: 'clawhub' },
+          },
+        }),
+      },
+    };
+    const deps = makeDeps();
+
+    await collect(installTeam(parsed, files, 'gw-1', '/w', deps));
+
+    const persistCall = (deps.persistTeam as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(persistCall.agents).toEqual([
+      { agentId: 'agent-1', role: 'coordinator', isManager: true, skills: ['plan'] },
+      { agentId: 'agent-2', role: 'worker', isManager: false, skills: ['code', 'review'] },
+    ]);
+  });
+
   it('progress total includes file and skill operations', async () => {
     const parsed = makeParsed();
     const files: Record<string, AgentFileSet> = {

--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -156,9 +156,12 @@ function openDatabaseAt(workspacePath: string): void {
       agent_id TEXT NOT NULL,
       role TEXT DEFAULT '',
       is_manager INTEGER DEFAULT 0,
+      skills_json TEXT DEFAULT '[]',
       PRIMARY KEY (team_id, agent_id)
     )
   `);
+
+  migrateAddColumn(sqlite, "ALTER TABLE team_agents ADD COLUMN skills_json TEXT DEFAULT '[]'");
 
   initFTS(sqlite);
 

--- a/packages/desktop/src/main/db/schema.ts
+++ b/packages/desktop/src/main/db/schema.ts
@@ -77,6 +77,7 @@ export const teamAgents = sqliteTable(
     agentId: text('agent_id').notNull(),
     role: text('role').default(''),
     isManager: integer('is_manager', { mode: 'boolean' }).default(false),
+    skillsJson: text('skills_json').default('[]'),
   },
   (table) => [primaryKey({ columns: [table.teamId, table.agentId] })],
 );

--- a/packages/desktop/src/main/ipc/data-handlers.ts
+++ b/packages/desktop/src/main/ipc/data-handlers.ts
@@ -9,6 +9,18 @@ function ipcError(err: unknown): { ok: false; error: string } {
   return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
 }
 
+function parseTeamAgentSkills(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string' && item.length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 export function registerDataHandlers(): void {
   ipcMain.handle(
     'data:create-task',
@@ -358,7 +370,7 @@ export function registerDataHandlers(): void {
       const agentRows = db.select().from(teamAgents).all();
       const agentsByTeam = new Map<
         string,
-        Array<{ agentId: string; role: string | null; isManager: boolean | null }>
+        Array<{ agentId: string; role: string | null; isManager: boolean | null; skillsJson: string | null }>
       >();
       for (const a of agentRows) {
         let list = agentsByTeam.get(a.teamId);
@@ -366,7 +378,7 @@ export function registerDataHandlers(): void {
           list = [];
           agentsByTeam.set(a.teamId, list);
         }
-        list.push({ agentId: a.agentId, role: a.role, isManager: a.isManager });
+        list.push({ agentId: a.agentId, role: a.role, isManager: a.isManager, skillsJson: a.skillsJson });
       }
       return {
         ok: true,
@@ -376,6 +388,7 @@ export function registerDataHandlers(): void {
             agentId: a.agentId,
             role: a.role ?? '',
             isManager: a.isManager ?? false,
+            skills: parseTeamAgentSkills(a.skillsJson),
           })),
         })),
       };
@@ -396,7 +409,12 @@ export function registerDataHandlers(): void {
         .from(teamAgents)
         .where(eq(teamAgents.teamId, params.id))
         .all()
-        .map((a) => ({ agentId: a.agentId, role: a.role ?? '', isManager: a.isManager ?? false }));
+        .map((a) => ({
+          agentId: a.agentId,
+          role: a.role ?? '',
+          isManager: a.isManager ?? false,
+          skills: parseTeamAgentSkills(a.skillsJson),
+        }));
       return { ok: true, result: { ...row, agents } };
     } catch (err) {
       console.error('[data] team-get failed:', err);
@@ -417,7 +435,7 @@ export function registerDataHandlers(): void {
         source?: string;
         version?: string;
         hubSlug?: string;
-        agents: Array<{ agentId: string; role?: string; isManager?: boolean }>;
+        agents: Array<{ agentId: string; role?: string; isManager?: boolean; skills?: string[] }>;
         createdAt: string;
         updatedAt: string;
       },
@@ -461,6 +479,7 @@ export function registerDataHandlers(): void {
                 agentId: agent.agentId,
                 role: agent.role ?? '',
                 isManager: agent.isManager ?? false,
+                skillsJson: JSON.stringify(agent.skills ?? []),
               })
               .run();
           }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -515,7 +515,7 @@ export interface ClawWorkAPI {
     source?: string;
     version?: string;
     hubSlug?: string;
-    agents: Array<{ agentId: string; role?: string; isManager?: boolean }>;
+    agents: Array<{ agentId: string; role?: string; isManager?: boolean; skills?: string[] }>;
     createdAt: string;
     updatedAt: string;
   }) => Promise<IpcResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -394,7 +394,7 @@ function buildApi(): ClawWorkAPI {
       source?: string;
       version?: string;
       hubSlug?: string;
-      agents: Array<{ agentId: string; role?: string; isManager?: boolean }>;
+      agents: Array<{ agentId: string; role?: string; isManager?: boolean; skills?: string[] }>;
       createdAt: string;
       updatedAt: string;
     }) => ipcRenderer.invoke('data:team-persist', team),

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -727,7 +727,6 @@
     "title": "Teams",
     "wizard": {
       "addAgent": "Agent hinzufügen",
-      "addSkill": "Skill hinzufuegen",
       "agentCount": "{{count}} Agents",
       "agentMdPlaceholder": "Agent-Anweisungen...",
       "agentName": "Agent-Name",
@@ -757,7 +756,6 @@
       "saving": "Speichern...",
       "selectExisting": "Vorhandenen wählen",
       "skills": "Skills",
-      "skillSlugPlaceholder": "ClawHub Skill-Slug",
       "soulMdPlaceholder": "Agent-Persönlichkeit...",
       "teamInfo": "Team-Info",
       "teamMdPlaceholder": "Team-Mission, Zusammenarbeitsmodell...",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -727,7 +727,6 @@
     "title": "Teams",
     "wizard": {
       "addAgent": "Add Agent",
-      "addSkill": "Add Skill",
       "agentCount": "{{count}} agents",
       "agentMdPlaceholder": "Agent instructions...",
       "agentName": "Agent Name",
@@ -757,7 +756,6 @@
       "saving": "Saving...",
       "selectExisting": "Select Existing",
       "skills": "Skills",
-      "skillSlugPlaceholder": "ClawHub skill slug",
       "soulMdPlaceholder": "Agent personality...",
       "teamInfo": "Team Info",
       "teamMdPlaceholder": "Team mission, collaboration model...",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -727,7 +727,6 @@
     "title": "Equipos",
     "wizard": {
       "addAgent": "Agregar agente",
-      "addSkill": "Agregar habilidad",
       "agentCount": "{{count}} agentes",
       "agentMdPlaceholder": "Instrucciones del agente...",
       "agentName": "Nombre del agente",
@@ -757,7 +756,6 @@
       "saving": "Guardando...",
       "selectExisting": "Seleccionar existente",
       "skills": "Skills",
-      "skillSlugPlaceholder": "ClawHub skill slug",
       "soulMdPlaceholder": "Personalidad del agente...",
       "teamInfo": "Info del equipo",
       "teamMdPlaceholder": "Misión del equipo, modelo de colaboración...",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -727,7 +727,6 @@
     "title": "チーム",
     "wizard": {
       "addAgent": "エージェント追加",
-      "addSkill": "スキルを追加",
       "agentCount": "{{count}} エージェント",
       "agentMdPlaceholder": "エージェント指示...",
       "agentName": "エージェント名",
@@ -757,7 +756,6 @@
       "saving": "保存中...",
       "selectExisting": "既存を選択",
       "skills": "Skills",
-      "skillSlugPlaceholder": "ClawHub skill slug",
       "soulMdPlaceholder": "エージェントの性格...",
       "teamInfo": "チーム情報",
       "teamMdPlaceholder": "チームのミッション、コラボレーションモデル...",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -727,7 +727,6 @@
     "title": "팀",
     "wizard": {
       "addAgent": "에이전트 추가",
-      "addSkill": "스킬 추가",
       "agentCount": "{{count}}개 에이전트",
       "agentMdPlaceholder": "에이전트 지시사항...",
       "agentName": "에이전트 이름",
@@ -757,7 +756,6 @@
       "saving": "저장 중...",
       "selectExisting": "기존 선택",
       "skills": "Skills",
-      "skillSlugPlaceholder": "ClawHub skill slug",
       "soulMdPlaceholder": "에이전트 성격...",
       "teamInfo": "팀 정보",
       "teamMdPlaceholder": "팀 미션, 협업 모델...",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -727,7 +727,6 @@
     "title": "Equipes",
     "wizard": {
       "addAgent": "Adicionar agente",
-      "addSkill": "Adicionar Skill",
       "agentCount": "{{count}} agentes",
       "agentMdPlaceholder": "Instruções do agente...",
       "agentName": "Nome do agente",
@@ -757,7 +756,6 @@
       "saving": "Salvando...",
       "selectExisting": "Selecionar existente",
       "skills": "Skills",
-      "skillSlugPlaceholder": "ClawHub skill slug",
       "soulMdPlaceholder": "Personalidade do agente...",
       "teamInfo": "Info da equipe",
       "teamMdPlaceholder": "Missão da equipe, modelo de colaboração...",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -727,7 +727,6 @@
     "title": "團隊",
     "wizard": {
       "addAgent": "新增 Agent",
-      "addSkill": "新增技能",
       "agentCount": "{{count}} 個 Agent",
       "agentMdPlaceholder": "Agent 指令...",
       "agentName": "Agent 名稱",
@@ -757,7 +756,6 @@
       "saving": "儲存中...",
       "selectExisting": "選擇已有",
       "skills": "Skills",
-      "skillSlugPlaceholder": "ClawHub skill slug",
       "soulMdPlaceholder": "Agent 性格...",
       "teamInfo": "團隊資訊",
       "teamMdPlaceholder": "團隊目標、協作模式...",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -727,7 +727,6 @@
     "title": "团队",
     "wizard": {
       "addAgent": "添加 Agent",
-      "addSkill": "添加技能",
       "agentCount": "{{count}} 个 Agent",
       "agentMdPlaceholder": "Agent 指令...",
       "agentName": "Agent 名称",
@@ -757,7 +756,6 @@
       "saving": "保存中...",
       "selectExisting": "选择已有",
       "skills": "Skills",
-      "skillSlugPlaceholder": "ClawHub skill slug",
       "soulMdPlaceholder": "Agent 人格...",
       "teamInfo": "团队信息",
       "teamMdPlaceholder": "团队目标、协作模式...",

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/AgentConfigStep.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/AgentConfigStep.tsx
@@ -11,9 +11,10 @@ interface AgentConfigStepProps {
   agents: AgentDraft[];
   onChange: (agents: AgentDraft[]) => void;
   gatewayId: string;
+  editMode?: boolean;
 }
 
-export default function AgentConfigStep({ agents, onChange, gatewayId }: AgentConfigStepProps) {
+export default function AgentConfigStep({ agents, onChange, gatewayId, editMode }: AgentConfigStepProps) {
   const { t } = useTranslation();
   const [existingAgents, setExistingAgents] = useState<AgentInfo[]>([]);
 
@@ -31,7 +32,7 @@ export default function AgentConfigStep({ agents, onChange, gatewayId }: AgentCo
   }, [gatewayId]);
 
   const addAgent = useCallback(() => {
-    onChange([...agents, createAgentDraft('worker')]);
+    onChange([...agents, { ...createAgentDraft('worker'), expandedByDefault: true }]);
   }, [agents, onChange]);
 
   const updateAgent = useCallback(
@@ -74,6 +75,7 @@ export default function AgentConfigStep({ agents, onChange, gatewayId }: AgentCo
             canRemove={agents.length > 2}
             gatewayId={gatewayId}
             availableExisting={availableExisting}
+            lockExisting={editMode && agent.lockedExisting}
             onUpdate={(patch) => updateAgent(agent.uid, patch)}
             onRemove={() => removeAgent(agent.uid)}
           />

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/AgentDraftCard.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/AgentDraftCard.tsx
@@ -1,10 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ChevronRight, Trash2, Plus, X, Crown, Loader2 } from 'lucide-react';
-import type { AgentInfo } from '@clawwork/shared';
+import { ChevronDown, ChevronRight, Trash2, X, Crown, Loader2, Search, Check } from 'lucide-react';
+import type { AgentInfo, SkillSearchResultEntry, SkillStatusEntry, SkillStatusReport } from '@clawwork/shared';
 import { parseIdentityMd } from '@clawwork/core';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { useUiStore } from '@/platform';
@@ -12,6 +11,13 @@ import type { AgentDraft } from './types';
 import { inputClass } from './utils';
 
 const EMPTY_MODELS: { id: string; name?: string; provider?: string }[] = [];
+
+interface SkillPickItem {
+  id: string;
+  title: string;
+  description?: string;
+  source: 'installed' | 'clawhub';
+}
 
 function modelLabel(modelId: string, models: { id: string; name?: string; provider?: string }[]): string {
   if (!modelId) return '';
@@ -27,6 +33,7 @@ interface AgentDraftCardProps {
   canRemove: boolean;
   gatewayId: string;
   availableExisting: AgentInfo[];
+  lockExisting?: boolean;
   onUpdate: (patch: Partial<AgentDraft>) => void;
   onRemove: () => void;
 }
@@ -38,24 +45,32 @@ export default function AgentDraftCard({
   canRemove,
   gatewayId,
   availableExisting,
+  lockExisting,
   onUpdate,
   onRemove,
 }: AgentDraftCardProps) {
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(index < 2);
+  const [expanded, setExpanded] = useState(agent.expandedByDefault ?? index < 2);
   const [activeTab, setActiveTab] = useState(agent.existingAgentId ? 'skills' : 'agent-md');
   const [skillInput, setSkillInput] = useState('');
+  const [skillResults, setSkillResults] = useState<SkillSearchResultEntry[]>([]);
+  const [skillSearching, setSkillSearching] = useState(false);
+  const [skillSearched, setSkillSearched] = useState(false);
+  const [loadingSkills, setLoadingSkills] = useState(false);
   const [pickOpen, setPickOpen] = useState(false);
-  const [existingSkillNames, setExistingSkillNames] = useState<string[]>([]);
   const [loadingDetails, setLoadingDetails] = useState(false);
   const [detailsLoadedFor, setDetailsLoadedFor] = useState<string | null>(null);
+  const skillSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const skillSearchEpoch = useRef(0);
   const modelCatalogByGateway = useUiStore((s) => s.modelCatalogByGateway);
+  const skillsStatus = useUiStore((s) => (gatewayId ? s.skillsStatusByGateway[gatewayId] : undefined));
+  const setSkillsStatusForGateway = useUiStore((s) => s.setSkillsStatusForGateway);
   const models = (gatewayId ? modelCatalogByGateway[gatewayId] : null) ?? EMPTY_MODELS;
   const isExisting = !!agent.existingAgentId;
+  const canSwitchMode = !lockExisting;
 
   const switchToNew = () => {
     onUpdate({ existingAgentId: undefined, name: '', description: '', model: '', agentMd: '', soulMd: '', skills: [] });
-    setExistingSkillNames([]);
     setDetailsLoadedFor(null);
     setActiveTab('agent-md');
   };
@@ -70,7 +85,6 @@ export default function AgentDraftCard({
       soulMd: '',
       skills: [],
     });
-    setExistingSkillNames([]);
     setDetailsLoadedFor(null);
     setActiveTab('agent-md');
     setPickOpen(false);
@@ -86,8 +100,7 @@ export default function AgentDraftCard({
     Promise.allSettled([
       window.clawwork.getAgentFile(gatewayId, agent.existingAgentId, 'IDENTITY.md'),
       window.clawwork.getAgentFile(gatewayId, agent.existingAgentId, 'SOUL.md'),
-      window.clawwork.getSkillsStatus(gatewayId, agent.existingAgentId),
-    ]).then(([identityRes, soulRes, skillsRes]) => {
+    ]).then(([identityRes, soulRes]) => {
       if (abortController.signal.aborted) return;
       const patch: Partial<AgentDraft> = {};
       if (identityRes.status === 'fulfilled' && identityRes.value.ok && identityRes.value.result) {
@@ -102,11 +115,6 @@ export default function AgentDraftCard({
         const data = soulRes.value.result as Record<string, unknown>;
         if (typeof data.content === 'string') patch.soulMd = data.content;
       }
-      if (skillsRes.status === 'fulfilled' && skillsRes.value.ok && skillsRes.value.result) {
-        const data = skillsRes.value.result as Record<string, unknown>;
-        const skills = data.skills as Array<{ name: string }> | undefined;
-        if (skills) setExistingSkillNames(skills.map((s) => s.name));
-      }
       if (Object.keys(patch).length > 0) onUpdate(patch);
       setDetailsLoadedFor(agent.existingAgentId!);
       setLoadingDetails(false);
@@ -115,118 +123,190 @@ export default function AgentDraftCard({
     return () => abortController.abort();
   }, [agent.existingAgentId, gatewayId, detailsLoadedFor, onUpdate]);
 
-  const addSkill = () => {
-    const slug = skillInput.trim();
-    if (slug && !agent.skills.includes(slug)) {
+  const addSkill = useCallback(
+    (slug: string) => {
+      if (!slug || agent.skills.includes(slug)) return;
       onUpdate({ skills: [...agent.skills, slug] });
-      setSkillInput('');
-    }
-  };
+    },
+    [agent.skills, onUpdate],
+  );
 
   const removeSkill = (slug: string) => {
     onUpdate({ skills: agent.skills.filter((s) => s !== slug) });
   };
 
+  useEffect(() => {
+    if (activeTab !== 'skills' || !gatewayId || skillsStatus) return;
+    let cancelled = false;
+    setLoadingSkills(true);
+    window.clawwork.getSkillsStatus(gatewayId).then((res) => {
+      if (cancelled) return;
+      if (res.ok && res.result) setSkillsStatusForGateway(gatewayId, res.result as unknown as SkillStatusReport);
+      setLoadingSkills(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, gatewayId, skillsStatus, setSkillsStatusForGateway]);
+
+  const runSkillSearch = useCallback(
+    async (query: string) => {
+      if (!gatewayId) return;
+      const epoch = ++skillSearchEpoch.current;
+      setSkillSearching(true);
+      setSkillSearched(true);
+      const res = await window.clawwork.searchSkills(gatewayId, { query, limit: 20 });
+      if (epoch !== skillSearchEpoch.current) return;
+      setSkillResults(res.ok && res.result ? res.result.results : []);
+      setSkillSearching(false);
+    },
+    [gatewayId],
+  );
+
+  const handleSkillQueryChange = useCallback(
+    (value: string) => {
+      setSkillInput(value);
+      if (skillSearchTimer.current) clearTimeout(skillSearchTimer.current);
+      const query = value.trim();
+      if (!query) {
+        skillSearchEpoch.current += 1;
+        setSkillResults([]);
+        setSkillSearching(false);
+        setSkillSearched(false);
+        return;
+      }
+      skillSearchTimer.current = setTimeout(() => runSkillSearch(query), 250);
+    },
+    [runSkillSearch],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (skillSearchTimer.current) clearTimeout(skillSearchTimer.current);
+    };
+  }, []);
+
+  const installedSkillItems = useMemo<SkillPickItem[]>(
+    () =>
+      (skillsStatus?.skills ?? []).map((skill: SkillStatusEntry) => ({
+        id: skill.skillKey || skill.name,
+        title: skill.name || skill.skillKey,
+        description: skill.description,
+        source: 'installed',
+      })),
+    [skillsStatus],
+  );
+
+  const searchSkillItems = useMemo<SkillPickItem[]>(
+    () =>
+      skillResults.map((skill) => ({
+        id: skill.slug,
+        title: skill.displayName || skill.slug,
+        description: skill.summary,
+        source: 'clawhub',
+      })),
+    [skillResults],
+  );
+
+  const skillPickItems = skillInput.trim() ? searchSkillItems : installedSkillItems;
+
   const displayModel = modelLabel(agent.model, models);
 
   return (
-    <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center gap-3 px-4 py-3 transition-colors hover:bg-[var(--bg-hover)] cursor-pointer"
-      >
-        {expanded ? (
-          <ChevronDown size={14} className="text-[var(--text-muted)]" />
-        ) : (
-          <ChevronRight size={14} className="text-[var(--text-muted)]" />
-        )}
-        <span className="type-body font-medium text-[var(--text-primary)] flex-1 text-left truncate">
-          {agent.name || t('teams.wizard.agentNamePlaceholder')}
-        </span>
-        {agent.role === 'coordinator' && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-[var(--bg-tertiary)] px-2 py-0.5 type-meta text-[var(--accent)]">
-            <Crown size={10} />
-            {t('teams.wizard.coordinator')}
+    <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)]">
+      <div className="flex items-center transition-colors hover:bg-[var(--bg-hover)]">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 px-4 py-3"
+        >
+          {expanded ? (
+            <ChevronDown size={14} className="text-[var(--text-muted)]" />
+          ) : (
+            <ChevronRight size={14} className="text-[var(--text-muted)]" />
+          )}
+          <span className="type-body flex-1 truncate text-left font-medium text-[var(--text-primary)]">
+            {agent.name || t('teams.wizard.agentNamePlaceholder')}
           </span>
-        )}
-        {displayModel && <span className="type-meta text-[var(--text-muted)] truncate max-w-32">{displayModel}</span>}
+          {agent.role === 'coordinator' && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-[var(--bg-tertiary)] px-2 py-0.5 type-meta text-[var(--accent)]">
+              <Crown size={10} />
+              {t('teams.wizard.coordinator')}
+            </span>
+          )}
+          {displayModel && <span className="max-w-32 truncate type-meta text-[var(--text-muted)]">{displayModel}</span>}
+          {isExisting && loadingDetails && <Loader2 size={12} className="animate-spin text-[var(--text-muted)]" />}
+        </button>
         {canRemove && !isFirst && (
           <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove();
-            }}
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-muted)] hover:text-[var(--text-danger)] hover:bg-[var(--bg-hover)] cursor-pointer"
+            type="button"
+            onClick={onRemove}
+            className="mr-3 flex h-6 w-6 cursor-pointer items-center justify-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-danger)]"
           >
             <Trash2 size={12} />
           </button>
         )}
-      </button>
+      </div>
 
       {expanded && (
         <div className="border-t border-[var(--border)] px-4 py-3 space-y-3">
-          <div className="flex items-center gap-1 rounded-lg bg-[var(--bg-tertiary)] p-1 w-fit">
-            <button
-              onClick={switchToNew}
-              className={cn(
-                'type-label px-3 py-1 rounded-md transition-all',
-                !isExisting
-                  ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)] shadow-[var(--shadow-card)]'
-                  : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
-              )}
-            >
-              {t('teams.wizard.createNew')}
-            </button>
-            <Popover open={pickOpen} onOpenChange={setPickOpen}>
-              <PopoverTrigger asChild>
-                <button
-                  className={cn(
-                    'type-label px-3 py-1 rounded-md transition-all',
-                    isExisting
-                      ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)] shadow-[var(--shadow-card)]'
-                      : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
-                  )}
-                >
-                  {isExisting ? agent.name : t('teams.wizard.selectExisting')}
-                </button>
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-64 p-1">
-                {availableExisting.length === 0 ? (
-                  <div className="px-3 py-2 type-body text-[var(--text-muted)]">{t('teams.noAgents')}</div>
-                ) : (
-                  <div className="max-h-48 overflow-y-auto">
-                    {availableExisting.map((info) => (
-                      <button
-                        key={info.id}
-                        onClick={() => pickExisting(info)}
-                        className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 transition-colors hover:bg-[var(--bg-hover)] cursor-pointer"
-                      >
-                        {info.identity?.emoji && <span className="emoji-sm">{info.identity.emoji}</span>}
-                        <span className="type-body text-[var(--text-primary)] truncate">{info.name ?? info.id}</span>
-                      </button>
-                    ))}
-                  </div>
+          {canSwitchMode && (
+            <div className="flex items-center gap-1 rounded-lg bg-[var(--bg-tertiary)] p-1 w-fit">
+              <button
+                onClick={switchToNew}
+                className={cn(
+                  'type-label px-3 py-1 rounded-md transition-all',
+                  !isExisting
+                    ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)] shadow-[var(--shadow-card)]'
+                    : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
                 )}
-              </PopoverContent>
-            </Popover>
-          </div>
+              >
+                {t('teams.wizard.createNew')}
+              </button>
+              <Popover open={pickOpen} onOpenChange={setPickOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    className={cn(
+                      'type-label px-3 py-1 rounded-md transition-all',
+                      isExisting
+                        ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)] shadow-[var(--shadow-card)]'
+                        : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
+                    )}
+                  >
+                    {isExisting ? agent.name : t('teams.wizard.selectExisting')}
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-64 p-1">
+                  {availableExisting.length === 0 ? (
+                    <div className="px-3 py-2 type-body text-[var(--text-muted)]">{t('teams.noAgents')}</div>
+                  ) : (
+                    <div className="max-h-48 overflow-y-auto">
+                      {availableExisting.map((info) => (
+                        <button
+                          key={info.id}
+                          onClick={() => pickExisting(info)}
+                          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 transition-colors hover:bg-[var(--bg-hover)] cursor-pointer"
+                        >
+                          {info.identity?.emoji && <span className="emoji-sm">{info.identity.emoji}</span>}
+                          <span className="type-body text-[var(--text-primary)] truncate">{info.name ?? info.id}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </PopoverContent>
+              </Popover>
+            </div>
+          )}
 
           {isExisting ? (
-            <div className="space-y-3">
-              <div className="flex items-center gap-3 rounded-md bg-[var(--bg-primary)] border border-[var(--border)] px-3 py-2">
-                <span className="type-body text-[var(--text-primary)] flex-1">{agent.name}</span>
-                {displayModel && <span className="type-meta text-[var(--text-muted)]">{displayModel}</span>}
-                {loadingDetails && <Loader2 size={12} className="animate-spin text-[var(--text-muted)]" />}
+            agent.description ? (
+              <div className="space-y-1">
+                <label className="type-meta text-[var(--text-muted)]">{t('teams.wizard.description')}</label>
+                <p className="type-body rounded-md bg-[var(--bg-primary)] border border-[var(--border)] px-3 py-2 text-[var(--text-secondary)]">
+                  {agent.description}
+                </p>
               </div>
-              {agent.description && (
-                <div className="space-y-1">
-                  <label className="type-meta text-[var(--text-muted)]">{t('teams.wizard.description')}</label>
-                  <p className="type-body rounded-md bg-[var(--bg-primary)] border border-[var(--border)] px-3 py-2 text-[var(--text-secondary)]">
-                    {agent.description}
-                  </p>
-                </div>
-              )}
-            </div>
+            ) : null
           ) : (
             <div className="space-y-3">
               <div className="grid grid-cols-3 gap-3">
@@ -284,8 +364,7 @@ export default function AgentDraftCard({
               <TabsTrigger value="soul-md">SOUL.md</TabsTrigger>
               <TabsTrigger value="skills">
                 {t('teams.wizard.skills')}
-                {agent.skills.length + existingSkillNames.length > 0 &&
-                  ` (${agent.skills.length + existingSkillNames.length})`}
+                {agent.skills.length > 0 && ` (${agent.skills.length})`}
               </TabsTrigger>
             </TabsList>
           </Tabs>
@@ -312,41 +391,65 @@ export default function AgentDraftCard({
 
           {activeTab === 'skills' && (
             <div className="space-y-2">
-              {existingSkillNames.length > 0 && (
-                <div className="flex flex-wrap gap-1.5">
-                  {existingSkillNames.map((name) => (
-                    <span
-                      key={name}
-                      className="inline-flex items-center rounded-full border border-[var(--border)] bg-[var(--bg-tertiary)] px-2.5 py-0.5 type-meta text-[var(--text-muted)]"
-                    >
-                      {name}
-                    </span>
-                  ))}
-                </div>
-              )}
-              <div className="flex gap-2">
+              <div className="flex items-center gap-2 rounded-md bg-[var(--bg-primary)] border border-[var(--border)] px-3 py-2">
+                <Search size={14} className="flex-shrink-0 text-[var(--text-muted)]" />
                 <input
                   type="text"
                   value={skillInput}
-                  onChange={(e) => setSkillInput(e.target.value)}
+                  onChange={(e) => handleSkillQueryChange(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {
                       e.preventDefault();
-                      addSkill();
+                      const first = skillPickItems.find((skill) => !agent.skills.includes(skill.id));
+                      if (first) addSkill(first.id);
                     }
                   }}
-                  placeholder={t('teams.wizard.skillSlugPlaceholder')}
-                  className={cn(inputClass, 'flex-1')}
+                  placeholder={t('settings.skillHubSearchPlaceholder')}
+                  className="min-w-0 flex-1 bg-transparent text-[var(--text-primary)] placeholder:text-[var(--text-muted)] type-label outline-none"
                 />
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={addSkill}
-                  disabled={!skillInput.trim()}
-                  aria-label={t('teams.wizard.addSkill')}
-                >
-                  <Plus size={14} />
-                </Button>
+                {(skillSearching || loadingSkills) && (
+                  <Loader2 size={14} className="animate-spin text-[var(--text-muted)]" />
+                )}
+              </div>
+              <div className="max-h-44 space-y-1 overflow-y-auto rounded-md border border-[var(--border)] bg-[var(--bg-primary)] p-1">
+                {skillPickItems.length > 0 ? (
+                  skillPickItems.map((skill) => {
+                    const selected = agent.skills.includes(skill.id);
+                    return (
+                      <button
+                        key={`${skill.source}-${skill.id}`}
+                        type="button"
+                        onClick={() => addSkill(skill.id)}
+                        disabled={selected}
+                        className={cn(
+                          'flex w-full items-start gap-2 rounded-md px-2 py-2 text-left transition-colors',
+                          selected ? 'cursor-default opacity-70' : 'cursor-pointer hover:bg-[var(--bg-hover)]',
+                        )}
+                      >
+                        <span className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center text-[var(--text-muted)]">
+                          {selected ? <Check size={13} /> : <Search size={12} />}
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="type-support block truncate text-[var(--text-primary)]">{skill.title}</span>
+                          <span className="type-mono-data block truncate text-[var(--text-muted)]">{skill.id}</span>
+                          {skill.description && (
+                            <span className="type-meta mt-0.5 line-clamp-2 block text-[var(--text-secondary)]">
+                              {skill.description}
+                            </span>
+                          )}
+                        </span>
+                      </button>
+                    );
+                  })
+                ) : (
+                  <p className="type-support px-2 py-2 text-[var(--text-muted)]">
+                    {skillSearching
+                      ? t('settings.skillHubSearching')
+                      : skillInput.trim() && skillSearched
+                        ? t('settings.skillHubNoResults')
+                        : t('settings.skillHubPrompt')}
+                  </p>
+                )}
               </div>
               {agent.skills.length > 0 && (
                 <div className="flex flex-wrap gap-1.5">

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/CreateTeamWizard.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/CreateTeamWizard.tsx
@@ -85,8 +85,9 @@ export default function CreateTeamWizard({ open, onOpenChange, defaultGatewayId,
               model: info?.model?.primary ?? '',
               agentMd: '',
               soulMd: '',
-              skills: [],
+              skills: a.skills ?? [],
               existingAgentId: a.agentId,
+              lockedExisting: true,
             };
           }),
         );
@@ -153,7 +154,10 @@ export default function CreateTeamWizard({ open, onOpenChange, defaultGatewayId,
 
   return (
     <Dialog open={open} onOpenChange={guardedOpenChange}>
-      <DialogContent className="max-w-[var(--dialog-max-width)] flex max-h-screen flex-col" {...contentProps}>
+      <DialogContent
+        className="flex max-h-full max-w-[var(--dialog-max-width)] flex-col overflow-hidden"
+        {...contentProps}
+      >
         <DialogHeader>
           <DialogTitle>{isEdit ? t('teams.editTeam') : t('teams.createTeam')}</DialogTitle>
           <DialogDescription>
@@ -188,7 +192,12 @@ export default function CreateTeamWizard({ open, onOpenChange, defaultGatewayId,
                 />
               )}
               {step === 2 && (
-                <AgentConfigStep agents={agents} onChange={handleAgentsChange} gatewayId={teamInfo.gatewayId} />
+                <AgentConfigStep
+                  agents={agents}
+                  onChange={handleAgentsChange}
+                  gatewayId={teamInfo.gatewayId}
+                  editMode={isEdit}
+                />
               )}
               {step === 3 && (
                 <InstallStep

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/TeamDetailView.tsx
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/TeamDetailView.tsx
@@ -11,11 +11,9 @@ import { useUiStore } from '@/stores/uiStore';
 import { cn } from '@/lib/utils';
 import TeamFileTree, { type TreeFile } from './TeamFileTree';
 
-interface SkillStatusEntry {
+interface SkillEntry {
   id: string;
   name: string;
-  description?: string;
-  eligible?: boolean;
 }
 
 interface TeamDetailViewProps {
@@ -34,21 +32,18 @@ export default function TeamDetailView({ team, onBack, onStartChat, onEdit }: Te
   );
   const [selectedFile, setSelectedFile] = useState<TreeFile | null>(null);
   const [agentFilesMap, setAgentFilesMap] = useState<Record<string, { name: string }[]>>({});
-  const [skillsMap, setSkillsMap] = useState<Record<string, SkillStatusEntry[]>>({});
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [editingContent, setEditingContent] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [loadingContent, setLoadingContent] = useState(false);
   const [discardTarget, setDiscardTarget] = useState<TreeFile | null>(null);
   const fetchedFiles = useRef(new Set<string>());
-  const fetchedSkills = useRef(new Set<string>());
   const loadSeq = useRef(0);
 
   useEffect(() => {
     setSelectedFile({ id: 'team-md', label: 'TEAM.md', kind: 'team-md' });
     setEditingContent(null);
     fetchedFiles.current.clear();
-    fetchedSkills.current.clear();
   }, [team.id]);
 
   useEffect(() => {
@@ -73,22 +68,6 @@ export default function TeamDetailView({ team, onBack, onStartChat, onEdit }: Te
     }
   }, [team.agents, team.gatewayId]);
 
-  useEffect(() => {
-    for (const agent of team.agents) {
-      if (fetchedSkills.current.has(agent.agentId)) continue;
-      fetchedSkills.current.add(agent.agentId);
-      const agentId = agent.agentId;
-      window.clawwork.getSkillsStatus(team.gatewayId, agentId).then((res) => {
-        if (!res.ok || !res.result) {
-          fetchedSkills.current.delete(agentId);
-          return;
-        }
-        const data = res.result as { skills?: SkillStatusEntry[] };
-        setSkillsMap((prev) => ({ ...prev, [agentId]: data.skills ?? [] }));
-      });
-    }
-  }, [team.agents, team.gatewayId]);
-
   const agentNodes = useMemo(
     () =>
       team.agents.map((a) => {
@@ -105,24 +84,24 @@ export default function TeamDetailView({ team, onBack, onStartChat, onEdit }: Te
             kind: 'agent-file' as const,
             agentId: a.agentId,
           })),
-          skillCount: (skillsMap[a.agentId] ?? []).length,
+          skillCount: (a.skills ?? []).length,
         };
       }),
-    [team.agents, agentFilesMap, skillsMap, catalogById],
+    [team.agents, agentFilesMap, catalogById],
   );
 
   const allSkills = useMemo(() => {
     const seen = new Set<string>();
-    const result: { id: string; name: string }[] = [];
+    const result: SkillEntry[] = [];
     for (const agent of team.agents) {
-      for (const skill of skillsMap[agent.agentId] ?? []) {
-        if (seen.has(skill.id)) continue;
-        seen.add(skill.id);
-        result.push({ id: skill.id, name: skill.name || skill.id });
+      for (const skill of agent.skills ?? []) {
+        if (seen.has(skill)) continue;
+        seen.add(skill);
+        result.push({ id: skill, name: skill });
       }
     }
     return result;
-  }, [team.agents, skillsMap]);
+  }, [team.agents]);
 
   const isDirty = editingContent !== null && editingContent !== fileContent;
   const {
@@ -202,16 +181,15 @@ export default function TeamDetailView({ team, onBack, onStartChat, onEdit }: Te
     }
   }, [selectedFile, editingContent, team.gatewayId, t]);
 
-  const agentSkills =
-    selectedFile?.kind === 'agent-skills' && selectedFile.agentId ? (skillsMap[selectedFile.agentId] ?? []) : [];
+  const agentSkills = useMemo<SkillEntry[]>(() => {
+    if (selectedFile?.kind !== 'agent-skills' || !selectedFile.agentId) return [];
+    const agent = team.agents.find((a) => a.agentId === selectedFile.agentId);
+    return (agent?.skills ?? []).map((skill) => ({ id: skill, name: skill }));
+  }, [selectedFile, team.agents]);
   const skillDetail = useMemo(() => {
     if (selectedFile?.kind !== 'skill-item' || !selectedFile.skillId) return null;
-    for (const skills of Object.values(skillsMap)) {
-      const found = skills.find((s) => s.id === selectedFile.skillId);
-      if (found) return found;
-    }
-    return null;
-  }, [selectedFile, skillsMap]);
+    return allSkills.find((skill) => skill.id === selectedFile.skillId) ?? null;
+  }, [selectedFile, allSkills]);
 
   const isEditable = selectedFile?.kind === 'agent-file';
   const isEditing = editingContent !== null;
@@ -344,9 +322,6 @@ export default function TeamDetailView({ team, onBack, onStartChat, onEdit }: Te
                       <Puzzle size={14} className="mt-0.5 flex-shrink-0 text-[var(--text-muted)]" />
                       <div className="min-w-0">
                         <p className="type-support font-medium text-[var(--text-primary)]">{skill.name || skill.id}</p>
-                        {skill.description && (
-                          <p className="type-meta text-[var(--text-secondary)]">{skill.description}</p>
-                        )}
                       </div>
                     </div>
                   ))
@@ -362,9 +337,6 @@ export default function TeamDetailView({ team, onBack, onStartChat, onEdit }: Te
                     {skillDetail.name || skillDetail.id}
                   </h3>
                 </div>
-                {skillDetail.description && (
-                  <p className="type-body text-[var(--text-secondary)]">{skillDetail.description}</p>
-                )}
                 <div className="type-meta text-[var(--text-muted)]">
                   ID: <span className="type-code-inline">{skillDetail.id}</span>
                 </div>

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/types.ts
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/types.ts
@@ -8,6 +8,8 @@ export interface AgentDraft {
   soulMd: string;
   skills: string[];
   existingAgentId?: string;
+  lockedExisting?: boolean;
+  expandedByDefault?: boolean;
 }
 
 export interface TeamInfo {

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/useTeamInstall.ts
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/useTeamInstall.ts
@@ -189,6 +189,7 @@ export function useTeamInstall(onDone?: () => void) {
           agentId: a.existingAgentId!,
           role: a.role,
           isManager: a.role === 'coordinator',
+          skills: a.skills,
         }));
 
         const now = new Date().toISOString();

--- a/packages/desktop/test/conductor-catalog-fallback.test.tsx
+++ b/packages/desktop/test/conductor-catalog-fallback.test.tsx
@@ -32,9 +32,9 @@ const mocks = vi.hoisted(() => {
     source: 'local',
     version: '1',
     agents: [
-      { agentId: 'manager-agent', role: 'manager', isManager: true },
-      { agentId: 'worker-a', role: 'coder', isManager: false },
-      { agentId: 'worker-b', role: 'reviewer', isManager: false },
+      { agentId: 'manager-agent', role: 'manager', isManager: true, skills: [] },
+      { agentId: 'worker-a', role: 'coder', isManager: false, skills: [] },
+      { agentId: 'worker-b', role: 'reviewer', isManager: false, skills: [] },
     ],
     createdAt: '2026-04-10T00:00:00.000Z',
     updatedAt: '2026-04-10T00:00:00.000Z',

--- a/packages/desktop/test/team-skill-bindings.test.tsx
+++ b/packages/desktop/test/team-skill-bindings.test.tsx
@@ -1,0 +1,327 @@
+// @vitest-environment jsdom
+
+import { act, useState, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Team } from '@clawwork/shared';
+import TeamDetailView from '../src/renderer/layouts/TeamsPanel/TeamDetailView';
+import AgentConfigStep from '../src/renderer/layouts/TeamsPanel/AgentConfigStep';
+import type { AgentDraft } from '../src/renderer/layouts/TeamsPanel/types';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) => {
+      if (key === 'teams.detail.agentSkillCount') return `${values?.count} skills`;
+      if (key === 'teams.detail.agentSkillsLabel') return `${values?.name} Skills`;
+      return key;
+    },
+  }),
+}));
+
+const mocks = vi.hoisted(() => ({
+  uiState: {
+    agentCatalogByGateway: {
+      'gw-1': { agents: [{ id: 'agent-a', name: 'Agent A', model: { primary: 'model-a' } }], defaultId: 'agent-a' },
+    },
+    modelCatalogByGateway: {},
+    skillsStatusByGateway: {} as Record<string, unknown>,
+    setSkillsStatusForGateway: vi.fn((gatewayId: string, report: unknown) => {
+      mocks.uiState.skillsStatusByGateway[gatewayId] = report;
+    }),
+  },
+}));
+
+vi.mock('../src/renderer/stores/uiStore', () => ({
+  useUiStore: <T,>(selector: (state: typeof mocks.uiState) => T) => selector(mocks.uiState),
+}));
+
+vi.mock('../src/renderer/hooks/useResizePanel', () => ({
+  useResizePanel: () => ({ width: 240, isDragging: false, handleMouseDown: vi.fn() }),
+}));
+
+vi.mock('../src/renderer/components/ui/scroll-area', () => ({
+  ScrollArea: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+vi.mock('@radix-ui/react-tabs', async () => {
+  const React = await import('react');
+  return {
+    Root: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    List: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ children, ...props }, ref) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    )),
+    Trigger: React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+      ({ children, ...props }, ref) => (
+        <button ref={ref} type="button" {...props}>
+          {children}
+        </button>
+      ),
+    ),
+  };
+});
+
+vi.mock('@radix-ui/react-popover', async () => {
+  const React = await import('react');
+  return {
+    Root: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Trigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Content: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ children, ...props }, ref) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    )),
+    Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+function render(ui: ReactElement): { container: HTMLDivElement; unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+const cleanups: Array<() => void> = [];
+
+describe('team skill bindings UI', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    (window as unknown as { clawwork: Partial<Window['clawwork']> }).clawwork = {
+      listAgentFiles: vi.fn(async () => ({ ok: true, result: { files: [] } })),
+      getAgentFile: vi.fn(async () => ({ ok: true, result: { content: '' } })),
+      setAgentFile: vi.fn(async () => ({ ok: true })),
+      listAgents: vi.fn(async () => ({ ok: true, result: { agents: [] } })),
+      getSkillsStatus: vi.fn(async () => ({
+        ok: true,
+        result: {
+          workspaceDir: '',
+          managedSkillsDir: '',
+          skills: [
+            {
+              name: 'Installed Skill',
+              description: 'Installed skill summary',
+              skillKey: 'installed-skill',
+              source: 'clawhub',
+              bundled: false,
+              filePath: '',
+              baseDir: '',
+              always: false,
+              disabled: false,
+              blockedByAllowlist: false,
+              eligible: true,
+              requirements: { bins: [], anyBins: [], env: [], config: [], os: [] },
+              missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+              configChecks: [],
+              install: [],
+            },
+          ],
+        },
+      })),
+      searchSkills: vi.fn(async () => ({
+        ok: true,
+        result: {
+          results: [{ score: 1, slug: 'searched-skill', displayName: 'Searched Skill', summary: 'Search hit' }],
+        },
+      })),
+    };
+    mocks.uiState.skillsStatusByGateway = {};
+    mocks.uiState.setSkillsStatusForGateway.mockClear();
+  });
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()?.();
+    vi.clearAllMocks();
+  });
+
+  it('renders only team-bound skills in team detail', async () => {
+    const team: Team = {
+      id: 'team-1',
+      name: 'Team',
+      emoji: '',
+      description: '',
+      gatewayId: 'gw-1',
+      source: 'local',
+      version: '1',
+      agents: [{ agentId: 'agent-a', role: 'coordinator', isManager: true, skills: ['team-skill'] }],
+      createdAt: '2026-04-10T00:00:00.000Z',
+      updatedAt: '2026-04-10T00:00:00.000Z',
+    };
+
+    const view = render(<TeamDetailView team={team} onBack={vi.fn()} onStartChat={vi.fn()} onEdit={vi.fn()} />);
+    cleanups.push(view.unmount);
+
+    await act(async () => Promise.resolve());
+    const skillsFolder = Array.from(view.container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('teams.detail.skills'),
+    );
+    expect(skillsFolder).toBeTruthy();
+    act(() => {
+      skillsFolder!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(view.container.textContent).toContain('team-skill');
+    expect(view.container.textContent).not.toContain('global-only');
+    expect(window.clawwork.getSkillsStatus).not.toHaveBeenCalled();
+  });
+
+  it('selects skills from the current gateway and ClawHub search', async () => {
+    let agents: AgentDraft[] = [
+      {
+        uid: 'a1',
+        name: 'Agent A',
+        description: '',
+        role: 'coordinator',
+        model: 'model-a',
+        agentMd: '',
+        soulMd: '',
+        skills: [],
+        existingAgentId: 'agent-a',
+        lockedExisting: true,
+      },
+    ];
+    const handleChange = vi.fn();
+    function Harness() {
+      const [drafts, setDrafts] = useState(agents);
+      agents = drafts;
+      return (
+        <AgentConfigStep
+          agents={drafts}
+          onChange={(nextAgents) => {
+            handleChange(nextAgents);
+            setDrafts(nextAgents);
+          }}
+          gatewayId="gw-1"
+          editMode
+        />
+      );
+    }
+
+    const view = render(<Harness />);
+    cleanups.push(view.unmount);
+
+    await act(async () => Promise.resolve());
+    expect(window.clawwork.getSkillsStatus).toHaveBeenCalledWith('gw-1');
+
+    const installed = Array.from(view.container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Installed Skill'),
+    );
+    expect(installed).toBeTruthy();
+    act(() => {
+      installed!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(agents[0].skills).toEqual(['installed-skill']);
+
+    const searchInput = view.container.querySelector('input[placeholder="settings.skillHubSearchPlaceholder"]');
+    expect(searchInput).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      setter?.call(searchInput, 'search');
+      searchInput!.dispatchEvent(new InputEvent('input', { bubbles: true, data: 'search' }));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+
+    expect(window.clawwork.searchSkills).toHaveBeenCalledWith('gw-1', { query: 'search', limit: 20 });
+    const searched = Array.from(view.container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Searched Skill'),
+    );
+    expect(searched).toBeTruthy();
+    act(() => {
+      searched!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(agents[0].skills).toEqual(['installed-skill', 'searched-skill']);
+  });
+
+  it('locks existing agent mode while editing a team', async () => {
+    const agents: AgentDraft[] = [
+      {
+        uid: 'a1',
+        name: 'Agent A',
+        description: '',
+        role: 'coordinator',
+        model: 'model-a',
+        agentMd: '',
+        soulMd: '',
+        skills: [],
+        existingAgentId: 'agent-a',
+        lockedExisting: true,
+      },
+    ];
+
+    const view = render(<AgentConfigStep agents={agents} onChange={vi.fn()} gatewayId="gw-1" editMode />);
+    cleanups.push(view.unmount);
+
+    await act(async () => Promise.resolve());
+
+    expect(view.container.textContent).not.toContain('teams.wizard.createNew');
+    expect(view.container.textContent).not.toContain('teams.wizard.selectExisting');
+    expect(view.container.textContent).toContain('teams.wizard.addAgent');
+  });
+
+  it('allows adding a configurable agent while editing a team', async () => {
+    let agents: AgentDraft[] = [
+      {
+        uid: 'a1',
+        name: 'Agent A',
+        description: '',
+        role: 'coordinator',
+        model: 'model-a',
+        agentMd: '',
+        soulMd: '',
+        skills: [],
+        existingAgentId: 'agent-a',
+        lockedExisting: true,
+      },
+      {
+        uid: 'a2',
+        name: 'Agent B',
+        description: '',
+        role: 'worker',
+        model: 'model-b',
+        agentMd: '',
+        soulMd: '',
+        skills: [],
+        existingAgentId: 'agent-b',
+        lockedExisting: true,
+      },
+    ];
+    function Harness() {
+      const [drafts, setDrafts] = useState(agents);
+      agents = drafts;
+      return <AgentConfigStep agents={drafts} onChange={setDrafts} gatewayId="gw-1" editMode />;
+    }
+
+    const view = render(<Harness />);
+    cleanups.push(view.unmount);
+
+    await act(async () => Promise.resolve());
+    const addButton = Array.from(view.container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('teams.wizard.addAgent'),
+    );
+    expect(addButton).toBeTruthy();
+
+    act(() => {
+      addButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(agents).toHaveLength(3);
+    expect(view.container.textContent).toContain('teams.wizard.createNew');
+    expect(view.container.textContent).toContain('teams.wizard.selectExisting');
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -63,6 +63,7 @@ export interface TeamAgent {
   agentId: string;
   role: string;
   isManager: boolean;
+  skills: string[];
 }
 
 export interface Team {


### PR DESCRIPTION
## Summary

Persist team-bound skill selections across installation, editing, local storage, and team detail rendering. This keeps team skill membership scoped to the team record instead of deriving it from all skills installed on an agent.

This PR is slightly over the nominal insertion budget because it includes focused persistence/UI tests and one cohesive cross-layer feature.

## Type of change

- [x] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Teams need to remember which skills belong to each team agent. Without a persisted binding, the detail view can only infer skills from gateway-wide agent status, which mixes global agent state with team membership.

## What changed?

- Added `skills` to `TeamAgent` and persisted it in SQLite via `team_agents.skills_json`.
- Passed skill bindings through team install/update and preload/main IPC contracts.
- Updated team edit UI to preserve existing agent bindings while allowing team-specific skill selection from installed skills or ClawHub search.
- Updated team detail rendering to show only skills bound to the team record.
- Added coverage for persistence and team skill binding UI behavior.

## Architecture impact

- Owning layer: shared / main / preload / renderer
- Cross-layer impact: yes. `TeamAgent.skills` is now part of the shared team contract, persisted by main-process data handlers, exposed through preload IPC, and consumed by renderer team UI.
- Invariants touched from `docs/architecture-invariants.md`: team persistence and shared type boundaries.
- Why those invariants remain protected: main owns SQLite writes, preload only forwards typed IPC, renderer consumes shared team data, and `pnpm check:architecture` passed.

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
```

## Screenshots or recordings

No screenshot captured. The change affects the team wizard/detail interactions; renderer contract checks and jsdom UI tests passed. Existing tokens and component state patterns were preserved, and `pnpm check:ui-contract` passed.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Teams now persist and display the skills bound to each team agent.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate