### PR TITLE
fix: readConfig now logs errors and backs up corrupted config

### DIFF
--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -1,6 +1,6 @@
 import { app, safeStorage } from 'electron';
 import { join } from 'path';
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, renameSync } from 'fs';
 import { homedir } from 'os';
 import { randomUUID } from 'node:crypto';
 import { CONFIG_FILE_NAME, DEFAULT_WORKSPACE_DIR } from '@clawwork/shared';
@@ -161,7 +161,14 @@ export function readConfig(): AppConfig | null {
     const config = JSON.parse(raw) as AppConfig;
     const migrated = migrateConfigIfNeeded(config);
     return decryptGatewayCredentials(migrated);
-  } catch {
+  } catch (err) {
+    console.error('[config] failed to read:', err);
+    const corruptedPath = `${cfgPath}.corrupted-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+    try {
+      renameSync(cfgPath, corruptedPath);
+    } catch {
+      // best-effort backup rename
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary

`readConfig()` had a bare `catch {}` that silently returned `null` on any parse/decrypt error, causing user config to disappear without trace.

## Changes

- **Log error:** added `console.error('[config] failed to read:', err)` in the catch block
- **Backup corrupted file:** renamed `config.json` → `config.json.corrupted-<ISO timestamp>` so recovery is possible
- **Graceful fallback:** still returns `null` so the first-run/onboarding flow kicks in as expected

## Testing

- `pnpm check` ✅ (architecture guardrails passed, eslint + prettier clean)
- `pnpm test` ✅ (256 tests, 42 test files — all passing)

Fixes clawwork-ai/ClawWork#384