### PR TITLE
[Feat] Add artifact preview thumbnails

### DIFF
--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,5 +1,6 @@
-import { ipcMain, BrowserWindow, dialog, shell } from 'electron';
+import { ipcMain, BrowserWindow, dialog, shell, nativeImage, type NativeImage } from 'electron';
 import { readFileSync, realpathSync, writeFileSync } from 'fs';
+import { readFile, stat } from 'fs/promises';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'node:url';
 import { resolve, sep } from 'path';
@@ -17,6 +18,15 @@ interface SaveParams {
   messageId: string;
   fileName?: string;
   mediaType?: string;
+}
+
+const MAX_THUMBNAIL_SOURCE_BYTES = 10 * 1024 * 1024;
+
+function resizeThumbnailImage(image: NativeImage, size: number): NativeImage {
+  const { width, height } = image.getSize();
+  const maxDimension = Math.max(width, height);
+  if (maxDimension <= size) return image;
+  return width >= height ? image.resize({ width: size }) : image.resize({ height: size });
 }
 
 export function registerArtifactHandlers(): void {
@@ -89,6 +99,37 @@ export function registerArtifactHandlers(): void {
       const encoding = isTextFile(params.localPath) ? 'utf-8' : 'base64';
       const content = readFileSync(fullPath, encoding);
       return { ok: true, result: { content, encoding } };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      return { ok: false, error: msg };
+    }
+  });
+
+  ipcMain.handle('artifact:thumbnail', async (_event, params: { localPath: string; size?: number }) => {
+    const workspacePath = getWorkspacePath();
+    if (!workspacePath) return { ok: false, error: 'workspace not configured' };
+    try {
+      const fullPath = resolveArtifactPath(workspacePath, params.localPath);
+      if (!fullPath) return { ok: false, error: 'invalid path' };
+      const size = Math.min(Math.max(params.size ?? 128, 32), 256);
+      const image =
+        process.platform === 'darwin' || process.platform === 'win32'
+          ? await nativeImage.createThumbnailFromPath(fullPath, { width: size, height: size })
+          : nativeImage.createEmpty();
+      if (image.isEmpty()) {
+        const fileStat = await stat(fullPath);
+        if (!fileStat.isFile() || fileStat.size > MAX_THUMBNAIL_SOURCE_BYTES) {
+          return { ok: false, error: 'thumbnail unavailable' };
+        }
+        const buffer = await readFile(fullPath);
+        const decoded = nativeImage.createFromBuffer(buffer);
+        if (!decoded.isEmpty()) {
+          const resized = resizeThumbnailImage(decoded, size);
+          return { ok: true, result: { dataUrl: resized.toDataURL() } };
+        }
+      }
+      if (image.isEmpty()) return { ok: false, error: 'thumbnail unavailable' };
+      return { ok: true, result: { dataUrl: image.toDataURL() } };
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'unknown error';
       return { ok: false, error: msg };

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -314,6 +314,7 @@ export interface ClawWorkAPI {
   listArtifacts: (taskId?: string) => Promise<IpcResult>;
   getArtifact: (id: string) => Promise<IpcResult>;
   readArtifactFile: (localPath: string) => Promise<IpcResult>;
+  readArtifactThumbnail: (localPath: string, size?: number) => Promise<IpcResult<{ dataUrl: string }>>;
   onArtifactSaved: (callback: (artifact: unknown) => void) => () => void;
   saveCodeBlock: (params: {
     taskId: string;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -130,6 +130,8 @@ function buildApi(): ClawWorkAPI {
     listArtifacts: (taskId?: string) => ipcRenderer.invoke('artifact:list', { taskId }),
     getArtifact: (id: string) => ipcRenderer.invoke('artifact:get', { id }),
     readArtifactFile: (localPath: string) => ipcRenderer.invoke('artifact:read-file', { localPath }),
+    readArtifactThumbnail: (localPath: string, size?: number) =>
+      ipcRenderer.invoke('artifact:thumbnail', { localPath, size }),
     onArtifactSaved: (callback: (artifact: unknown) => void) => {
       const listener = (_event: Electron.IpcRendererEvent, artifact: unknown): void => {
         callback(artifact);

--- a/packages/desktop/src/renderer/components/ArtifactThumbnail.tsx
+++ b/packages/desktop/src/renderer/components/ArtifactThumbnail.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { File, FileCode, FileText, Image } from 'lucide-react';
+import type { Artifact, ArtifactType } from '@clawwork/shared';
+import { cn } from '@/lib/utils';
+
+interface ArtifactThumbnailProps {
+  artifact: Artifact;
+  className?: string;
+  iconSize?: number;
+}
+
+function getTypeConfig(type: ArtifactType, name: string) {
+  if (type === 'image') return { Icon: Image, color: 'text-[var(--info)]', bg: 'bg-[var(--info)]/10' };
+  if (type === 'code') return { Icon: FileCode, color: 'text-[var(--accent)]', bg: 'bg-[var(--accent-dim)]' };
+  if (name.endsWith('.md') || name.endsWith('.txt'))
+    return { Icon: FileText, color: 'text-[var(--warning)]', bg: 'bg-[var(--warning)]/10' };
+  return { Icon: File, color: 'text-[var(--text-muted)]', bg: 'bg-[var(--bg-tertiary)]' };
+}
+
+function isImageArtifact(artifact: Artifact): boolean {
+  return artifact.type === 'image' || artifact.mimeType.startsWith('image/');
+}
+
+function readResult(value: unknown): { content: string; encoding: string } | null {
+  if (!value || typeof value !== 'object') return null;
+  const result = value as { content?: unknown; encoding?: unknown };
+  if (typeof result.content !== 'string' || typeof result.encoding !== 'string') return null;
+  return { content: result.content, encoding: result.encoding };
+}
+
+export default function ArtifactThumbnail({ artifact, className, iconSize = 18 }: ArtifactThumbnailProps) {
+  const { Icon, color, bg } = getTypeConfig(artifact.type, artifact.name);
+  const [src, setSrc] = useState<string | null>(null);
+  const image = isImageArtifact(artifact);
+
+  useEffect(() => {
+    if (!image) {
+      setSrc(null);
+      return;
+    }
+
+    let cancelled = false;
+    setSrc(null);
+
+    window.clawwork
+      .readArtifactFile(artifact.localPath)
+      .then((res) => {
+        if (cancelled || !res.ok) return;
+        const data = readResult(res.result);
+        if (!data || data.encoding !== 'base64') return;
+        setSrc(`data:${artifact.mimeType};base64,${data.content}`);
+      })
+      .catch(() => {
+        if (!cancelled) setSrc(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [artifact.localPath, artifact.mimeType, image]);
+
+  return (
+    <div className={cn('relative flex shrink-0 items-center justify-center overflow-hidden rounded-lg', bg, className)}>
+      {src ? (
+        <img src={src} alt="" loading="lazy" className="h-full w-full object-cover" onError={() => setSrc(null)} />
+      ) : (
+        <Icon size={iconSize} className={color} />
+      )}
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/components/ArtifactThumbnail.tsx
+++ b/packages/desktop/src/renderer/components/ArtifactThumbnail.tsx
@@ -21,11 +21,39 @@ function isImageArtifact(artifact: Artifact): boolean {
   return artifact.type === 'image' || artifact.mimeType.startsWith('image/');
 }
 
-function readResult(value: unknown): { content: string; encoding: string } | null {
+function thumbnailResult(value: unknown): { dataUrl: string } | null {
   if (!value || typeof value !== 'object') return null;
-  const result = value as { content?: unknown; encoding?: unknown };
-  if (typeof result.content !== 'string' || typeof result.encoding !== 'string') return null;
-  return { content: result.content, encoding: result.encoding };
+  const result = value as { dataUrl?: unknown };
+  if (typeof result.dataUrl !== 'string') return null;
+  return { dataUrl: result.dataUrl };
+}
+
+const thumbnailCache = new Map<string, string | null>();
+const thumbnailRequests = new Map<string, Promise<string | null>>();
+
+function loadThumbnail(localPath: string): Promise<string | null> {
+  if (thumbnailCache.has(localPath)) return Promise.resolve(thumbnailCache.get(localPath) ?? null);
+  const existing = thumbnailRequests.get(localPath);
+  if (existing) return existing;
+
+  const request = window.clawwork
+    .readArtifactThumbnail(localPath, 128)
+    .then((res) => {
+      const data = res.ok ? thumbnailResult(res.result) : null;
+      const src = data?.dataUrl ?? null;
+      thumbnailCache.set(localPath, src);
+      return src;
+    })
+    .catch(() => {
+      thumbnailCache.set(localPath, null);
+      return null;
+    })
+    .finally(() => {
+      thumbnailRequests.delete(localPath);
+    });
+
+  thumbnailRequests.set(localPath, request);
+  return request;
 }
 
 export default function ArtifactThumbnail({ artifact, className, iconSize = 18 }: ArtifactThumbnailProps) {
@@ -42,22 +70,14 @@ export default function ArtifactThumbnail({ artifact, className, iconSize = 18 }
     let cancelled = false;
     setSrc(null);
 
-    window.clawwork
-      .readArtifactFile(artifact.localPath)
-      .then((res) => {
-        if (cancelled || !res.ok) return;
-        const data = readResult(res.result);
-        if (!data || data.encoding !== 'base64') return;
-        setSrc(`data:${artifact.mimeType};base64,${data.content}`);
-      })
-      .catch(() => {
-        if (!cancelled) setSrc(null);
-      });
+    loadThumbnail(artifact.localPath).then((thumbnailSrc) => {
+      if (!cancelled) setSrc(thumbnailSrc);
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [artifact.localPath, artifact.mimeType, image]);
+  }, [artifact.localPath, image]);
 
   return (
     <div className={cn('relative flex shrink-0 items-center justify-center overflow-hidden rounded-lg', bg, className)}>

--- a/packages/desktop/src/renderer/components/FileCard.tsx
+++ b/packages/desktop/src/renderer/components/FileCard.tsx
@@ -1,10 +1,11 @@
 import { type MouseEvent } from 'react';
 import { motion } from 'framer-motion';
-import { FileText, FileCode, Image, File, MoreHorizontal } from 'lucide-react';
+import { MoreHorizontal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import type { Artifact, ArtifactType } from '@clawwork/shared';
+import type { Artifact } from '@clawwork/shared';
 import { cn, formatRelativeTime, formatFileSize } from '@/lib/utils';
 import { motion as motionPresets, motionDuration, motionEase } from '@/styles/design-tokens';
+import ArtifactThumbnail from './ArtifactThumbnail';
 
 interface FileCardProps {
   artifact: Artifact;
@@ -15,14 +16,6 @@ interface FileCardProps {
   onContextMenu: (e: MouseEvent) => void;
 }
 
-function getTypeConfig(type: ArtifactType, name: string) {
-  if (type === 'image') return { Icon: Image, color: 'text-[var(--info)]', bg: 'bg-[var(--info)]/10' };
-  if (type === 'code') return { Icon: FileCode, color: 'text-[var(--accent)]', bg: 'bg-[var(--accent-dim)]' };
-  if (name.endsWith('.md') || name.endsWith('.txt'))
-    return { Icon: FileText, color: 'text-[var(--warning)]', bg: 'bg-[var(--warning)]/10' };
-  return { Icon: File, color: 'text-[var(--text-muted)]', bg: 'bg-[var(--bg-tertiary)]' };
-}
-
 function extBadge(name: string): string {
   const dot = name.lastIndexOf('.');
   return dot !== -1 ? name.slice(dot + 1).toUpperCase() : '';
@@ -30,7 +23,6 @@ function extBadge(name: string): string {
 
 export default function FileCard({ artifact, taskTitle, selected, isNew, onClick, onContextMenu }: FileCardProps) {
   const { t } = useTranslation();
-  const { Icon, color, bg } = getTypeConfig(artifact.type, artifact.name);
   const ext = extBadge(artifact.name);
 
   return (
@@ -78,9 +70,7 @@ export default function FileCard({ artifact, taskTitle, selected, isNew, onClick
         </button>
         <div className="pointer-events-none relative p-3">
           <div className="flex items-start gap-2.5">
-            <div className={cn('flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center', bg)}>
-              <Icon size={18} className={color} />
-            </div>
+            <ArtifactThumbnail artifact={artifact} className="h-14 w-14" iconSize={20} />
             <div className="min-w-0 flex-1">
               <p className="type-label truncate leading-snug text-[var(--text-primary)]">{artifact.name}</p>
               <p className="type-support mt-0.5 text-[var(--text-muted)]">{formatFileSize(artifact.size)}</p>

--- a/packages/desktop/src/renderer/components/FilePreview.tsx
+++ b/packages/desktop/src/renderer/components/FilePreview.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { ExternalLink, Loader2, Copy, Check } from 'lucide-react';
+import { ExternalLink, Loader2, Copy, Check, X } from 'lucide-react';
 import hljs from 'highlight.js';
 import { useTranslation } from 'react-i18next';
 import type { Artifact } from '@clawwork/shared';
@@ -14,6 +14,7 @@ import MarkdownContent from './MarkdownContent';
 interface FilePreviewProps {
   artifact: Artifact;
   onNavigateToTask: (taskId: string, messageId: string) => void;
+  onClose?: () => void;
 }
 
 function isImage(mime: string): boolean {
@@ -84,7 +85,7 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-export default function FilePreview({ artifact, onNavigateToTask }: FilePreviewProps) {
+export default function FilePreview({ artifact, onNavigateToTask, onClose }: FilePreviewProps) {
   const { t } = useTranslation();
   const [content, setContent] = useState<string | null>(null);
   const [encoding, setEncoding] = useState<'utf-8' | 'base64'>('utf-8');
@@ -124,6 +125,20 @@ export default function FilePreview({ artifact, onNavigateToTask }: FilePreviewP
         <div className="flex items-center gap-1.5 flex-shrink-0">
           <span className="type-meta text-[var(--text-muted)]">{formatFileSize(artifact.size)}</span>
           {isCode && content !== null && <CopyButton text={content} />}
+          {onClose ? (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={t('filePreview.close')}
+              title={t('filePreview.close')}
+              className={cn(
+                'flex h-7 w-7 items-center justify-center rounded-md transition-colors',
+                'text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]',
+              )}
+            >
+              <X size={14} />
+            </button>
+          ) : null}
         </div>
       </header>
 

--- a/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
+++ b/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useMemo, useCallback, useRef, useState, type MouseEvent } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Search, Loader2, ChevronRight, X } from 'lucide-react';
+import { Search, Loader2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useFileStore } from '@/stores/fileStore';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
 import { useUiStore } from '@/stores/uiStore';
 import { cn } from '@/lib/utils';
-import { motion as motionPresets } from '@/styles/design-tokens';
+import { motionDuration, motionEase } from '@/styles/design-tokens';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import FileCard from '@/components/FileCard';
 import FilePreview from '@/components/FilePreview';
@@ -18,7 +18,6 @@ import type { ArtifactSearchResult } from '@/stores/fileStore';
 import EmptyState from '@/components/semantic/EmptyState';
 import ListItem from '@/components/semantic/ListItem';
 import SectionCard from '@/components/semantic/SectionCard';
-import ToolbarButton from '@/components/semantic/ToolbarButton';
 import WindowTitlebar from '@/components/semantic/WindowTitlebar';
 
 function sortArtifacts(list: Artifact[], sortBy: 'date' | 'name' | 'type'): Artifact[] {
@@ -192,6 +191,15 @@ export default function FileBrowser() {
     [selectedId, artifacts],
   );
 
+  useEffect(() => {
+    if (!selectedArtifact) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setSelectedArtifact(null);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [selectedArtifact, setSelectedArtifact]);
+
   const taskIdsWithArtifacts = useMemo(() => {
     const ids = new Set<string>();
     for (const a of artifacts) ids.add(a.taskId);
@@ -212,7 +220,7 @@ export default function FileBrowser() {
   const isSearchMode = searchQuery.trim().length > 0;
 
   return (
-    <div className="flex h-full">
+    <div className="relative flex h-full overflow-hidden">
       <div className="flex flex-col flex-1 min-w-0">
         <WindowTitlebar
           left={<h2 className="type-section-title text-[var(--text-primary)]">{t('common.fileManager')}</h2>}
@@ -345,42 +353,36 @@ export default function FileBrowser() {
 
       <AnimatePresence>
         {selectedArtifact && (
-          <motion.div
-            {...motionPresets.slideIn}
-            initial={{ opacity: 0, x: 16 }}
-            exit={{ opacity: 0, x: 16 }}
-            className="relative flex-shrink-0 border-l border-[var(--border)] bg-[var(--bg-secondary)]"
-            style={{ width: panelWidth }}
-          >
-            <div
-              onMouseDown={handleMouseDown}
-              className={cn(
-                'absolute left-0 top-0 bottom-0 w-1 -translate-x-1/2 z-10 cursor-col-resize',
-                'group flex items-center justify-center',
-              )}
+          <div className="pointer-events-none absolute inset-y-0 right-0 z-30 flex max-w-full justify-end">
+            <motion.div
+              initial={{ opacity: 0, x: 24 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: 24 }}
+              transition={{ duration: motionDuration.moderate, ease: motionEase.standard }}
+              className="pointer-events-auto relative h-full flex-shrink-0 border-l border-[var(--border)] bg-[var(--bg-secondary)] shadow-[var(--shadow-floating)]"
+              style={{ width: panelWidth, maxWidth: 'calc(100% - 48px)' }}
             >
               <div
+                onMouseDown={handleMouseDown}
                 className={cn(
-                  'w-1 h-8 rounded-full transition-colors duration-150',
-                  isDragging ? 'bg-[var(--accent)]' : 'bg-transparent group-hover:bg-[var(--text-muted)]',
+                  'absolute left-0 top-0 bottom-0 w-1 -translate-x-1/2 z-10 cursor-col-resize',
+                  'group flex items-center justify-center',
                 )}
+              >
+                <div
+                  className={cn(
+                    'w-1 h-8 rounded-full transition-colors duration-150',
+                    isDragging ? 'bg-[var(--accent)]' : 'bg-transparent group-hover:bg-[var(--text-muted)]',
+                  )}
+                />
+              </div>
+              <FilePreview
+                artifact={selectedArtifact}
+                onNavigateToTask={handleNavigateToTask}
+                onClose={() => setSelectedArtifact(null)}
               />
-            </div>
-            <ToolbarButton
-              onClick={() => setSelectedArtifact(null)}
-              title={t('filePreview.close')}
-              icon={<ChevronRight size={13} />}
-              className={cn(
-                'absolute left-0 top-1/2 -translate-x-full -translate-y-1/2 z-10',
-                'w-5 h-12 justify-center p-0',
-                'bg-[var(--bg-secondary)] border border-r-0 border-[var(--border)]',
-                'rounded-l-lg cursor-pointer',
-                'text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)]',
-                'transition-colors duration-150',
-              )}
-            />
-            <FilePreview artifact={selectedArtifact} onNavigateToTask={handleNavigateToTask} />
-          </motion.div>
+            </motion.div>
+          </div>
         )}
       </AnimatePresence>
 

--- a/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
+++ b/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
@@ -10,6 +10,7 @@ import { STAGGER_STEP, motionDuration } from '@/styles/design-tokens';
 import type { Artifact } from '@clawwork/shared';
 import ListItem from '@/components/semantic/ListItem';
 import PanelHeader from '@/components/semantic/PanelHeader';
+import ArtifactThumbnail from '@/components/ArtifactThumbnail';
 
 const listVariants = {
   hidden: {},
@@ -87,12 +88,7 @@ export default function RightPanel() {
                   >
                     <ListItem
                       leading={
-                        <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-secondary)]">
-                          <FileText
-                            size={15}
-                            className="text-[var(--text-muted)] transition-colors group-hover:text-[var(--text-secondary)]"
-                          />
-                        </div>
+                        <ArtifactThumbnail artifact={a} className="h-10 w-10 border border-[var(--border-subtle)]" />
                       }
                       title={a.name}
                       subtitle={formatArtifactSubtitle(a.localPath)}


### PR DESCRIPTION
## Summary

Add shared artifact thumbnail rendering for file management surfaces and change the file preview panel into an overlay drawer so previews no longer shrink the file grid.

## Type of change

- [x] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

File artifacts previously showed only generic icons, making image-heavy artifact lists hard to scan. Opening an artifact preview also inserted a flex panel into the file browser layout, which compressed the grid instead of behaving like a drawer.

## What changed?

- Added a shared renderer-only `ArtifactThumbnail` component that displays image artifacts as thumbnails and falls back to type icons for other artifacts.
- Updated the file manager grid and conversation right-panel artifact list to use the shared thumbnail component.
- Converted the file manager preview panel to an absolute overlay drawer with an in-header close button and Escape-to-close behavior.
- Kept the drawer resize grip on the edge without the previous visible mid-panel handle.

## Architecture impact

- Owning layer: renderer
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: renderer remains presentation-only; artifact file reads still go through the typed preload bridge.
- Why those invariants remain protected: no main, preload, shared protocol, storage, or IPC surface changes were made.

## Linked issues

None

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
Manual smoke test in Electron dev app: verified file manager thumbnails, overlay drawer behavior without grid reflow, header close button, and conversation right-panel artifact thumbnails.
```

## Screenshots or recordings

Manual visual verification was performed in the Electron dev app. The change preserves existing CSS variables, motion tokens, and `pnpm check:ui-contract` rules; it reuses existing border/background/text tokens for the thumbnail fallbacks and drawer chrome.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
File artifacts now show image thumbnails in the file manager and conversation artifact panel, and file previews open in an overlay drawer without shrinking the file grid.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
