### PR TITLE
[Fix] Persist assistant media attachments

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -30,6 +30,6 @@
     },
     "website": {}
   },
-  "ignore": ["keynote/**", "website/**", ".claude/**"],
+  "ignore": ["keynote/**", ".claude/**", ".agents/**"],
   "exclude": ["unlisted"]
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export {
   INTERNAL_ASSISTANT_MARKERS,
   sanitizeModel,
   isVisibleAssistantContent,
+  normalizeContentBlocks,
   normalizeAssistantTurns,
   collapseDiscoveredMessages,
 } from './protocol/normalize-history.js';

--- a/packages/core/src/ports/gateway-transport.ts
+++ b/packages/core/src/ports/gateway-transport.ts
@@ -1,4 +1,4 @@
-import type { CommandsListParams, IpcResult } from '@clawwork/shared';
+import type { CommandsListParams, IpcResult, MessageAttachment } from '@clawwork/shared';
 
 export interface GatewayEvent {
   event: string;
@@ -54,7 +54,7 @@ export interface DiscoveredSession {
   inputTokens?: number;
   outputTokens?: number;
   contextTokens?: number;
-  messages: { role: string; content: string; timestamp: string }[];
+  messages: { role: string; content: string; timestamp: string; attachments?: MessageAttachment[] }[];
 }
 
 export interface SyncResult {

--- a/packages/core/src/protocol/normalize-history.ts
+++ b/packages/core/src/protocol/normalize-history.ts
@@ -1,4 +1,4 @@
-import type { ToolCall, Message } from '@clawwork/shared';
+import type { Message, MessageAttachment, ToolCall } from '@clawwork/shared';
 import type { RawContentBlock, RawHistoryMessage, NormalizedAssistantTurn, DiscoveredMessageShape } from './types.js';
 import { safeJsonParse } from './parse-content.js';
 
@@ -15,11 +15,162 @@ export function isVisibleAssistantContent(content: string): boolean {
   return trimmed.length > 0 && !INTERNAL_ASSISTANT_MARKERS.has(trimmed);
 }
 
-function extractAssistantText(blocks: RawContentBlock[]): string {
-  return blocks
-    .filter((b) => b.type === 'text' && b.text)
-    .map((b) => b.text!)
-    .join('');
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|avif)(?:[?#].*)?$/i;
+const DATA_IMAGE_RE = /^data:image\/(png|jpe?g|gif|webp|avif);base64,/i;
+
+function cleanMediaCandidate(raw: string): string {
+  const trimmed = raw.trim();
+  const wrapped = trimmed.match(/^`([^`]+)`$/) ?? trimmed.match(/^"([^"]+)"$/) ?? trimmed.match(/^'([^']+)'$/);
+  return (wrapped?.[1] ?? trimmed).replace(/[`"'\\})\],]+$/, '').trim();
+}
+
+function hasUnsafePathSegment(value: string): boolean {
+  return value.split(/[\\/]+/).some((segment) => segment === '..');
+}
+
+function encodeFilePath(path: string): string {
+  return `file://${path.split('/').map(encodeURIComponent).join('/')}`;
+}
+
+function filePathFromMediaCandidate(candidate: string): string | null {
+  if (!candidate.startsWith('file://')) return candidate;
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'file:' || (url.hostname && url.hostname !== 'localhost')) return null;
+    return decodeURIComponent(url.pathname);
+  } catch {
+    return null;
+  }
+}
+
+function fileNameFromSource(source: string, fallback: string): string {
+  const withoutQuery = source.split(/[?#]/)[0] ?? source;
+  const normalized = withoutQuery.replaceAll('\\', '/');
+  const candidate = normalized.split('/').filter(Boolean).at(-1);
+  if (!candidate) return fallback;
+  try {
+    return decodeURIComponent(candidate);
+  } catch {
+    return candidate;
+  }
+}
+
+function mimeTypeFromSource(source: string, fallback?: string): string | undefined {
+  if (fallback?.startsWith('image/')) return fallback;
+  const lower = source.split(/[?#]/)[0]?.toLowerCase() ?? '';
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.gif')) return 'image/gif';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  if (lower.endsWith('.avif')) return 'image/avif';
+  const dataMatch = source.match(/^data:(image\/[^;]+);/i);
+  return dataMatch?.[1] ?? fallback;
+}
+
+function attachmentFromMediaSource(source: string, alt?: string, mimeType?: string): MessageAttachment | null {
+  const candidate = cleanMediaCandidate(source);
+  if (!candidate || candidate.length > 4096 || hasUnsafePathSegment(candidate) || candidate.startsWith('~'))
+    return null;
+
+  if (DATA_IMAGE_RE.test(candidate)) {
+    return {
+      fileName: alt?.trim() || 'image.png',
+      dataUrl: candidate,
+      mimeType: mimeTypeFromSource(candidate, mimeType),
+    };
+  }
+
+  if (/^https:\/\//i.test(candidate) && IMAGE_EXT_RE.test(candidate)) {
+    return {
+      fileName: alt?.trim() || fileNameFromSource(candidate, 'image.png'),
+      dataUrl: candidate,
+      mimeType: mimeTypeFromSource(candidate, mimeType),
+    };
+  }
+
+  const filePath = filePathFromMediaCandidate(candidate);
+  if (!filePath) return null;
+  if (filePath.startsWith('/') && IMAGE_EXT_RE.test(filePath)) {
+    return {
+      fileName: alt?.trim() || fileNameFromSource(filePath, 'image.png'),
+      dataUrl: encodeFilePath(filePath),
+      mimeType: mimeTypeFromSource(filePath, mimeType),
+      sourcePath: filePath,
+    };
+  }
+
+  return null;
+}
+
+function splitTextMediaDirectives(text: string): { text: string; attachments: MessageAttachment[] } {
+  const attachments: MessageAttachment[] = [];
+  const kept: string[] = [];
+  let inFence = false;
+
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trimStart();
+    if (/^(```|~~~)/.test(trimmed)) {
+      inFence = !inFence;
+      kept.push(line);
+      continue;
+    }
+
+    if (!inFence && trimmed.toUpperCase().startsWith('MEDIA:')) {
+      const media = attachmentFromMediaSource(trimmed.slice('MEDIA:'.length));
+      if (media) {
+        attachments.push(media);
+        continue;
+      }
+    }
+
+    kept.push(line);
+  }
+
+  if (attachments.length > 0) {
+    while (kept[0]?.trim() === '') kept.shift();
+    while (kept.at(-1)?.trim() === '') kept.pop();
+  }
+
+  return { text: kept.join('\n'), attachments };
+}
+
+export function mergeMessageAttachments(
+  base: MessageAttachment[] | undefined,
+  incoming: MessageAttachment[] | undefined,
+): MessageAttachment[] | undefined {
+  const merged = [...(base ?? [])];
+  const seen = new Set(merged.map((attachment) => attachment.dataUrl));
+  for (const attachment of incoming ?? []) {
+    if (seen.has(attachment.dataUrl)) continue;
+    seen.add(attachment.dataUrl);
+    merged.push(attachment);
+  }
+  return merged.length ? merged : undefined;
+}
+
+export function normalizeContentBlocks(blocks: RawContentBlock[]): {
+  content: string;
+  attachments?: MessageAttachment[];
+} {
+  let content = '';
+  let attachments: MessageAttachment[] | undefined;
+
+  for (const block of blocks) {
+    if (block.type === 'text' && block.text) {
+      const parsed = splitTextMediaDirectives(block.text);
+      content += parsed.text;
+      attachments = mergeMessageAttachments(attachments, parsed.attachments);
+      continue;
+    }
+
+    if (block.type === 'image') {
+      const source = block.url ?? block.openUrl;
+      const attachment = source ? attachmentFromMediaSource(source, block.alt, block.mimeType) : null;
+      attachments = mergeMessageAttachments(attachments, attachment ? [attachment] : undefined);
+    }
+  }
+
+  return { content, attachments };
 }
 
 function toISOTimestamp(epoch: number | undefined): string {
@@ -71,7 +222,7 @@ function shouldStartVisibleAssistantTurn(
   timestamp: string,
   canMergeToolFinal: boolean,
 ): boolean {
-  return Boolean(turn?.content && turn.timestamp !== timestamp && !canMergeToolFinal);
+  return Boolean((turn?.content || turn?.attachments?.length) && turn.timestamp !== timestamp && !canMergeToolFinal);
 }
 
 export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): NormalizedAssistantTurn[] {
@@ -110,7 +261,8 @@ export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): Normalize
     if (msg.role !== 'assistant') continue;
 
     const timestamp = toISOTimestamp(msg.timestamp);
-    const text = extractAssistantText(msg.content ?? []);
+    const normalizedContent = normalizeContentBlocks(msg.content ?? []);
+    const text = normalizedContent.content;
     const toolCalls = (msg.content ?? [])
       .filter((block: RawContentBlock) => block.type === 'toolCall' && block.id && block.name)
       .map(
@@ -130,7 +282,7 @@ export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): Normalize
         }),
       );
 
-    if (!text.trim() && toolCalls.length === 0) continue;
+    if (!text.trim() && toolCalls.length === 0 && !normalizedContent.attachments?.length) continue;
 
     const visibleText = isVisibleAssistantContent(text) ? text.trim() : '';
 
@@ -141,8 +293,17 @@ export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): Normalize
       if (visibleText) {
         turn.content = appendSegment(turn.content, visibleText);
       }
+      turn.attachments = mergeMessageAttachments(turn.attachments, normalizedContent.attachments);
       turn.timestamp = timestamp;
       canMergeToolFinal = true;
+      continue;
+    }
+
+    if (!visibleText && normalizedContent.attachments?.length) {
+      const turn = ensureCurrent(timestamp);
+      turn.attachments = mergeMessageAttachments(turn.attachments, normalizedContent.attachments);
+      turn.timestamp = timestamp;
+      canMergeToolFinal = false;
       continue;
     }
 
@@ -154,11 +315,12 @@ export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): Normalize
 
     const turn = ensureCurrent(timestamp);
     turn.content = appendSegment(turn.content, visibleText);
+    turn.attachments = mergeMessageAttachments(turn.attachments, normalizedContent.attachments);
     turn.timestamp = timestamp;
     canMergeToolFinal = false;
   }
 
-  return turns.filter((turn) => turn.content || turn.toolCalls.length > 0);
+  return turns.filter((turn) => turn.content || turn.toolCalls.length > 0 || (turn.attachments?.length ?? 0) > 0);
 }
 
 export function collapseDiscoveredMessages(messages: DiscoveredMessageShape[], taskId: string): Message[] {
@@ -167,7 +329,11 @@ export function collapseDiscoveredMessages(messages: DiscoveredMessageShape[], t
 
   function flushAssistant(): void {
     if (!currentAssistant) return;
-    if (currentAssistant.content || currentAssistant.toolCalls.length > 0) {
+    if (
+      currentAssistant.content ||
+      currentAssistant.toolCalls.length > 0 ||
+      (currentAssistant.attachments?.length ?? 0) > 0
+    ) {
       collapsed.push(currentAssistant);
     }
     currentAssistant = null;
@@ -192,7 +358,7 @@ export function collapseDiscoveredMessages(messages: DiscoveredMessageShape[], t
 
     const visibleText = isVisibleAssistantContent(message.content) ? message.content.trim() : '';
     const toolCalls = message.toolCalls ?? [];
-    if (!visibleText && toolCalls.length === 0) continue;
+    if (!visibleText && toolCalls.length === 0 && !message.attachments?.length) continue;
 
     if (!currentAssistant) {
       currentAssistant = {
@@ -209,6 +375,7 @@ export function collapseDiscoveredMessages(messages: DiscoveredMessageShape[], t
     if (visibleText) {
       currentAssistant.content = appendSegment(currentAssistant.content, visibleText);
     }
+    currentAssistant.attachments = mergeMessageAttachments(currentAssistant.attachments, message.attachments);
     if (toolCalls.length > 0) {
       const existingIds = new Set(currentAssistant.toolCalls.map((toolCall) => toolCall.id));
       currentAssistant.toolCalls.push(...toolCalls.filter((toolCall) => !existingIds.has(toolCall.id)));

--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -1,4 +1,4 @@
-import type { ToolCall } from '@clawwork/shared';
+import type { MessageAttachment, ToolCall } from '@clawwork/shared';
 
 export interface ChatMessage {
   role?: string;
@@ -21,6 +21,10 @@ export interface ChatEventPayload {
 export interface RawContentBlock {
   type: string;
   text?: string;
+  url?: string;
+  openUrl?: string;
+  alt?: string;
+  mimeType?: string;
   id?: string;
   name?: string;
   arguments?: Record<string, unknown> | string;
@@ -40,6 +44,7 @@ export interface RawHistoryMessage {
 export interface NormalizedAssistantTurn {
   content: string;
   toolCalls: ToolCall[];
+  attachments?: MessageAttachment[];
   timestamp: string;
 }
 
@@ -48,4 +53,5 @@ export interface DiscoveredMessageShape {
   content: string;
   timestamp: string;
   toolCalls?: ToolCall[];
+  attachments?: MessageAttachment[];
 }

--- a/packages/core/src/services/session-sync.ts
+++ b/packages/core/src/services/session-sync.ts
@@ -3,7 +3,21 @@ import type { Message, MessageRole, ToolCall, IpcResult } from '@clawwork/shared
 import type { RawHistoryMessage } from '../protocol/types.js';
 import type { ActiveTurn, MessageState } from '../stores/message-store.js';
 import { mergeCanonicalMessageWithActiveTurn } from '../stores/message-store.js';
-import { sanitizeModel, normalizeAssistantTurns, collapseDiscoveredMessages } from '../protocol/normalize-history.js';
+import {
+  sanitizeModel,
+  normalizeContentBlocks,
+  normalizeAssistantTurns,
+  collapseDiscoveredMessages,
+  mergeMessageAttachments,
+} from '../protocol/normalize-history.js';
+
+type DiscoveredSyncMessage = {
+  role: string;
+  content: string;
+  timestamp: string;
+  attachments?: unknown[];
+  toolCalls?: ToolCall[];
+};
 
 export interface SessionSyncDeps {
   persistence: {
@@ -52,7 +66,7 @@ export interface SessionSyncDeps {
         inputTokens?: number;
         outputTokens?: number;
         contextTokens?: number;
-        messages: { role: string; content: string; timestamp: string; toolCalls?: ToolCall[] }[];
+        messages: DiscoveredSyncMessage[];
       }[];
     }>;
   };
@@ -101,9 +115,76 @@ export interface SessionSyncDeps {
 
 const RETRY_DELAYS = [2000, 4000, 8000];
 
+function normalizeLocalAssistantMessage(row: { role: string; content: string; attachments?: unknown[] }): {
+  content: string;
+  attachments?: Message['attachments'];
+} {
+  const existingAttachments = Array.isArray(row.attachments) ? (row.attachments as Message['attachments']) : undefined;
+  if (row.role !== 'assistant') return { content: row.content, attachments: existingAttachments };
+  const normalized = normalizeContentBlocks([{ type: 'text', text: row.content }]);
+  return {
+    content: normalized.content,
+    attachments: mergeMessageAttachments(existingAttachments, normalized.attachments),
+  };
+}
+
 export function createSessionSync(deps: SessionSyncDeps) {
   let hydrationPromise: Promise<void> | null = null;
   const syncChains = new Map<string, Promise<void>>();
+
+  function persistCanonicalMessage(message: Message): void {
+    deps.persistence
+      .persistMessage({
+        id: message.id,
+        taskId: message.taskId,
+        role: message.role,
+        content: message.content,
+        timestamp: message.timestamp,
+        sessionKey: message.sessionKey,
+        agentId: message.agentId,
+        runId: message.runId,
+        attachments: message.attachments as unknown[] | undefined,
+        toolCalls: message.toolCalls,
+      })
+      .catch((err) => console.error('[session-sync] persistMessage failed:', err));
+  }
+
+  function backfillAssistantAttachments(
+    taskId: string,
+    sessionKey: string,
+    incoming: Array<{ timestamp: string; attachments?: Message['attachments'] }>,
+  ): void {
+    const withAttachments = incoming.filter((message) => message.attachments?.length);
+    if (withAttachments.length === 0) return;
+
+    const byTimestamp = new Map(withAttachments.map((message) => [message.timestamp, message]));
+    const updated: Message[] = [];
+
+    deps.getMessageStore().setState((s) => {
+      const messages = s.messagesByTask[taskId] ?? [];
+      let changed = false;
+      const next = messages.map((message) => {
+        if (message.role !== 'assistant') return message;
+        if ((message.sessionKey ?? sessionKey) !== sessionKey) return message;
+        const match = byTimestamp.get(message.timestamp);
+        if (!match?.attachments?.length) return message;
+
+        const merged = mergeMessageAttachments(message.attachments, match.attachments);
+        if ((merged?.length ?? 0) === (message.attachments?.length ?? 0)) return message;
+
+        changed = true;
+        const nextMessage = { ...message, attachments: merged };
+        updated.push(nextMessage);
+        return nextMessage;
+      });
+
+      return changed ? { messagesByTask: { ...s.messagesByTask, [taskId]: next } } : {};
+    });
+
+    for (const message of updated) {
+      persistCanonicalMessage(message);
+    }
+  }
 
   async function hydrateFromLocal(): Promise<void> {
     if (!hydrationPromise) {
@@ -116,19 +197,22 @@ export function createSessionSync(deps: SessionSyncDeps) {
           try {
             const res = await deps.persistence.loadMessages(t.id);
             if (res.ok && res.rows && res.rows.length > 0) {
-              const msgs: Message[] = res.rows.map((r) => ({
-                id: r.id,
-                taskId: r.taskId,
-                role: r.role as MessageRole,
-                content: r.content,
-                artifacts: [],
-                toolCalls: Array.isArray(r.toolCalls) ? (r.toolCalls as ToolCall[]) : [],
-                timestamp: r.timestamp,
-                sessionKey: r.sessionKey,
-                agentId: r.agentId,
-                runId: r.runId,
-                attachments: r.attachments as Message['attachments'],
-              }));
+              const msgs: Message[] = res.rows.map((r) => {
+                const normalized = normalizeLocalAssistantMessage(r);
+                return {
+                  id: r.id,
+                  taskId: r.taskId,
+                  role: r.role as MessageRole,
+                  content: normalized.content,
+                  artifacts: [],
+                  toolCalls: Array.isArray(r.toolCalls) ? (r.toolCalls as ToolCall[]) : [],
+                  timestamp: r.timestamp,
+                  sessionKey: r.sessionKey,
+                  agentId: r.agentId,
+                  runId: r.runId,
+                  attachments: normalized.attachments,
+                };
+              });
               messageStore.bulkLoad(t.id, msgs);
             }
           } catch (err) {
@@ -166,6 +250,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
     );
 
     const gatewayAssistant = normalizeAssistantTurns(rawMsgs);
+    backfillAssistantAttachments(taskId, sessionKey, gatewayAssistant);
 
     const newest = gatewayAssistant.filter(
       (m) =>
@@ -186,6 +271,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
         content: gm.content,
         artifacts: [],
         toolCalls: gm.toolCalls,
+        attachments: gm.attachments,
         sessionKey,
         agentId: parseAgentIdFromSessionKey(sessionKey),
         timestamp: gm.timestamp,
@@ -207,19 +293,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
         }));
       }
 
-      deps.persistence
-        .persistMessage({
-          id: mergedCanonical.id,
-          taskId,
-          role: 'assistant',
-          content: mergedCanonical.content,
-          timestamp: mergedCanonical.timestamp,
-          sessionKey,
-          agentId: mergedCanonical.agentId,
-          runId: mergedCanonical.runId,
-          toolCalls: mergedCanonical.toolCalls,
-        })
-        .catch((err) => console.error('[session-sync] persistMessage failed:', err));
+      persistCanonicalMessage(mergedCanonical);
     }
   }
 
@@ -280,20 +354,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
     deps.getMessageStore().bulkLoad(params.taskId, nextMessages);
 
     for (const msg of mapped) {
-      deps.persistence
-        .persistMessage({
-          id: msg.id,
-          taskId: msg.taskId,
-          role: msg.role,
-          content: msg.content,
-          timestamp: msg.timestamp,
-          sessionKey: msg.sessionKey,
-          agentId: msg.agentId,
-          runId: msg.runId,
-          attachments: msg.attachments as unknown[] | undefined,
-          toolCalls: msg.toolCalls,
-        })
-        .catch((err) => console.error('[session-sync] loadAndPersist persistMessage failed:', err));
+      persistCanonicalMessage(msg);
     }
   }
 
@@ -309,10 +370,11 @@ export function createSessionSync(deps: SessionSyncDeps) {
 
       for (const d of discovered) {
         const collapsedMessages = collapseDiscoveredMessages(
-          d.messages.map((message: { role: string; content: string; timestamp: string; toolCalls?: ToolCall[] }) => ({
+          d.messages.map((message: DiscoveredSyncMessage) => ({
             role: message.role,
             content: message.content,
             timestamp: message.timestamp,
+            attachments: message.attachments as Message['attachments'],
             toolCalls: message.toolCalls,
           })),
           d.taskId,
@@ -332,6 +394,11 @@ export function createSessionSync(deps: SessionSyncDeps) {
         const hasLocalData = local.length > 0;
 
         if (hasLocalData) {
+          backfillAssistantAttachments(
+            d.taskId,
+            d.sessionKey,
+            collapsedMessages.filter((message) => message.role === 'assistant'),
+          );
           const localTimestamps = new Set(local.filter((m) => m.role === 'assistant').map((m) => m.timestamp));
           const newAssistantMsgs = collapsedMessages.filter(
             (message) => message.role === 'assistant' && !localTimestamps.has(message.timestamp),

--- a/packages/core/test/normalize-history.test.ts
+++ b/packages/core/test/normalize-history.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeAssistantTurns } from '../src/protocol/normalize-history';
+import {
+  collapseDiscoveredMessages,
+  normalizeAssistantTurns,
+  normalizeContentBlocks,
+} from '../src/protocol/normalize-history';
 import type { RawHistoryMessage } from '../src/protocol/types';
 
 describe('normalizeAssistantTurns', () => {
@@ -68,5 +72,93 @@ describe('normalizeAssistantTurns', () => {
       args: { path: 'README.md' },
       result: 'file contents',
     });
+  });
+
+  it('extracts line-start MEDIA directives as image attachments', () => {
+    const rawMsgs: RawHistoryMessage[] = [
+      {
+        role: 'assistant',
+        timestamp: 2000,
+        content: [{ type: 'text', text: 'MEDIA:/Users/x/.openclaw/media/out.png\n\nImage ready' }],
+      },
+    ];
+
+    const turns = normalizeAssistantTurns(rawMsgs);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].content).toBe('Image ready');
+    expect(turns[0].attachments).toEqual([
+      {
+        fileName: 'out.png',
+        dataUrl: 'file:///Users/x/.openclaw/media/out.png',
+        mimeType: 'image/png',
+        sourcePath: '/Users/x/.openclaw/media/out.png',
+      },
+    ]);
+  });
+
+  it('decodes file URL media paths before reading from sourcePath', () => {
+    const normalized = normalizeContentBlocks([
+      { type: 'text', text: 'MEDIA:file:///Users/x/.openclaw/media/generated%20image.png' },
+    ]);
+
+    expect(normalized.attachments?.[0]).toMatchObject({
+      fileName: 'generated image.png',
+      dataUrl: 'file:///Users/x/.openclaw/media/generated%20image.png',
+      sourcePath: '/Users/x/.openclaw/media/generated image.png',
+    });
+  });
+
+  it('keeps prose MEDIA mentions as text', () => {
+    const normalized = normalizeContentBlocks([{ type: 'text', text: 'Use MEDIA:/tmp/out.png in a tool result' }]);
+
+    expect(normalized).toEqual({ content: 'Use MEDIA:/tmp/out.png in a tool result' });
+  });
+
+  it('extracts supported image content blocks', () => {
+    const normalized = normalizeContentBlocks([
+      { type: 'text', text: 'Image ready' },
+      { type: 'image', url: 'https://example.com/result.webp', alt: 'result.webp', mimeType: 'image/webp' },
+    ]);
+
+    expect(normalized).toEqual({
+      content: 'Image ready',
+      attachments: [{ fileName: 'result.webp', dataUrl: 'https://example.com/result.webp', mimeType: 'image/webp' }],
+    });
+  });
+
+  it('preserves media-only assistant turns', () => {
+    const rawMsgs: RawHistoryMessage[] = [
+      {
+        role: 'assistant',
+        timestamp: 2000,
+        content: [{ type: 'text', text: 'MEDIA:/Users/x/.openclaw/media/out.png' }],
+      },
+    ];
+
+    const turns = normalizeAssistantTurns(rawMsgs);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].content).toBe('');
+    expect(turns[0].attachments?.[0]?.fileName).toBe('out.png');
+  });
+
+  it('carries discovered assistant attachments through collapse', () => {
+    const messages = collapseDiscoveredMessages(
+      [
+        {
+          role: 'assistant',
+          content: 'Image ready',
+          timestamp: '2026-04-27T17:03:05.234Z',
+          attachments: [{ fileName: 'out.png', dataUrl: 'file:///Users/x/out.png', mimeType: 'image/png' }],
+        },
+      ],
+      'task-1',
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].attachments).toEqual([
+      { fileName: 'out.png', dataUrl: 'file:///Users/x/out.png', mimeType: 'image/png' },
+    ]);
   });
 });

--- a/packages/desktop/src/main/artifact/auto-extract.ts
+++ b/packages/desktop/src/main/artifact/auto-extract.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow } from 'electron';
+import { createHash } from 'crypto';
 import { readFileSync } from 'fs';
 import { resolve, sep } from 'path';
 import { extractImagesFromMarkdown, extractCodeBlocksFromMarkdown } from './extract.js';
@@ -7,29 +8,133 @@ import { getDb } from '../db/index.js';
 import { artifacts } from '../db/schema.js';
 import { eq } from 'drizzle-orm';
 import { safeFetch } from '../net/safe-fetch.js';
-import type { Artifact } from '@clawwork/shared';
+import { readOpenClawMediaFile } from '../media/resolve.js';
+import type { Artifact, MessageAttachment } from '@clawwork/shared';
 
 interface AutoExtractParams {
   workspacePath: string;
   taskId: string;
   messageId: string;
   content: string;
+  attachments?: MessageAttachment[];
 }
 
-export async function autoExtractArtifacts(params: AutoExtractParams): Promise<void> {
-  const { workspacePath, taskId, messageId, content } = params;
+const DATA_IMAGE_RE = /^data:(image\/(?:png|jpe?g|gif|webp|avif));base64,(.+)$/i;
+const extractionByMessage = new Map<string, Promise<void>>();
+
+type ExistingArtifact = Pick<Artifact, 'name' | 'type' | 'size' | 'contentText' | 'sourceKey'>;
+
+function hashText(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+function sourceKey(kind: string, value: string): string {
+  return `${kind}:${hashText(value)}`;
+}
+
+function canonicalSavedName(name: string): string {
+  return name.replace(/-[0-9a-f]{8}(\.[^.]+)$/i, '$1');
+}
+
+function isUniqueArtifactError(err: unknown): boolean {
+  return (
+    err instanceof Error && err.message.includes('UNIQUE constraint failed: artifacts.message_id, artifacts.source_key')
+  );
+}
+
+function extFromMime(mimeType: string | undefined): string {
+  if (mimeType === 'image/jpeg') return 'jpg';
+  if (mimeType === 'image/gif') return 'gif';
+  if (mimeType === 'image/webp') return 'webp';
+  if (mimeType === 'image/avif') return 'avif';
+  return 'png';
+}
+
+function safeImageFileName(fileName: string | undefined, mimeType: string | undefined): string {
+  const ext = extFromMime(mimeType);
+  const raw = fileName?.trim() || `image.${ext}`;
+  const clean = raw.replace(/[/\\]/g, '_').replace(/[^a-zA-Z0-9._-]/g, '_');
+  if (/\.(png|jpe?g|gif|webp|avif)$/i.test(clean)) return clean;
+  return `${clean || 'image'}.${ext}`;
+}
+
+async function readAttachmentImage(attachment: MessageAttachment): Promise<Buffer | null> {
+  if (attachment.sourcePath) {
+    const base64 = await readOpenClawMediaFile(attachment.sourcePath);
+    return base64 ? Buffer.from(base64, 'base64') : null;
+  }
+
+  const dataMatch = attachment.dataUrl.match(DATA_IMAGE_RE);
+  if (dataMatch) return Buffer.from(dataMatch[2], 'base64');
+
+  if (/^https:\/\//i.test(attachment.dataUrl)) {
+    return safeFetch(attachment.dataUrl);
+  }
+
+  return null;
+}
+
+async function doAutoExtractArtifacts(params: AutoExtractParams): Promise<void> {
+  const { workspacePath, taskId, messageId, content, attachments = [] } = params;
 
   const db = getDb();
   const existingForMsg = db.select().from(artifacts).where(eq(artifacts.messageId, messageId)).all();
-  if (existingForMsg.length > 0) return;
+  const existing = existingForMsg as ExistingArtifact[];
+  const existingSourceKeys = new Set(existing.map((artifact) => artifact.sourceKey).filter(Boolean));
 
   const images = extractImagesFromMarkdown(content);
   const codeBlocks = extractCodeBlocksFromMarkdown(content);
 
   const saved: Artifact[] = [];
 
+  async function saveExtracted(input: {
+    fileName: string;
+    buffer: Buffer;
+    artifactType: 'image' | 'code';
+    sourceKey: string;
+    contentText?: string;
+  }): Promise<void> {
+    if (existingSourceKeys.has(input.sourceKey)) return;
+
+    const canonicalName = canonicalSavedName(input.fileName);
+    const legacyDuplicate = existing.some((artifact) => {
+      if (artifact.sourceKey || artifact.type !== input.artifactType) return false;
+      if (canonicalSavedName(artifact.name) !== canonicalName || artifact.size !== input.buffer.length) return false;
+      if (input.artifactType === 'code') return artifact.contentText === input.contentText;
+      return true;
+    });
+    if (legacyDuplicate) {
+      existingSourceKeys.add(input.sourceKey);
+      return;
+    }
+
+    try {
+      const artifact = await saveArtifactFromBuffer({
+        workspacePath,
+        taskId,
+        messageId,
+        fileName: input.fileName,
+        buffer: input.buffer,
+        artifactType: input.artifactType,
+        contentText: input.contentText,
+        sourceKey: input.sourceKey,
+      });
+      existingSourceKeys.add(input.sourceKey);
+      existing.push(artifact);
+      saved.push(artifact);
+    } catch (err) {
+      if (isUniqueArtifactError(err)) {
+        existingSourceKeys.add(input.sourceKey);
+        return;
+      }
+      throw err;
+    }
+  }
+
   for (const img of images) {
     try {
+      const key = sourceKey('markdown-image', img.src);
+      if (existingSourceKeys.has(key)) continue;
       let buffer: Buffer;
       if (img.isRemote) {
         buffer = await safeFetch(img.src);
@@ -42,27 +147,48 @@ export async function autoExtractArtifacts(params: AutoExtractParams): Promise<v
       }
       const ext = img.src.split('.').pop()?.split('?')[0]?.toLowerCase() ?? 'png';
       const fileName = img.alt ? `${img.alt.replace(/[^a-zA-Z0-9_-]/g, '_')}.${ext}` : `image.${ext}`;
-      saved.push(
-        await saveArtifactFromBuffer({ workspacePath, taskId, messageId, fileName, buffer, artifactType: 'image' }),
-      );
+      await saveExtracted({
+        fileName,
+        buffer,
+        artifactType: 'image',
+        sourceKey: key,
+      });
     } catch (err) {
       console.error('[auto-extract] image save failed:', err);
     }
   }
 
+  for (const attachment of attachments) {
+    try {
+      if (!attachment.dataUrl && !attachment.sourcePath) continue;
+      if (attachment.mimeType && !attachment.mimeType.startsWith('image/')) continue;
+      const key = sourceKey('attachment', attachment.sourcePath ?? attachment.dataUrl);
+      if (existingSourceKeys.has(key)) continue;
+      const buffer = await readAttachmentImage(attachment);
+      if (!buffer) continue;
+      const fileName = safeImageFileName(attachment.fileName, attachment.mimeType);
+      await saveExtracted({
+        fileName,
+        buffer,
+        artifactType: 'image',
+        sourceKey: key,
+      });
+    } catch (err) {
+      console.error('[auto-extract] attachment image save failed:', err);
+    }
+  }
+
   for (const block of codeBlocks) {
     try {
-      saved.push(
-        await saveArtifactFromBuffer({
-          workspacePath,
-          taskId,
-          messageId,
-          fileName: block.fileName,
-          buffer: Buffer.from(block.content, 'utf-8'),
-          artifactType: 'code',
-          contentText: block.content,
-        }),
-      );
+      const key = sourceKey('code', `${block.fileName}\0${block.content}`);
+      if (existingSourceKeys.has(key)) continue;
+      await saveExtracted({
+        fileName: block.fileName,
+        buffer: Buffer.from(block.content, 'utf-8'),
+        artifactType: 'code',
+        contentText: block.content,
+        sourceKey: key,
+      });
     } catch (err) {
       console.error('[auto-extract] code block save failed:', err);
     }
@@ -76,4 +202,19 @@ export async function autoExtractArtifacts(params: AutoExtractParams): Promise<v
       win.webContents.send('artifact:saved', artifact);
     }
   }
+}
+
+export async function autoExtractArtifacts(params: AutoExtractParams): Promise<void> {
+  const key = `${params.taskId}:${params.messageId}`;
+  const active = extractionByMessage.get(key);
+  if (active) {
+    await active;
+    return;
+  }
+
+  const job = doAutoExtractArtifacts(params).finally(() => {
+    if (extractionByMessage.get(key) === job) extractionByMessage.delete(key);
+  });
+  extractionByMessage.set(key, job);
+  await job;
 }

--- a/packages/desktop/src/main/artifact/save.ts
+++ b/packages/desktop/src/main/artifact/save.ts
@@ -50,10 +50,11 @@ interface SaveArtifactParams {
   sourcePath: string;
   fileName?: string;
   mediaType?: string;
+  sourceKey?: string;
 }
 
 export async function saveArtifact(params: SaveArtifactParams): Promise<Artifact> {
-  const { workspacePath, taskId, messageId, sourcePath, fileName, mediaType } = params;
+  const { workspacePath, taskId, messageId, sourcePath, fileName, mediaType, sourceKey } = params;
 
   const taskDir = ensureTaskDir(workspacePath, taskId);
   const originalName = fileName ?? basename(sourcePath);
@@ -77,6 +78,7 @@ export async function saveArtifact(params: SaveArtifactParams): Promise<Artifact
     localPath,
     mimeType,
     size: stat.size,
+    sourceKey: sourceKey ?? '',
     createdAt: now,
   };
 
@@ -93,6 +95,7 @@ export async function saveArtifact(params: SaveArtifactParams): Promise<Artifact
         localPath: artifact.localPath,
         mimeType: artifact.mimeType,
         size: artifact.size,
+        sourceKey: artifact.sourceKey ?? '',
         createdAt: artifact.createdAt,
       })
       .run();
@@ -116,10 +119,11 @@ interface SaveArtifactFromBufferParams {
   buffer: Buffer;
   artifactType: 'code' | 'image' | 'file';
   contentText?: string;
+  sourceKey?: string;
 }
 
 export async function saveArtifactFromBuffer(params: SaveArtifactFromBufferParams): Promise<Artifact> {
-  const { workspacePath, taskId, messageId, fileName, buffer, artifactType, contentText } = params;
+  const { workspacePath, taskId, messageId, fileName, buffer, artifactType, contentText, sourceKey } = params;
 
   const taskDir = ensureTaskDir(workspacePath, taskId);
   const { finalName, destPath } = resolveArtifactDestination(taskDir, fileName);
@@ -141,6 +145,7 @@ export async function saveArtifactFromBuffer(params: SaveArtifactFromBufferParam
     localPath,
     mimeType,
     size: buffer.length,
+    sourceKey: sourceKey ?? '',
     contentText: contentText ?? '',
     createdAt: now,
   };
@@ -158,6 +163,7 @@ export async function saveArtifactFromBuffer(params: SaveArtifactFromBufferParam
         localPath: artifact.localPath,
         mimeType: artifact.mimeType,
         size: artifact.size,
+        sourceKey: artifact.sourceKey ?? '',
         createdAt: artifact.createdAt,
         contentText: contentText ?? '',
       })

--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -61,6 +61,8 @@ CREATE TABLE IF NOT EXISTS artifacts (
   local_path TEXT NOT NULL,
   mime_type TEXT NOT NULL DEFAULT '',
   size INTEGER NOT NULL DEFAULT 0,
+  source_key TEXT NOT NULL DEFAULT '',
+  content_text TEXT NOT NULL DEFAULT '',
   created_at TEXT NOT NULL
 );
 `;
@@ -130,9 +132,25 @@ function openDatabaseAt(workspacePath: string): void {
     )
   `);
 
-  sqlite.exec("DELETE FROM messages WHERE role = 'assistant' AND (content = '' OR TRIM(content) = 'NO_REPLY')");
+  sqlite.exec(`
+    DELETE FROM messages
+    WHERE role = 'assistant'
+      AND (content = '' OR TRIM(content) = 'NO_REPLY')
+      AND COALESCE(image_attachments, '') = ''
+      AND COALESCE(tool_calls, '') = ''
+      AND NOT EXISTS (
+        SELECT 1 FROM artifacts WHERE artifacts.message_id = messages.id
+      )
+  `);
 
   migrateAddColumn(sqlite, "ALTER TABLE artifacts ADD COLUMN content_text TEXT NOT NULL DEFAULT ''");
+  migrateAddColumn(sqlite, "ALTER TABLE artifacts ADD COLUMN source_key TEXT NOT NULL DEFAULT ''");
+
+  sqlite.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS artifacts_source_dedup
+    ON artifacts(message_id, source_key)
+    WHERE source_key <> ''
+  `);
 
   sqlite.exec(`
     CREATE TABLE IF NOT EXISTS teams (

--- a/packages/desktop/src/main/db/schema.ts
+++ b/packages/desktop/src/main/db/schema.ts
@@ -96,6 +96,7 @@ export const artifacts = sqliteTable('artifacts', {
   localPath: text('local_path').notNull(),
   mimeType: text('mime_type').notNull().default(''),
   size: integer('size').notNull().default(0),
+  sourceKey: text('source_key').notNull().default(''),
   contentText: text('content_text').notNull().default(''),
   createdAt: text('created_at').notNull(),
 });

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import { initDebugLogger, getDebugLogger } from './debug/index.js';
 import { registerWsHandlers } from './ipc/ws-handlers.js';
 import { registerArtifactHandlers } from './ipc/artifact-handlers.js';
 import { registerInboxHandlers } from './ipc/inbox-handlers.js';
+import { registerMediaHandlers } from './ipc/media-handlers.js';
 import { registerWorkspaceHandlers } from './ipc/workspace-handlers.js';
 import { registerSettingsHandlers } from './ipc/settings-handlers.js';
 import { registerSearchHandlers } from './ipc/search-handlers.js';
@@ -204,6 +205,7 @@ if (!gotLock) {
     registerWsHandlers();
     registerArtifactHandlers();
     registerInboxHandlers();
+    registerMediaHandlers();
     registerWorkspaceHandlers();
     registerSettingsHandlers();
     registerSearchHandlers();

--- a/packages/desktop/src/main/ipc/data-handlers.ts
+++ b/packages/desktop/src/main/ipc/data-handlers.ts
@@ -1,8 +1,9 @@
 import { ipcMain } from 'electron';
-import { eq, desc } from 'drizzle-orm';
+import { and, eq, desc } from 'drizzle-orm';
 import { getDb, isDbReady } from '../db/index.js';
 import { tasks, messages, artifacts, taskRooms, taskRoomSessions, teams, teamAgents } from '../db/schema.js';
 import { autoExtractArtifacts } from '../artifact/auto-extract.js';
+import type { MessageAttachment } from '@clawwork/shared';
 import { getWorkspacePath } from '../workspace/config.js';
 
 function ipcError(err: unknown): { ok: false; error: string } {
@@ -171,12 +172,29 @@ export function registerDataHandlers(): void {
             },
           })
           .run();
-        if (msg.role === 'assistant' && msg.content.length > 0) {
+        const persisted = db
+          .select({ id: messages.id })
+          .from(messages)
+          .where(
+            and(
+              eq(messages.taskId, msg.taskId),
+              eq(messages.sessionKey, resolvedSessionKey),
+              eq(messages.role, msg.role),
+              eq(messages.timestamp, msg.timestamp),
+            ),
+          )
+          .get();
+        const persistedMessageId = persisted?.id ?? msg.id;
+        if (msg.role === 'assistant' && (msg.content.length > 0 || (msg.attachments?.length ?? 0) > 0)) {
           const workspacePath = getWorkspacePath();
           if (workspacePath) {
-            autoExtractArtifacts({ workspacePath, taskId: msg.taskId, messageId: msg.id, content: msg.content }).catch(
-              (err: unknown) => console.error('[auto-extract]', err),
-            );
+            autoExtractArtifacts({
+              workspacePath,
+              taskId: msg.taskId,
+              messageId: persistedMessageId,
+              content: msg.content,
+              attachments: msg.attachments as MessageAttachment[] | undefined,
+            }).catch((err: unknown) => console.error('[auto-extract]', err));
           }
         }
         return { ok: true };

--- a/packages/desktop/src/main/ipc/media-handlers.ts
+++ b/packages/desktop/src/main/ipc/media-handlers.ts
@@ -1,0 +1,14 @@
+import { ipcMain } from 'electron';
+import { readOpenClawMediaFile } from '../media/resolve.js';
+
+export function registerMediaHandlers(): void {
+  ipcMain.handle('media:read-file', async (_event, params: { sourcePath: string }) => {
+    try {
+      const content = await readOpenClawMediaFile(params.sourcePath);
+      if (!content) return { ok: false, error: 'invalid path' };
+      return { ok: true, result: { content, encoding: 'base64' as const } };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };
+    }
+  });
+}

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron';
 import { getGatewayClient, getAllGatewayClients, reconnectGateway } from '../ws/index.js';
 import { readConfig, ensureDeviceId } from '../workspace/config.js';
 import { isClawWorkSession, parseTaskIdFromSessionKey, parseAgentIdFromSessionKey } from '@clawwork/shared';
-import { parseToolArgs } from '@clawwork/core';
+import { normalizeContentBlocks, parseToolArgs } from '@clawwork/core';
 import type {
   ApprovalDecision,
   ChatAttachment,
@@ -71,9 +71,13 @@ interface ChatHistoryMessage {
     type: string;
     text?: string;
     thinking?: string;
+    url?: string;
+    openUrl?: string;
+    alt?: string;
+    mimeType?: string;
     id?: string;
     name?: string;
-    arguments?: unknown;
+    arguments?: Record<string, unknown> | string;
     result?: unknown;
   }[];
   timestamp?: number;
@@ -267,7 +271,13 @@ export function registerWsHandlers(): void {
       inputTokens?: number;
       outputTokens?: number;
       contextTokens?: number;
-      messages: { role: string; content: string; timestamp: string; toolCalls: ParsedToolCall[] }[];
+      messages: {
+        role: string;
+        content: string;
+        timestamp: string;
+        attachments?: unknown[];
+        toolCalls: ParsedToolCall[];
+      }[];
     }[] = [];
 
     for (const [gatewayId, gw] of clients) {
@@ -299,10 +309,15 @@ export function registerWsHandlers(): void {
           const msgs = rawMsgs
             .filter((m) => m.role === 'user' || m.role === 'assistant')
             .map((m) => {
-              const textContent = (m.content ?? [])
-                .filter((b) => b.type === 'text' && b.text)
-                .map((b) => b.text!)
-                .join('');
+              const normalizedContent =
+                m.role === 'assistant'
+                  ? normalizeContentBlocks(m.content ?? [])
+                  : {
+                      content: (m.content ?? [])
+                        .filter((b) => b.type === 'text' && b.text)
+                        .map((b) => b.text!)
+                        .join(''),
+                    };
 
               const toolCalls: ParsedToolCall[] = (m.content ?? [])
                 .filter((b) => b.type === 'toolCall' && b.id && b.name)
@@ -332,13 +347,14 @@ export function registerWsHandlers(): void {
 
               return {
                 role: m.role,
-                content: textContent,
+                content: normalizedContent.content,
+                attachments: normalizedContent.attachments,
                 timestamp: m.timestamp ? new Date(m.timestamp).toISOString() : new Date().toISOString(),
                 toolCalls,
               };
             })
             .filter((m) => {
-              if (!m.content && m.toolCalls.length === 0) return false;
+              if (!m.content && m.toolCalls.length === 0 && !m.attachments?.length) return false;
               if (m.role === 'assistant' && INTERNAL_ASSISTANT_MARKERS.has(m.content.trim())) return false;
               return true;
             });

--- a/packages/desktop/src/main/media/resolve.ts
+++ b/packages/desktop/src/main/media/resolve.ts
@@ -1,0 +1,73 @@
+import type { Stats } from 'fs';
+import { realpathSync } from 'fs';
+import { open, realpath, stat } from 'fs/promises';
+import { homedir } from 'os';
+import { isAbsolute, join, resolve, sep } from 'path';
+
+const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|avif)$/i;
+
+function isWithin(parent: string, child: string): boolean {
+  return child === parent || child.startsWith(`${parent}${sep}`);
+}
+
+function mediaRoots(): string[] {
+  const stateDir = process.env.OPENCLAW_STATE_DIR
+    ? resolve(process.env.OPENCLAW_STATE_DIR)
+    : join(homedir(), '.openclaw');
+  return [resolve(stateDir, 'media')];
+}
+
+function isSameFile(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function isLexicallyAllowedMediaPath(sourcePath: string): boolean {
+  if (!sourcePath || sourcePath.includes('\0') || !isAbsolute(sourcePath)) return false;
+  const requested = resolve(sourcePath);
+  if (!IMAGE_EXT_RE.test(requested)) return false;
+  return mediaRoots().some((root) => isWithin(root, requested));
+}
+
+async function resolveAllowedMediaPath(sourcePath: string, fd: number, openedStat: Stats): Promise<string | null> {
+  const requested = resolve(sourcePath);
+  const roots = await Promise.all(
+    mediaRoots().map((root) =>
+      realpath(root).catch(() => {
+        return null;
+      }),
+    ),
+  );
+  const fdTarget =
+    process.platform === 'win32'
+      ? null
+      : (() => {
+          try {
+            const target = realpathSync(`/dev/fd/${fd}`);
+            return target.startsWith('/dev/fd/') ? null : target;
+          } catch {
+            return null;
+          }
+        })();
+  const realTarget = fdTarget ?? (await realpath(requested).catch(() => null));
+  if (!realTarget) return null;
+  if (!roots.some((root) => root !== null && isWithin(root, realTarget))) return null;
+  const targetStat = await stat(realTarget).catch(() => null);
+  if (!targetStat || !isSameFile(openedStat, targetStat)) return null;
+  return realTarget;
+}
+
+export async function readOpenClawMediaFile(sourcePath: string): Promise<string | null> {
+  if (!isLexicallyAllowedMediaPath(sourcePath)) return null;
+  const handle = await open(sourcePath, 'r').catch(() => null);
+  if (!handle) return null;
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size > MAX_MEDIA_BYTES) return null;
+    const realTarget = await resolveAllowedMediaPath(sourcePath, handle.fd, stat);
+    if (!realTarget) return null;
+    return await handle.readFile({ encoding: 'base64' });
+  } finally {
+    await handle.close();
+  }
+}

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -334,6 +334,7 @@ export interface ClawWorkAPI {
   readInboxFile: (localPath: string) => Promise<IpcResult<{ content: string; encoding: 'base64' }>>;
   openInboxFile: (localPath: string) => Promise<IpcResult>;
   showInboxInFolder: (localPath: string) => Promise<IpcResult>;
+  readMediaFile: (sourcePath: string) => Promise<IpcResult<{ content: string; encoding: 'base64' }>>;
   exportSessionMarkdown: (taskId: string) => Promise<IpcResult>;
   exportSessionMarkdownAs: (taskId: string) => Promise<IpcResult>;
 

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -149,6 +149,7 @@ function buildApi(): ClawWorkAPI {
     readInboxFile: (localPath: string) => ipcRenderer.invoke('inbox:read-file', { localPath }),
     openInboxFile: (localPath: string) => ipcRenderer.invoke('inbox:open', { localPath }),
     showInboxInFolder: (localPath: string) => ipcRenderer.invoke('inbox:show-in-folder', { localPath }),
+    readMediaFile: (sourcePath: string) => ipcRenderer.invoke('media:read-file', { sourcePath }),
     exportSessionMarkdown: (taskId: string) => ipcRenderer.invoke('session:export-markdown', { taskId }),
     exportSessionMarkdownAs: (taskId: string) => ipcRenderer.invoke('session:export-markdown-as', { taskId }),
 

--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -136,12 +136,24 @@ function InlineImageBubble({
   single,
   onOpen,
 }: {
-  attachment: { fileName: string; dataUrl: string; mimeType?: string; localPath?: string };
+  attachment: { fileName: string; dataUrl: string; mimeType?: string; localPath?: string; sourcePath?: string };
   single: boolean;
   onOpen?: (src: string) => void;
 }) {
   const [src, setSrc] = useState(attachment.dataUrl);
   useEffect(() => {
+    if (attachment.sourcePath) {
+      let aborted = false;
+      window.clawwork.readMediaFile(attachment.sourcePath).then((res) => {
+        if (aborted) return;
+        if (res.ok && res.result) {
+          setSrc(`data:${attachment.mimeType ?? 'image/png'};base64,${res.result.content}`);
+        }
+      });
+      return () => {
+        aborted = true;
+      };
+    }
     if (!attachment.localPath) return;
     if (attachment.dataUrl.startsWith('data:')) return;
     let aborted = false;
@@ -154,7 +166,7 @@ function InlineImageBubble({
     return () => {
       aborted = true;
     };
-  }, [attachment.localPath, attachment.mimeType, attachment.dataUrl]);
+  }, [attachment.localPath, attachment.sourcePath, attachment.mimeType, attachment.dataUrl]);
   return (
     <img
       src={src}
@@ -208,7 +220,16 @@ const ChatMessage = memo(function ChatMessage({
     return () => window.clearTimeout(timer);
   }, [saveState]);
 
-  if (!isUser && !isSystem && !message.content && message.toolCalls.length === 0 && !message.thinkingContent) {
+  const attachments = message.attachments;
+
+  if (
+    !isUser &&
+    !isSystem &&
+    !message.content &&
+    !attachments?.length &&
+    message.toolCalls.length === 0 &&
+    !message.thinkingContent
+  ) {
     return null;
   }
 
@@ -222,7 +243,6 @@ const ChatMessage = memo(function ChatMessage({
     );
   }
 
-  const attachments = message.attachments;
   const canSaveMessage = Boolean(message.content.trim()) && Boolean(message.taskId) && Boolean(message.id);
 
   const handleCopy = (): void => {
@@ -306,8 +326,8 @@ const ChatMessage = memo(function ChatMessage({
             />
           </div>
         ) : null}
-        {isUser && attachments?.length ? (
-          <div className={cn('flex gap-2 mt-2 flex-wrap', 'justify-end')}>
+        {attachments?.length ? (
+          <div className={cn('flex gap-2 mt-2 flex-wrap', isUser ? 'justify-end' : 'justify-start')}>
             {attachments.map((attachment, i) => {
               const isImage = !attachment.mimeType || attachment.mimeType.startsWith('image/');
               return isImage ? (

--- a/packages/desktop/test/artifact-handlers.test.ts
+++ b/packages/desktop/test/artifact-handlers.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+const allMock = vi.fn();
+const whereMock = vi.fn(() => ({ all: allMock }));
+const fromMock = vi.fn(() => ({ where: whereMock, all: allMock }));
+const selectMock = vi.fn(() => ({ from: fromMock }));
+const getDbMock = vi.fn(() => ({ select: selectMock }));
+const autoExtractArtifactsMock = vi.fn();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handleMap.set(channel, handler);
+    }),
+  },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  dialog: {},
+  shell: { openPath: vi.fn(), showItemInFolder: vi.fn() },
+}));
+
+vi.mock('../src/main/db/index.js', () => ({
+  getDb: getDbMock,
+  getSqlite: vi.fn(() => null),
+}));
+
+vi.mock('../src/main/workspace/config.js', () => ({
+  getWorkspacePath: vi.fn(() => null),
+}));
+
+vi.mock('../src/main/artifact/save.js', () => ({
+  saveArtifact: vi.fn(),
+  saveArtifactFromBuffer: vi.fn(),
+}));
+
+vi.mock('../src/main/artifact/auto-extract.js', () => ({
+  autoExtractArtifacts: autoExtractArtifactsMock,
+}));
+
+vi.mock('../src/main/net/safe-fetch.js', () => ({
+  safeFetch: vi.fn(),
+}));
+
+describe('artifact handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handleMap.clear();
+  });
+
+  it('lists artifacts without triggering auto-extract side effects', async () => {
+    const { registerArtifactHandlers } = await import('../src/main/ipc/artifact-handlers.js');
+    registerArtifactHandlers();
+
+    allMock.mockReturnValue([
+      {
+        id: 'a1',
+        taskId: 'task-1',
+        messageId: 'msg-1',
+        type: 'image',
+        name: 'image-1---abc-11111111.png',
+        localPath: 'task-1/image-1---abc-11111111.png',
+        mimeType: 'image/png',
+        size: 10,
+        createdAt: '2026-03-16T00:00:00.000Z',
+      },
+      {
+        id: 'a2',
+        taskId: 'task-1',
+        messageId: 'msg-1',
+        type: 'image',
+        name: 'image-1---abc-22222222.png',
+        localPath: 'task-1/image-1---abc-22222222.png',
+        mimeType: 'image/png',
+        size: 10,
+        createdAt: '2026-03-16T00:00:01.000Z',
+      },
+    ]);
+
+    const listArtifacts = handleMap.get('artifact:list');
+    expect(listArtifacts).toBeTypeOf('function');
+
+    await expect(listArtifacts?.({}, { taskId: 'task-1' })).resolves.toEqual({
+      ok: true,
+      result: [expect.objectContaining({ id: 'a1' }), expect.objectContaining({ id: 'a2' })],
+    });
+    expect(autoExtractArtifactsMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/test/auto-extract.test.ts
+++ b/packages/desktop/test/auto-extract.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'crypto';
+
+const webContentsSendMock = vi.fn();
+const dbAllMock = vi.fn();
+const whereMock = vi.fn(() => ({ all: dbAllMock }));
+const fromMock = vi.fn(() => ({ where: whereMock }));
+const selectMock = vi.fn(() => ({ from: fromMock }));
+const getDbMock = vi.fn(() => ({ select: selectMock }));
+const saveArtifactFromBufferMock = vi.fn();
+const readOpenClawMediaFileMock = vi.fn();
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [{ webContents: { send: webContentsSendMock } }]),
+  },
+}));
+
+vi.mock('../src/main/db/index.js', () => ({
+  getDb: getDbMock,
+}));
+
+vi.mock('../src/main/artifact/save.js', () => ({
+  saveArtifactFromBuffer: saveArtifactFromBufferMock,
+}));
+
+vi.mock('../src/main/media/resolve.js', () => ({
+  readOpenClawMediaFile: readOpenClawMediaFileMock,
+}));
+
+describe('autoExtractArtifacts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbAllMock.mockReturnValue([]);
+    saveArtifactFromBufferMock.mockResolvedValue({
+      id: 'artifact-1',
+      taskId: 'task-1',
+      messageId: 'msg-1',
+      type: 'image',
+      name: 'result.png',
+      localPath: 'task-1/result.png',
+      mimeType: 'image/png',
+      size: 5,
+      createdAt: '2026-03-16T00:00:00.000Z',
+    });
+    readOpenClawMediaFileMock.mockResolvedValue(Buffer.from('image').toString('base64'));
+  });
+
+  it('saves assistant image attachments as image artifacts', async () => {
+    const { autoExtractArtifacts } = await import('../src/main/artifact/auto-extract.js');
+
+    await autoExtractArtifacts({
+      workspacePath: '/workspace',
+      taskId: 'task-1',
+      messageId: 'msg-1',
+      content: '',
+      attachments: [
+        {
+          fileName: 'result.png',
+          dataUrl: 'file:///Users/x/.openclaw/media/result.png',
+          mimeType: 'image/png',
+          sourcePath: '/Users/x/.openclaw/media/result.png',
+        },
+      ],
+    });
+
+    expect(readOpenClawMediaFileMock).toHaveBeenCalledWith('/Users/x/.openclaw/media/result.png');
+    expect(saveArtifactFromBufferMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspacePath: '/workspace',
+        taskId: 'task-1',
+        messageId: 'msg-1',
+        fileName: 'result.png',
+        buffer: Buffer.from('image'),
+        artifactType: 'image',
+        sourceKey: expect.stringMatching(/^attachment:/),
+      }),
+    );
+    expect(webContentsSendMock).toHaveBeenCalledWith('artifact:saved', expect.objectContaining({ id: 'artifact-1' }));
+  });
+
+  it('does not save duplicate attachment artifacts with the same source key', async () => {
+    const { autoExtractArtifacts } = await import('../src/main/artifact/auto-extract.js');
+
+    const sourcePath = '/Users/x/.openclaw/media/result.png';
+    const key = `attachment:${createHash('sha256').update(sourcePath).digest('hex').slice(0, 16)}`;
+    dbAllMock.mockReturnValue([{ name: 'result-a1b2c3d4.png', type: 'image', size: 5, sourceKey: key }]);
+
+    await autoExtractArtifacts({
+      workspacePath: '/workspace',
+      taskId: 'task-1',
+      messageId: 'msg-1',
+      content: '',
+      attachments: [
+        {
+          fileName: 'result.png',
+          dataUrl: 'file:///Users/x/.openclaw/media/result.png',
+          mimeType: 'image/png',
+          sourcePath,
+        },
+      ],
+    });
+
+    expect(saveArtifactFromBufferMock).not.toHaveBeenCalled();
+    expect(webContentsSendMock).not.toHaveBeenCalled();
+  });
+
+  it('does not re-save legacy attachment artifacts that predate source keys', async () => {
+    const { autoExtractArtifacts } = await import('../src/main/artifact/auto-extract.js');
+
+    dbAllMock.mockReturnValue([{ name: 'result-a1b2c3d4.png', type: 'image', size: 5, sourceKey: '' }]);
+
+    await autoExtractArtifacts({
+      workspacePath: '/workspace',
+      taskId: 'task-1',
+      messageId: 'msg-1',
+      content: '',
+      attachments: [
+        {
+          fileName: 'result.png',
+          dataUrl: 'file:///Users/x/.openclaw/media/result.png',
+          mimeType: 'image/png',
+          sourcePath: '/Users/x/.openclaw/media/result.png',
+        },
+      ],
+    });
+
+    expect(saveArtifactFromBufferMock).not.toHaveBeenCalled();
+    expect(webContentsSendMock).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent extraction for the same message', async () => {
+    const { autoExtractArtifacts } = await import('../src/main/artifact/auto-extract.js');
+
+    let resolveRead: (value: string) => void = () => {};
+    readOpenClawMediaFileMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveRead = resolve;
+      }),
+    );
+
+    const params = {
+      workspacePath: '/workspace',
+      taskId: 'task-1',
+      messageId: 'msg-1',
+      content: '',
+      attachments: [
+        {
+          fileName: 'result.png',
+          dataUrl: 'file:///Users/x/.openclaw/media/result.png',
+          mimeType: 'image/png',
+          sourcePath: '/Users/x/.openclaw/media/result.png',
+        },
+      ],
+    };
+
+    const first = autoExtractArtifacts(params);
+    const second = autoExtractArtifacts(params);
+    expect(readOpenClawMediaFileMock).toHaveBeenCalledTimes(1);
+
+    resolveRead(Buffer.from('image').toString('base64'));
+    await Promise.all([first, second]);
+
+    expect(saveArtifactFromBufferMock).toHaveBeenCalledTimes(1);
+    expect(webContentsSendMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/test/core-session-sync.test.ts
+++ b/packages/desktop/test/core-session-sync.test.ts
@@ -6,7 +6,7 @@ function createHarness(params: {
   tasks: Array<{ id: string; gatewayId: string; sessionKey: string }>;
   loadMessagesRows: Record<
     string,
-    Array<{ id: string; taskId: string; role: string; content: string; timestamp: string }>
+    Array<{ id: string; taskId: string; role: string; content: string; timestamp: string; attachments?: unknown[] }>
   >;
   discovered: Array<{
     gatewayId: string;
@@ -21,7 +21,13 @@ function createHarness(params: {
     inputTokens?: number;
     outputTokens?: number;
     contextTokens?: number;
-    messages: { role: string; content: string; timestamp: string; toolCalls?: Message['toolCalls'] }[];
+    messages: {
+      role: string;
+      content: string;
+      timestamp: string;
+      attachments?: Message['attachments'];
+      toolCalls?: Message['toolCalls'];
+    }[];
   }>;
 }) {
   const persisted: Array<{
@@ -211,5 +217,109 @@ describe('core session sync startup flow', () => {
         toolCalls: [expect.objectContaining({ id: 'exec-1', name: 'exec', status: 'done', result: 'ok' })],
       }),
     );
+  });
+
+  it('normalizes persisted assistant MEDIA directives during local hydration', async () => {
+    const harness = createHarness({
+      tasks: [
+        {
+          id: 'task-media',
+          gatewayId: 'gw-1',
+          sessionKey: 'agent:main:clawwork:task:task-media',
+        },
+      ],
+      loadMessagesRows: {
+        'task-media': [
+          {
+            id: 'a1',
+            taskId: 'task-media',
+            role: 'assistant',
+            content: 'MEDIA:/Users/x/.openclaw/media/generated.png\n\nImage ready',
+            timestamp: '2026-03-16T10:00:01.000Z',
+          },
+        ],
+      },
+      discovered: [],
+    });
+
+    await harness.sessionSync.hydrateFromLocal();
+
+    expect(harness.messageStore.messagesByTask['task-media']).toEqual([
+      expect.objectContaining({
+        id: 'a1',
+        content: 'Image ready',
+        attachments: [
+          {
+            fileName: 'generated.png',
+            dataUrl: 'file:///Users/x/.openclaw/media/generated.png',
+            mimeType: 'image/png',
+            sourcePath: '/Users/x/.openclaw/media/generated.png',
+          },
+        ],
+      }),
+    ]);
+    expect(harness.persisted).toEqual([]);
+  });
+
+  it('backfills attachments for existing assistant messages with the same timestamp', async () => {
+    const attachment = {
+      fileName: 'generated.png',
+      dataUrl: 'file:///Users/x/.openclaw/media/generated.png',
+      mimeType: 'image/png',
+      sourcePath: '/Users/x/.openclaw/media/generated.png',
+    };
+    const harness = createHarness({
+      tasks: [
+        {
+          id: 'task-media',
+          gatewayId: 'gw-1',
+          sessionKey: 'agent:main:clawwork:task:task-media',
+        },
+      ],
+      loadMessagesRows: {
+        'task-media': [
+          {
+            id: 'a1',
+            taskId: 'task-media',
+            role: 'assistant',
+            content: 'Image ready',
+            timestamp: '2026-03-16T10:00:01.000Z',
+          },
+        ],
+      },
+      discovered: [
+        {
+          gatewayId: 'gw-1',
+          taskId: 'task-media',
+          sessionKey: 'agent:main:clawwork:task:task-media',
+          title: 'Media task',
+          updatedAt: '2026-03-16T10:00:01.000Z',
+          agentId: 'main',
+          messages: [
+            {
+              role: 'assistant',
+              content: 'Image ready',
+              timestamp: '2026-03-16T10:00:01.000Z',
+              attachments: [attachment],
+            },
+          ],
+        },
+      ],
+    });
+
+    await harness.sessionSync.syncFromGateway();
+
+    expect(harness.messageStore.messagesByTask['task-media']).toEqual([
+      expect.objectContaining({
+        id: 'a1',
+        attachments: [attachment],
+      }),
+    ]);
+    expect(harness.persisted).toEqual([
+      expect.objectContaining({
+        id: 'a1',
+        attachments: [attachment],
+      }),
+    ]);
   });
 });

--- a/packages/desktop/test/data-handlers.test.ts
+++ b/packages/desktop/test/data-handlers.test.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handleMap = new Map<string, (...args: unknown[]) => unknown>();
-const getWorkspacePathMock = vi.fn(() => null);
+const getWorkspacePathMock = vi.fn<() => string | null>(() => null);
 const autoExtractArtifactsMock = vi.fn();
 const runMock = vi.fn();
 const conflictRunMock = vi.fn();
 const onConflictDoUpdateMock = vi.fn(() => ({ run: conflictRunMock }));
 const valuesMock = vi.fn(() => ({ onConflictDoUpdate: onConflictDoUpdateMock, run: runMock }));
 const insertMock = vi.fn(() => ({ values: valuesMock }));
-const selectGetMock = vi.fn(() => ({ sk: 'agent:main:clawwork:task:task-1' }));
+const selectGetMock = vi.fn<() => { sk?: string; id?: string }>(() => ({ sk: 'agent:main:clawwork:task:task-1' }));
 const selectWhereMock = vi.fn(() => ({ get: selectGetMock }));
 const selectFromMock = vi.fn(() => ({ where: selectWhereMock }));
 const selectMock = vi.fn(() => ({ from: selectFromMock }));
@@ -43,6 +43,8 @@ describe('registerDataHandlers', () => {
     autoExtractArtifactsMock.mockReset();
     runMock.mockReset();
     conflictRunMock.mockReset();
+    selectGetMock.mockReset();
+    selectGetMock.mockReturnValue({ sk: 'agent:main:clawwork:task:task-1' });
     onConflictDoUpdateMock.mockClear();
     valuesMock.mockClear();
     insertMock.mockClear();
@@ -112,5 +114,81 @@ describe('registerDataHandlers', () => {
         }),
       }),
     );
+  });
+
+  it('auto-extracts assistant image attachments even when content is empty', async () => {
+    const { registerDataHandlers } = await import('../src/main/ipc/data-handlers.js');
+
+    getWorkspacePathMock.mockReturnValue('/workspace');
+    autoExtractArtifactsMock.mockResolvedValue(undefined);
+    registerDataHandlers();
+
+    const createMessage = handleMap.get('data:create-message');
+    expect(createMessage).toBeTypeOf('function');
+
+    const attachments = [
+      {
+        fileName: 'result.png',
+        dataUrl: 'file:///Users/x/.openclaw/media/result.png',
+        mimeType: 'image/png',
+        sourcePath: '/Users/x/.openclaw/media/result.png',
+      },
+    ];
+
+    expect(
+      createMessage?.(
+        {},
+        {
+          id: 'msg-image-1',
+          taskId: 'task-1',
+          role: 'assistant',
+          content: '',
+          timestamp: '2026-03-16T00:00:01.000Z',
+          attachments,
+        },
+      ),
+    ).toEqual({ ok: true });
+
+    expect(autoExtractArtifactsMock).toHaveBeenCalledWith({
+      workspacePath: '/workspace',
+      taskId: 'task-1',
+      messageId: 'msg-image-1',
+      content: '',
+      attachments,
+    });
+  });
+
+  it('auto-extracts using the persisted message id after logical upsert', async () => {
+    const { registerDataHandlers } = await import('../src/main/ipc/data-handlers.js');
+
+    getWorkspacePathMock.mockReturnValue('/workspace');
+    autoExtractArtifactsMock.mockResolvedValue(undefined);
+    selectGetMock.mockReturnValueOnce({ id: 'existing-msg-1' });
+    registerDataHandlers();
+
+    const createMessage = handleMap.get('data:create-message');
+    expect(createMessage).toBeTypeOf('function');
+
+    expect(
+      createMessage?.(
+        {},
+        {
+          id: 'incoming-msg-2',
+          taskId: 'task-1',
+          role: 'assistant',
+          content: 'done',
+          timestamp: '2026-03-16T00:00:01.000Z',
+          sessionKey: 'agent:main:clawwork:task:task-1',
+        },
+      ),
+    ).toEqual({ ok: true });
+
+    expect(autoExtractArtifactsMock).toHaveBeenCalledWith({
+      workspacePath: '/workspace',
+      taskId: 'task-1',
+      messageId: 'existing-msg-1',
+      content: 'done',
+      attachments: undefined,
+    });
   });
 });

--- a/packages/desktop/test/db.test.ts
+++ b/packages/desktop/test/db.test.ts
@@ -27,6 +27,19 @@ describe('initDatabase', () => {
     expect(Database).toHaveBeenCalled();
   });
 
+  it('does not purge media-only assistant messages during startup cleanup', () => {
+    initDatabase('/tmp/workspace-a');
+
+    const cleanupSql = mockDbInstance.exec.mock.calls
+      .map(([sql]) => String(sql))
+      .find((sql) => sql.includes('DELETE FROM messages'));
+
+    expect(cleanupSql).toContain("COALESCE(image_attachments, '') = ''");
+    expect(cleanupSql).toContain("COALESCE(tool_calls, '') = ''");
+    expect(cleanupSql).toContain('NOT EXISTS');
+    expect(cleanupSql).toContain('artifacts.message_id = messages.id');
+  });
+
   it('returns early when called with same path', () => {
     initDatabase('/tmp/workspace-a');
     vi.clearAllMocks();

--- a/packages/desktop/test/media-resolve.test.ts
+++ b/packages/desktop/test/media-resolve.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('fs', () => ({
+  realpathSync: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  open: vi.fn(),
+  realpath: vi.fn(),
+  stat: vi.fn(),
+}));
+
+import { realpathSync } from 'fs';
+import { open, realpath, stat } from 'fs/promises';
+import { readOpenClawMediaFile } from '../src/main/media/resolve.js';
+
+const mockOpen = vi.mocked(open);
+const mockRealpath = vi.mocked(realpath);
+const mockStat = vi.mocked(stat);
+const mockRealpathSync = vi.mocked(realpathSync);
+const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+
+describe('OpenClaw media file access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENCLAW_STATE_DIR = '/state';
+  });
+
+  afterEach(() => {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+  });
+
+  it('reads opened image fds inside the OpenClaw media root', async () => {
+    const readFile = vi.fn().mockResolvedValue('aW1hZ2U=');
+    const close = vi.fn().mockResolvedValue(undefined);
+    const openedStat = { dev: 1, ino: 2, isFile: () => true, size: 1024 };
+    mockOpen.mockResolvedValue({
+      fd: 42,
+      stat: vi.fn().mockResolvedValue(openedStat),
+      readFile,
+      close,
+    } as unknown as Awaited<ReturnType<typeof open>>);
+    mockRealpath.mockImplementation(async (path) => {
+      if (path === '/state/media') return '/state/media';
+      throw new Error(`unexpected path ${path}`);
+    });
+    mockRealpathSync.mockReturnValue('/state/media/tool-image-generation/out.png');
+    mockStat.mockResolvedValue(openedStat as Awaited<ReturnType<typeof stat>>);
+
+    await expect(readOpenClawMediaFile('/state/media/tool-image-generation/out.png')).resolves.toBe('aW1hZ2U=');
+    expect(readFile).toHaveBeenCalledWith({ encoding: 'base64' });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects opened fds outside the OpenClaw media root', async () => {
+    const readFile = vi.fn().mockResolvedValue('c2VjcmV0');
+    const close = vi.fn().mockResolvedValue(undefined);
+    const openedStat = { dev: 1, ino: 2, isFile: () => true, size: 1024 };
+    mockOpen.mockResolvedValue({
+      fd: 42,
+      stat: vi.fn().mockResolvedValue(openedStat),
+      readFile,
+      close,
+    } as unknown as Awaited<ReturnType<typeof open>>);
+    mockRealpath.mockImplementation(async (path) => {
+      if (path === '/state/media') return '/state/media';
+      throw new Error(`unexpected path ${path}`);
+    });
+    mockRealpathSync.mockReturnValue('/private/etc/passwd');
+    mockStat.mockResolvedValue(openedStat as Awaited<ReturnType<typeof stat>>);
+
+    await expect(readOpenClawMediaFile('/state/media/tool-image-generation/out.png')).resolves.toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects non-image extensions before reading', async () => {
+    const readFile = vi.fn().mockResolvedValue('c2VjcmV0');
+    const close = vi.fn().mockResolvedValue(undefined);
+    mockOpen.mockResolvedValue({
+      fd: 42,
+      stat: vi.fn().mockResolvedValue({ isFile: () => true, size: 1024 }),
+      readFile,
+      close,
+    } as unknown as Awaited<ReturnType<typeof open>>);
+    mockRealpath.mockResolvedValue('/state/media');
+    mockRealpathSync.mockReturnValue('/state/media/secret.txt');
+
+    await expect(readOpenClawMediaFile('/state/media/secret.txt')).resolves.toBeNull();
+    expect(mockOpen).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('rejects paths outside the media root before opening them', async () => {
+    await expect(readOpenClawMediaFile('/private/tmp/out.png')).resolves.toBeNull();
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the requested real path when macOS keeps dev fd aliases unresolved', async () => {
+    const readFile = vi.fn().mockResolvedValue('aW1hZ2U=');
+    const close = vi.fn().mockResolvedValue(undefined);
+    const openedStat = { dev: 1, ino: 2, isFile: () => true, size: 1024 };
+    mockOpen.mockResolvedValue({
+      fd: 42,
+      stat: vi.fn().mockResolvedValue(openedStat),
+      readFile,
+      close,
+    } as unknown as Awaited<ReturnType<typeof open>>);
+    mockRealpath.mockImplementation(async (path) => {
+      if (path === '/state/media') return '/state/media';
+      if (path === '/state/media/tool-image-generation/out.png') return '/state/media/tool-image-generation/out.png';
+      throw new Error(`unexpected path ${path}`);
+    });
+    mockRealpathSync.mockReturnValue('/dev/fd/42');
+    mockStat.mockResolvedValue(openedStat as Awaited<ReturnType<typeof stat>>);
+
+    await expect(readOpenClawMediaFile('/state/media/tool-image-generation/out.png')).resolves.toBe('aW1hZ2U=');
+    expect(readFile).toHaveBeenCalledWith({ encoding: 'base64' });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects paths that change between open and realpath fallback', async () => {
+    const readFile = vi.fn().mockResolvedValue('c2VjcmV0');
+    const close = vi.fn().mockResolvedValue(undefined);
+    const openedStat = { dev: 1, ino: 2, isFile: () => true, size: 1024 };
+    mockOpen.mockResolvedValue({
+      fd: 42,
+      stat: vi.fn().mockResolvedValue(openedStat),
+      readFile,
+      close,
+    } as unknown as Awaited<ReturnType<typeof open>>);
+    mockRealpath.mockImplementation(async (path) => {
+      if (path === '/state/media') return '/state/media';
+      if (path === '/state/media/tool-image-generation/out.png') return '/state/media/tool-image-generation/out.png';
+      throw new Error(`unexpected path ${path}`);
+    });
+    mockRealpathSync.mockReturnValue('/dev/fd/42');
+    mockStat.mockResolvedValue({ dev: 1, ino: 3, isFile: () => true, size: 1024 } as Awaited<ReturnType<typeof stat>>);
+
+    await expect(readOpenClawMediaFile('/state/media/tool-image-generation/out.png')).resolves.toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -163,6 +163,7 @@ export interface MessageAttachment {
   dataUrl: string;
   mimeType?: string;
   localPath?: string;
+  sourcePath?: string;
   size?: number;
 }
 
@@ -191,6 +192,7 @@ export interface Artifact {
   localPath: string;
   mimeType: string;
   size: number;
+  sourceKey?: string;
   contentText?: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary

Persist and render assistant-generated media attachments from Gateway history, then extract those images into local artifacts without duplicating messages or files. This fixes media-only assistant turns disappearing after restart and prevents startup cleanup from deleting attachment-backed assistant messages.

Oversize note: this exceeds the usual insertion budget because the fix crosses the shared/core/main/preload/renderer media path and includes focused regression coverage for each boundary.

## Type of change

- [ ] \`[Feat]\` new feature
- [x] \`[Fix]\` bug fix
- [x] \`[UI]\` UI or UX change
- [ ] \`[Docs]\` documentation-only change
- [ ] \`[Refactor]\` internal cleanup
- [x] \`[Build]\` CI, packaging, or tooling change
- [ ] \`[Chore]\` maintenance

## Why is this needed?

Assistant image outputs can arrive as Gateway image blocks or MEDIA directives rather than Markdown content. Previously those media-only assistant turns could be dropped, rendered without durable access to the underlying OpenClaw media file, or purged during DB startup cleanup because the message content was empty.

## What changed?

- Normalize assistant history image blocks and MEDIA directives into \`MessageAttachment\` records.
- Persist assistant attachments through session sync and backfill attachments onto existing assistant messages with matching timestamps.
- Add a constrained main/preload media read path for OpenClaw media files, with path/root/size checks before renderer display.
- Auto-extract assistant image attachments into artifacts with source-key deduplication and concurrent extraction serialization.
- Preserve media-only assistant messages during startup cleanup when they have attachments, tool calls, or artifact references.
- Ignore local \`.agents/**\` skill files in knip so \`pnpm check\` stays focused on project source.

## Architecture impact

- Owning layer: shared / core / main / preload / renderer
- Cross-layer impact: yes. Shared types carry attachment source metadata; core normalizes and syncs attachments; main validates and reads OpenClaw media files; preload exposes the narrow bridge; renderer displays assistant attachments.
- Invariants touched from \`docs/architecture-invariants.md\`: renderer does not import Node or main modules; preload remains a typed bridge; artifact persistence remains main-process/local-first; message persistence keeps assistant DB writes in session sync.
- Why those invariants remain protected: file IO stays behind \`media:read-file\` in main, renderer only receives base64 content through preload, and assistant message writes still route through the existing persistence path rather than adding a renderer writer.

## Linked issues

Closes #

## Validation

- [x] \`pnpm lint\`
- [x] \`pnpm test\`
- [ ] \`pnpm build\`
- [x] \`pnpm check:ui-contract\`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

\`\`\`text
pnpm check
git diff HEAD~1..HEAD --check
/pre-ship --committed: no MUST-FIX findings, sentinel /tmp/.preship-ok-07c7ad45509488ce
\`\`\`

## Screenshots or recordings

No screenshot attached. The renderer change only displays assistant attachments using existing message attachment layout and existing design tokens/classes.

## Release note

- [ ] No user-facing change. Release note is \`NONE\`.
- [x] User-facing change. Release note is included below.

\`\`\`release-note
Assistant-generated images from Gateway history now persist, render, and appear as local artifacts after restart.
\`\`\`

## Checklist

- [x] All commits are signed off (\`git commit -s\`)
- [x] The PR title uses at least one approved prefix: \`[Feat]\`, \`[Fix]\`, \`[UI]\`, \`[Docs]\`, \`[Refactor]\`, \`[Build]\`, or \`[Chore]\`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate