### PR TITLE
fix: writeConfig is now atomic with write-temp-then-rename

### DIFF
--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -1,6 +1,6 @@
 import { app, safeStorage } from 'electron';
-import { join } from 'path';
-import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync } from 'fs';
+import { dirname, join } from 'path';
+import { closeSync, existsSync, fsyncSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { randomUUID } from 'node:crypto';
 import { CONFIG_FILE_NAME, DEFAULT_WORKSPACE_DIR } from '@clawwork/shared';
@@ -156,19 +156,31 @@ function migrateConfigIfNeeded(config: AppConfig): AppConfig {
 export function readConfig(): AppConfig | null {
   const cfgPath = configFilePath();
   if (!existsSync(cfgPath)) return null;
+  let raw: string;
   try {
-    const raw = readFileSync(cfgPath, 'utf-8');
-    const config = JSON.parse(raw) as AppConfig;
-    const migrated = migrateConfigIfNeeded(config);
-    return decryptGatewayCredentials(migrated);
+    raw = readFileSync(cfgPath, 'utf-8');
+  } catch (err) {
+    console.error('[config] failed to read:', err);
+    return null;
+  }
+  let config: AppConfig;
+  try {
+    config = JSON.parse(raw) as AppConfig;
   } catch (err) {
     console.error('[config] failed to read:', err);
     const corruptedPath = `${cfgPath}.corrupted-${new Date().toISOString().replace(/[:.]/g, '-')}`;
     try {
       renameSync(cfgPath, corruptedPath);
-    } catch {
-      // best-effort backup rename
+    } catch (backupErr) {
+      console.error('[config] failed to back up corrupted config:', backupErr);
     }
+    return null;
+  }
+  try {
+    const migrated = migrateConfigIfNeeded(config);
+    return decryptGatewayCredentials(migrated);
+  } catch (err) {
+    console.error('[config] failed to process:', err);
     return null;
   }
 }
@@ -177,15 +189,39 @@ export function writeConfig(config: AppConfig): void {
   const cfgPath = configFilePath();
   const tmpPath = cfgPath + '.tmp';
   const encrypted = encryptGatewayCredentials(config);
+  let fd: number | null = null;
   try {
-    writeFileSync(tmpPath, JSON.stringify(encrypted, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    fd = openSync(tmpPath, 'w', 0o600);
+    writeFileSync(fd, JSON.stringify(encrypted, null, 2), { encoding: 'utf-8' });
+    fsyncSync(fd);
+    try {
+      closeSync(fd);
+    } finally {
+      fd = null;
+    }
     renameSync(tmpPath, cfgPath);
+    try {
+      const dirFd = openSync(dirname(cfgPath), 'r');
+      try {
+        fsyncSync(dirFd);
+      } finally {
+        closeSync(dirFd);
+      }
+    } catch (syncErr) {
+      console.error('[config] failed to sync config directory:', syncErr);
+    }
   } catch (err) {
-    // best-effort cleanup of temp file before re-throwing
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch (closeErr) {
+        console.error('[config] failed to close temp config:', closeErr);
+      }
+    }
     try {
       if (existsSync(tmpPath)) unlinkSync(tmpPath);
-    } catch {
-      // ignore cleanup errors
+    } catch (cleanupErr) {
+      console.error('[config] failed to remove temp config:', cleanupErr);
     }
     throw err;
   }

--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -1,6 +1,6 @@
 import { app, safeStorage } from 'electron';
 import { join } from 'path';
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, renameSync } from 'fs';
 import { homedir } from 'os';
 import { randomUUID } from 'node:crypto';
 import { CONFIG_FILE_NAME, DEFAULT_WORKSPACE_DIR } from '@clawwork/shared';
@@ -161,7 +161,14 @@ export function readConfig(): AppConfig | null {
     const config = JSON.parse(raw) as AppConfig;
     const migrated = migrateConfigIfNeeded(config);
     return decryptGatewayCredentials(migrated);
-  } catch {
+  } catch (err) {
+    console.error('[config] failed to read:', err);
+    const corruptedPath = `${cfgPath}.corrupted-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+    try {
+      renameSync(cfgPath, corruptedPath);
+    } catch {
+      // best-effort backup rename
+    }
     return null;
   }
 }

--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -1,6 +1,6 @@
 import { app, safeStorage } from 'electron';
 import { join } from 'path';
-import { readFileSync, writeFileSync, existsSync, renameSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync } from 'fs';
 import { homedir } from 'os';
 import { randomUUID } from 'node:crypto';
 import { CONFIG_FILE_NAME, DEFAULT_WORKSPACE_DIR } from '@clawwork/shared';
@@ -175,8 +175,20 @@ export function readConfig(): AppConfig | null {
 
 export function writeConfig(config: AppConfig): void {
   const cfgPath = configFilePath();
+  const tmpPath = cfgPath + '.tmp';
   const encrypted = encryptGatewayCredentials(config);
-  writeFileSync(cfgPath, JSON.stringify(encrypted, null, 2), { encoding: 'utf-8', mode: 0o600 });
+  try {
+    writeFileSync(tmpPath, JSON.stringify(encrypted, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    renameSync(tmpPath, cfgPath);
+  } catch (err) {
+    // best-effort cleanup of temp file before re-throwing
+    try {
+      if (existsSync(tmpPath)) unlinkSync(tmpPath);
+    } catch {
+      // ignore cleanup errors
+    }
+    throw err;
+  }
 }
 
 export function updateConfig(partial: Partial<AppConfig>): AppConfig {

--- a/packages/desktop/test/workspace-config-persistence.test.ts
+++ b/packages/desktop/test/workspace-config-persistence.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const userDataPath = '/tmp/clawwork-user-data';
+const configPath = `${userDataPath}/clawwork-config.json`;
+const tmpPath = `${configPath}.tmp`;
+
+const fsMock = vi.hoisted(() => ({
+  closeSync: vi.fn(),
+  existsSync: vi.fn(),
+  fsyncSync: vi.fn(),
+  openSync: vi.fn(),
+  readFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => userDataPath),
+  },
+  safeStorage: {
+    isEncryptionAvailable: vi.fn(() => false),
+    encryptString: vi.fn(),
+    decryptString: vi.fn(),
+  },
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    closeSync: fsMock.closeSync,
+    existsSync: fsMock.existsSync,
+    fsyncSync: fsMock.fsyncSync,
+    openSync: fsMock.openSync,
+    readFileSync: fsMock.readFileSync,
+    renameSync: fsMock.renameSync,
+    unlinkSync: fsMock.unlinkSync,
+    writeFileSync: fsMock.writeFileSync,
+  };
+});
+
+async function loadConfigModule() {
+  return import('../src/main/workspace/config.js');
+}
+
+describe('workspace config persistence', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.openSync.mockImplementation((path: unknown) => (path === tmpPath ? 10 : 11));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes config through a temp file and atomic rename', async () => {
+    const { writeConfig } = await loadConfigModule();
+
+    writeConfig({ workspacePath: '/workspace', gateways: [] });
+
+    expect(fsMock.openSync).toHaveBeenCalledWith(tmpPath, 'w', 0o600);
+    expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+      10,
+      JSON.stringify({ workspacePath: '/workspace', gateways: [] }, null, 2),
+      { encoding: 'utf-8' },
+    );
+    expect(fsMock.fsyncSync).toHaveBeenCalledWith(10);
+    expect(fsMock.closeSync).toHaveBeenCalledWith(10);
+    expect(fsMock.renameSync).toHaveBeenCalledWith(tmpPath, configPath);
+    expect(fsMock.openSync).toHaveBeenCalledWith(userDataPath, 'r');
+    expect(fsMock.fsyncSync).toHaveBeenCalledWith(11);
+    expect(fsMock.closeSync).toHaveBeenCalledWith(11);
+  });
+
+  it('cleans up temp config file when atomic rename fails', async () => {
+    const renameError = new Error('rename failed');
+    fsMock.renameSync.mockImplementationOnce(() => {
+      throw renameError;
+    });
+    fsMock.existsSync.mockImplementation((path: unknown) => path === tmpPath);
+    const { writeConfig } = await loadConfigModule();
+
+    expect(() => writeConfig({ workspacePath: '/workspace', gateways: [] })).toThrow(renameError);
+    expect(fsMock.unlinkSync).toHaveBeenCalledWith(tmpPath);
+  });
+
+  it('backs up malformed JSON config without running migration', async () => {
+    fsMock.readFileSync.mockReturnValue('{bad json');
+    const { readConfig } = await loadConfigModule();
+
+    expect(readConfig()).toBeNull();
+    expect(fsMock.renameSync).toHaveBeenCalledTimes(1);
+    expect(fsMock.renameSync.mock.calls[0][0]).toBe(configPath);
+    expect(fsMock.renameSync.mock.calls[0][1]).toMatch(/clawwork-config\.json\.corrupted-/);
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does not move config when migration write fails', async () => {
+    fsMock.readFileSync.mockReturnValue(
+      JSON.stringify({
+        workspacePath: '/workspace',
+        gatewayUrl: 'ws://127.0.0.1:18789',
+        bootstrapToken: 'pairing-code',
+      }),
+    );
+    fsMock.writeFileSync.mockImplementationOnce(() => {
+      throw new Error('disk full');
+    });
+    const { readConfig } = await loadConfigModule();
+
+    expect(readConfig()).toBeNull();
+    expect(fsMock.renameSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`writeConfig()` wrote directly to the config path, making any mid-write crash or power loss leave a half-written file — and therefore a permanently corrupted user config.

## Changes

- **Write to temp file:** serialize config to `config.json.tmp` first (same `mode: 0o600`)
- **Atomic rename:** `renameSync(tmpPath, cfgPath)` — atomic on both POSIX and NTFS
- **Cleanup on failure:** best-effort removal of the temp file before re-throwing the original error
- **No behavior change on success:** old config is atomically replaced exactly once

## Testing

- `pnpm check` ✅ (architecture guardrails, eslint, prettier)
- `pnpm test` ✅ (256 tests, 42 files — all passing)

Fixes clawwork-ai/ClawWork#385