### PR TITLE
[Feat] Hide artifact filenames

### DIFF
--- a/packages/desktop/src/main/db/search.ts
+++ b/packages/desktop/src/main/db/search.ts
@@ -23,8 +23,8 @@ SELECT * FROM (
   JOIN messages m ON m.rowid = messages_fts.rowid
   WHERE messages_fts MATCH ?
   UNION ALL
-  SELECT 'artifact' AS type, a.id, a.name AS title,
-    snippet(artifacts_fts, 0, '<<', '>>', '…', 32) AS snippet,
+  SELECT 'artifact' AS type, a.id, a.type AS title,
+    snippet(artifacts_fts, 1, '<<', '>>', '…', 32) AS snippet,
     a.task_id, artifacts_fts.rank
   FROM artifacts_fts
   JOIN artifacts a ON a.rowid = artifacts_fts.rowid
@@ -59,11 +59,10 @@ export function globalSearch(db: Database.Database, query: string): SearchResult
 
 const ARTIFACT_SEARCH_SQL = `
 SELECT a.id, a.task_id, a.name, a.type, a.local_path, a.mime_type, a.size, a.created_at, a.file_path, a.message_id,
-  snippet(artifacts_fts, 0, '<mark>', '</mark>', '…', 20) AS name_snippet,
   snippet(artifacts_fts, 1, '<mark>', '</mark>', '…', 32) AS content_snippet
 FROM artifacts_fts
 JOIN artifacts a ON a.rowid = artifacts_fts.rowid
-WHERE artifacts_fts MATCH ?
+WHERE __WHERE__
 ORDER BY artifacts_fts.rank
 LIMIT 50;
 `;
@@ -82,13 +81,35 @@ interface ArtifactSearchResult {
   contentSnippet?: string;
 }
 
-export function searchArtifacts(db: Database.Database, query: string): ArtifactSearchResult[] {
+type ArtifactSearchKind = 'all' | 'image' | 'code' | 'file' | 'other';
+
+interface ArtifactSearchOptions {
+  kind?: ArtifactSearchKind;
+}
+
+function artifactKindClause(kind: ArtifactSearchKind | undefined): string | null {
+  if (!kind || kind === 'all') return null;
+  if (kind === 'image') return "(a.type = 'image' OR a.mime_type LIKE 'image/%')";
+  if (kind === 'code') return "a.type = 'code'";
+  if (kind === 'file') return "a.type = 'file'";
+  return "(a.type NOT IN ('image', 'code', 'file') AND a.mime_type NOT LIKE 'image/%')";
+}
+
+export function searchArtifacts(
+  db: Database.Database,
+  query: string,
+  options: ArtifactSearchOptions = {},
+): ArtifactSearchResult[] {
   const q = query.trim();
   if (!q) return [];
   const ftsQuery = q.replace(/[^\w\u4e00-\u9fff]/g, ' ').trim() + '*';
   if (ftsQuery === '*') return [];
-  const stmt = db.prepare(ARTIFACT_SEARCH_SQL);
-  const rows = stmt.all(ftsQuery) as Array<{
+  const clauses = ['artifacts_fts MATCH ?'];
+  const params: string[] = [ftsQuery];
+  const kindClause = artifactKindClause(options.kind);
+  if (kindClause) clauses.push(kindClause);
+  const stmt = db.prepare(ARTIFACT_SEARCH_SQL.replace('__WHERE__', clauses.join(' AND ')));
+  const rows = stmt.all(...params) as Array<{
     id: string;
     task_id: string;
     name: string;
@@ -99,7 +120,6 @@ export function searchArtifacts(db: Database.Database, query: string): ArtifactS
     created_at: string;
     file_path: string;
     message_id: string;
-    name_snippet: string;
     content_snippet: string;
   }>;
   return rows.map((r) => ({
@@ -113,6 +133,6 @@ export function searchArtifacts(db: Database.Database, query: string): ArtifactS
     createdAt: r.created_at,
     filePath: r.file_path,
     messageId: r.message_id,
-    contentSnippet: r.content_snippet || r.name_snippet || undefined,
+    contentSnippet: r.content_snippet || undefined,
   }));
 }

--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -255,16 +255,19 @@ export function registerArtifactHandlers(): void {
     }
   });
 
-  ipcMain.handle('artifact:search', async (_event, params: { query: string }) => {
-    const sqlite = getSqlite();
-    if (!sqlite) return { ok: false, error: 'db not ready' };
-    try {
-      const results = searchArtifacts(sqlite, params.query);
-      return { ok: true, result: results };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
-    }
-  });
+  ipcMain.handle(
+    'artifact:search',
+    async (_event, params: { query: string; kind?: 'all' | 'image' | 'code' | 'file' | 'other' }) => {
+      const sqlite = getSqlite();
+      if (!sqlite) return { ok: false, error: 'db not ready' };
+      try {
+        const results = searchArtifacts(sqlite, params.query, { kind: params.kind });
+        return { ok: true, result: results };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
+      }
+    },
+  );
 
   ipcMain.handle('session:export-markdown', async (_event, params: { taskId: string }) => {
     const workspacePath = getWorkspacePath();

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -324,7 +324,10 @@ export interface ClawWorkAPI {
     fileName?: string;
   }) => Promise<IpcResult>;
   saveImageFromUrl: (params: { taskId: string; messageId: string; url: string; alt?: string }) => Promise<IpcResult>;
-  searchArtifacts: (query: string) => Promise<IpcResult>;
+  searchArtifacts: (
+    query: string,
+    options?: { kind?: 'all' | 'image' | 'code' | 'file' | 'other' },
+  ) => Promise<IpcResult>;
   openArtifactFile: (localPath: string) => Promise<IpcResult>;
   showArtifactInFolder: (localPath: string) => Promise<IpcResult>;
   saveInboxAttachment: (params: {

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -143,7 +143,7 @@ function buildApi(): ClawWorkAPI {
     },
     saveCodeBlock: (params) => ipcRenderer.invoke('artifact:save-content', params),
     saveImageFromUrl: (params) => ipcRenderer.invoke('artifact:save-image-url', params),
-    searchArtifacts: (query: string) => ipcRenderer.invoke('artifact:search', { query }),
+    searchArtifacts: (query: string, options) => ipcRenderer.invoke('artifact:search', { query, ...(options ?? {}) }),
     openArtifactFile: (localPath: string) => ipcRenderer.invoke('artifact:open-file', { localPath }),
     showArtifactInFolder: (localPath: string) => ipcRenderer.invoke('artifact:show-in-folder', { localPath }),
     saveInboxAttachment: (params: { taskId: string; fileName: string; base64: string }) =>

--- a/packages/desktop/src/renderer/components/ChatInput/index.tsx
+++ b/packages/desktop/src/renderer/components/ChatInput/index.tsx
@@ -32,6 +32,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useVoiceInput } from '@/hooks/useVoiceInput';
 import { cn } from '@/lib/utils';
+import { getArtifactLabel } from '@/lib/artifact-labels';
 import { createWhisperSttSession } from '@/lib/voice/whisper-stt';
 import { useRoomStore } from '@/stores/roomStore';
 import { useSettingsStore } from '@/stores/settingsStore';
@@ -617,7 +618,7 @@ export default function ChatInput() {
                       <SelectionTag
                         key={a.id}
                         icon={<File size={14} />}
-                        label={a.name}
+                        label={getArtifactLabel(a, t)}
                         variant="muted"
                         onRemove={() => removeSelectedArtifact(a.id)}
                       />

--- a/packages/desktop/src/renderer/components/FileCard.tsx
+++ b/packages/desktop/src/renderer/components/FileCard.tsx
@@ -4,6 +4,7 @@ import { MoreHorizontal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Artifact } from '@clawwork/shared';
 import { cn, formatRelativeTime, formatFileSize } from '@/lib/utils';
+import { getArtifactLabel } from '@/lib/artifact-labels';
 import { motion as motionPresets, motionDuration, motionEase } from '@/styles/design-tokens';
 import ArtifactThumbnail from './ArtifactThumbnail';
 
@@ -24,6 +25,7 @@ function extBadge(name: string): string {
 export default function FileCard({ artifact, taskTitle, selected, isNew, onClick, onContextMenu }: FileCardProps) {
   const { t } = useTranslation();
   const ext = extBadge(artifact.name);
+  const title = getArtifactLabel(artifact, t);
 
   return (
     <div className="relative">
@@ -51,7 +53,7 @@ export default function FileCard({ artifact, taskTitle, selected, isNew, onClick
           onClick={onClick}
           onContextMenu={onContextMenu}
           className="absolute inset-0 z-0 rounded-xl focus-visible:ring-2 focus-visible:ring-[var(--border-accent)]"
-          aria-label={artifact.name}
+          aria-label={title}
         />
         <button
           type="button"
@@ -72,7 +74,7 @@ export default function FileCard({ artifact, taskTitle, selected, isNew, onClick
           <div className="flex items-start gap-2.5">
             <ArtifactThumbnail artifact={artifact} className="h-14 w-14" iconSize={20} />
             <div className="min-w-0 flex-1">
-              <p className="type-label truncate leading-snug text-[var(--text-primary)]">{artifact.name}</p>
+              <p className="type-label truncate leading-snug text-[var(--text-primary)]">{title}</p>
               <p className="type-support mt-0.5 text-[var(--text-muted)]">{formatFileSize(artifact.size)}</p>
             </div>
             {ext && (

--- a/packages/desktop/src/renderer/components/FilePreview.tsx
+++ b/packages/desktop/src/renderer/components/FilePreview.tsx
@@ -9,6 +9,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { motion as motionPresets } from '@/styles/design-tokens';
 import { cn, formatFileSize } from '@/lib/utils';
 import { copyTextToClipboard } from '@/lib/clipboard';
+import { getArtifactLabel } from '@/lib/artifact-labels';
 import MarkdownContent from './MarkdownContent';
 
 interface FilePreviewProps {
@@ -93,6 +94,7 @@ export default function FilePreview({ artifact, onNavigateToTask, onClose }: Fil
   const [error, setError] = useState<string | null>(null);
 
   const ext = extFromName(artifact.name);
+  const title = getArtifactLabel(artifact, t);
   const isCode = encoding === 'utf-8' && !isMarkdown(artifact.name) && !isImage(artifact.mimeType);
 
   useEffect(() => {
@@ -120,7 +122,7 @@ export default function FilePreview({ artifact, onNavigateToTask, onClose }: Fil
               {ext}
             </span>
           )}
-          <h3 className="type-label min-w-0 truncate text-[var(--text-primary)]">{artifact.name}</h3>
+          <h3 className="type-label min-w-0 truncate text-[var(--text-primary)]">{title}</h3>
         </div>
         <div className="flex items-center gap-1.5 flex-shrink-0">
           <span className="type-meta text-[var(--text-muted)]">{formatFileSize(artifact.size)}</span>
@@ -150,7 +152,13 @@ export default function FilePreview({ artifact, onNavigateToTask, onClose }: Fil
         )}
         {error && <p className="type-support px-4 py-8 text-center text-[var(--danger)]">{error}</p>}
         {!loading && !error && content !== null && (
-          <PreviewContent content={content} encoding={encoding} mimeType={artifact.mimeType} name={artifact.name} />
+          <PreviewContent
+            content={content}
+            encoding={encoding}
+            mimeType={artifact.mimeType}
+            name={artifact.name}
+            alt={title}
+          />
         )}
       </ScrollArea>
 
@@ -195,11 +203,13 @@ function PreviewContent({
   encoding,
   mimeType,
   name,
+  alt,
 }: {
   content: string;
   encoding: string;
   mimeType: string;
   name: string;
+  alt: string;
 }) {
   const { t } = useTranslation();
 
@@ -208,7 +218,7 @@ function PreviewContent({
       <div className="flex items-center justify-center p-4">
         <img
           src={`data:${mimeType};base64,${content}`}
-          alt={name}
+          alt={alt}
           className="max-w-full max-h-96 rounded-lg object-contain"
         />
       </div>

--- a/packages/desktop/src/renderer/components/MentionPicker.tsx
+++ b/packages/desktop/src/renderer/components/MentionPicker.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { Task, Artifact, FileIndexEntry } from '@clawwork/shared';
 import { useFileStore } from '@/stores/fileStore';
 import { cn, formatFileSize } from '@/lib/utils';
+import { getArtifactLabel } from '@/lib/artifact-labels';
 import AgentIcon from './AgentIcon';
 import { MENTION_ALL_AGENT_ID } from './ChatInput/constants';
 
@@ -272,7 +273,7 @@ export default function MentionPicker({
                   onMouseEnter={() => onHoverIndex(i)}
                 >
                   <span className="flex-shrink-0">{artifactIcon(a.type, 14)}</span>
-                  <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{a.name}</span>
+                  <span className="flex-1 min-w-0 truncate text-[var(--text-primary)]">{getArtifactLabel(a, t)}</span>
                   <span className="type-support flex-shrink-0 text-[var(--text-muted)]">{formatFileSize(a.size)}</span>
                 </button>
               );

--- a/packages/desktop/src/renderer/components/SearchResults.tsx
+++ b/packages/desktop/src/renderer/components/SearchResults.tsx
@@ -77,6 +77,8 @@ export default function SearchResults({ results, onSelect }: SearchResultsProps)
             </p>
             {grouped[type].map((result, idx) => {
               const Icon = ICON_MAP[result.type];
+              const title = result.type === 'artifact' ? t('search.files') : result.title || t('common.noTitle');
+              const snippet = result.type === 'artifact' && !result.snippet ? t('search.fileMatch') : result.snippet;
               return (
                 <motion.button
                   key={result.id}
@@ -91,11 +93,9 @@ export default function SearchResults({ results, onSelect }: SearchResultsProps)
                 >
                   <Icon size={15} className="mt-0.5 flex-shrink-0 text-[var(--text-muted)]" />
                   <div className="min-w-0 flex-1">
-                    <p className="type-label truncate text-[var(--text-primary)]">
-                      {result.title || t('common.noTitle')}
-                    </p>
+                    <p className="type-label truncate text-[var(--text-primary)]">{title}</p>
                     <p className="type-support mt-0.5 truncate text-[var(--text-secondary)]">
-                      {highlightSnippet(result.snippet)}
+                      {highlightSnippet(snippet)}
                     </p>
                   </div>
                 </motion.button>

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -19,6 +19,15 @@
   "archived": {
     "empty": "Keine archivierten Chats"
   },
+  "artifactKinds": {
+    "code": "Code-Snippet",
+    "data": "Datenartefakt",
+    "file": "Datei",
+    "image": "Bild",
+    "link": "Link",
+    "markdown": "Markdown-Dokument",
+    "text": "Textdatei"
+  },
   "chatInput": {
     "abortFailed": "Generierung konnte nicht gestoppt werden",
     "addContextFolder": "Kontextordner fuer @-Dateiverweise hinzufuegen",
@@ -303,11 +312,12 @@
     "exportedToFiles": "In Dateien exportiert"
   },
   "fileBrowser": {
-    "allTasks": "Alle Aufgaben",
+    "allTypes": "Alle Typen",
     "searchFiles": "Dateien suchen…",
-    "sortByDate": "Nach Datum",
-    "sortByName": "Nach Name",
-    "sortByType": "Nach Typ"
+    "typeCode": "Code",
+    "typeFiles": "Dateien",
+    "typeImages": "Bilder",
+    "typeOther": "Andere"
   },
   "filePreview": {
     "cannotPreview": "Vorschau fuer diesen Dateityp nicht verfuegbar",
@@ -380,6 +390,7 @@
     "toolCount": "{{count}} Tools"
   },
   "search": {
+    "fileMatch": "Dateitreffer",
     "files": "Dateien",
     "messages": "Nachrichten",
     "noResults": "Keine Ergebnisse gefunden",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -19,6 +19,15 @@
   "archived": {
     "empty": "No archived chats"
   },
+  "artifactKinds": {
+    "code": "Code snippet",
+    "data": "Data artifact",
+    "file": "File",
+    "image": "Image",
+    "link": "Link",
+    "markdown": "Markdown document",
+    "text": "Text file"
+  },
   "chatInput": {
     "abortFailed": "Failed to stop generation",
     "addContextFolder": "Add context folder for @ file references",
@@ -303,11 +312,12 @@
     "exportedToFiles": "Exported to Files"
   },
   "fileBrowser": {
-    "allTasks": "All Tasks",
+    "allTypes": "All Types",
     "searchFiles": "Search files…",
-    "sortByDate": "By date",
-    "sortByName": "By name",
-    "sortByType": "By type"
+    "typeCode": "Code",
+    "typeFiles": "Files",
+    "typeImages": "Images",
+    "typeOther": "Other"
   },
   "filePreview": {
     "cannotPreview": "Cannot preview this file type",
@@ -380,6 +390,7 @@
     "toolCount": "{{count}} tools"
   },
   "search": {
+    "fileMatch": "File match",
     "files": "Files",
     "messages": "Messages",
     "noResults": "No results found",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -19,6 +19,15 @@
   "archived": {
     "empty": "No hay chats archivados"
   },
+  "artifactKinds": {
+    "code": "Fragmento de código",
+    "data": "Artefacto de datos",
+    "file": "Archivo",
+    "image": "Imagen",
+    "link": "Enlace",
+    "markdown": "Documento Markdown",
+    "text": "Archivo de texto"
+  },
   "chatInput": {
     "abortFailed": "No se pudo detener la generación",
     "addContextFolder": "Agregar carpeta de contexto para referencias de archivos con @",
@@ -303,11 +312,12 @@
     "exportedToFiles": "Exportado a archivos"
   },
   "fileBrowser": {
-    "allTasks": "Todas las tareas",
+    "allTypes": "Todos los tipos",
     "searchFiles": "Buscar archivos…",
-    "sortByDate": "Por fecha",
-    "sortByName": "Por nombre",
-    "sortByType": "Por tipo"
+    "typeCode": "Código",
+    "typeFiles": "Archivos",
+    "typeImages": "Imágenes",
+    "typeOther": "Otros"
   },
   "filePreview": {
     "cannotPreview": "No se puede previsualizar este tipo de archivo",
@@ -380,6 +390,7 @@
     "toolCount": "{{count}} herramientas"
   },
   "search": {
+    "fileMatch": "Coincidencia de archivo",
     "files": "Archivos",
     "messages": "Mensajes",
     "noResults": "No se encontraron resultados",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -19,6 +19,15 @@
   "archived": {
     "empty": "アーカイブ済みチャットはありません"
   },
+  "artifactKinds": {
+    "code": "コードスニペット",
+    "data": "データ成果物",
+    "file": "ファイル",
+    "image": "画像",
+    "link": "リンク",
+    "markdown": "Markdown ドキュメント",
+    "text": "テキストファイル"
+  },
   "chatInput": {
     "abortFailed": "生成の停止に失敗しました",
     "addContextFolder": "@ ファイル参照用のコンテキストフォルダを追加",
@@ -303,11 +312,12 @@
     "exportedToFiles": "ファイルにエクスポートしました"
   },
   "fileBrowser": {
-    "allTasks": "すべてのタスク",
+    "allTypes": "すべての種類",
     "searchFiles": "ファイルを検索…",
-    "sortByDate": "日付順",
-    "sortByName": "名前順",
-    "sortByType": "種類順"
+    "typeCode": "コード",
+    "typeFiles": "ファイル",
+    "typeImages": "画像",
+    "typeOther": "その他"
   },
   "filePreview": {
     "cannotPreview": "このファイル形式はプレビューできません",
@@ -380,6 +390,7 @@
     "toolCount": "{{count}} ツール"
   },
   "search": {
+    "fileMatch": "ファイル一致",
     "files": "ファイル",
     "messages": "メッセージ",
     "noResults": "結果が見つかりません",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -19,6 +19,15 @@
   "archived": {
     "empty": "보관된 대화가 없습니다"
   },
+  "artifactKinds": {
+    "code": "코드 스니펫",
+    "data": "데이터 산출물",
+    "file": "파일",
+    "image": "이미지",
+    "link": "링크",
+    "markdown": "Markdown 문서",
+    "text": "텍스트 파일"
+  },
   "chatInput": {
     "abortFailed": "생성 중지에 실패했습니다",
     "addContextFolder": "@ 파일 참조를 위한 컨텍스트 폴더 추가",
@@ -303,11 +312,12 @@
     "exportedToFiles": "파일로 내보냈습니다"
   },
   "fileBrowser": {
-    "allTasks": "모든 작업",
+    "allTypes": "모든 유형",
     "searchFiles": "파일 검색…",
-    "sortByDate": "날짜순",
-    "sortByName": "이름순",
-    "sortByType": "유형순"
+    "typeCode": "코드",
+    "typeFiles": "파일",
+    "typeImages": "이미지",
+    "typeOther": "기타"
   },
   "filePreview": {
     "cannotPreview": "이 파일 유형은 미리보기할 수 없습니다",
@@ -380,6 +390,7 @@
     "toolCount": "{{count}}개 도구"
   },
   "search": {
+    "fileMatch": "파일 일치",
     "files": "파일",
     "messages": "메시지",
     "noResults": "검색 결과가 없습니다",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -19,6 +19,15 @@
   "archived": {
     "empty": "Nenhuma conversa arquivada"
   },
+  "artifactKinds": {
+    "code": "Trecho de codigo",
+    "data": "Artefato de dados",
+    "file": "Arquivo",
+    "image": "Imagem",
+    "link": "Link",
+    "markdown": "Documento Markdown",
+    "text": "Arquivo de texto"
+  },
   "chatInput": {
     "abortFailed": "Falha ao parar a geração",
     "addContextFolder": "Adicionar pasta de contexto para referências de arquivo com @",
@@ -303,11 +312,12 @@
     "exportedToFiles": "Exportado para Arquivos"
   },
   "fileBrowser": {
-    "allTasks": "Todas as Tarefas",
+    "allTypes": "Todos os tipos",
     "searchFiles": "Buscar arquivos…",
-    "sortByDate": "Por data",
-    "sortByName": "Por nome",
-    "sortByType": "Por tipo"
+    "typeCode": "Codigo",
+    "typeFiles": "Arquivos",
+    "typeImages": "Imagens",
+    "typeOther": "Outros"
   },
   "filePreview": {
     "cannotPreview": "Não é possível pré-visualizar este tipo de arquivo",
@@ -380,6 +390,7 @@
     "toolCount": "{{count}} ferramentas"
   },
   "search": {
+    "fileMatch": "Correspondencia de arquivo",
     "files": "Arquivos",
     "messages": "Mensagens",
     "noResults": "Nenhum resultado encontrado",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -19,6 +19,15 @@
   "archived": {
     "empty": "沒有已封存的對話"
   },
+  "artifactKinds": {
+    "code": "程式碼片段",
+    "data": "資料產物",
+    "file": "檔案",
+    "image": "圖片",
+    "link": "連結",
+    "markdown": "Markdown 文件",
+    "text": "文字檔"
+  },
   "chatInput": {
     "abortFailed": "無法停止生成",
     "addContextFolder": "新增上下文資料夾以使用 @ 檔案參照",
@@ -303,11 +312,12 @@
     "exportedToFiles": "已匯出為檔案"
   },
   "fileBrowser": {
-    "allTasks": "所有任務",
+    "allTypes": "所有類型",
     "searchFiles": "搜尋檔案…",
-    "sortByDate": "依日期",
-    "sortByName": "依名稱",
-    "sortByType": "依類型"
+    "typeCode": "程式碼",
+    "typeFiles": "檔案",
+    "typeImages": "圖片",
+    "typeOther": "其他"
   },
   "filePreview": {
     "cannotPreview": "無法預覽此檔案類型",
@@ -380,6 +390,7 @@
     "toolCount": "{{count}} 個工具"
   },
   "search": {
+    "fileMatch": "檔案符合",
     "files": "檔案",
     "messages": "訊息",
     "noResults": "找不到結果",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -19,6 +19,15 @@
   "archived": {
     "empty": "暂无归档对话"
   },
+  "artifactKinds": {
+    "code": "代码片段",
+    "data": "数据产物",
+    "file": "文件",
+    "image": "图片",
+    "link": "链接",
+    "markdown": "Markdown 文档",
+    "text": "文本文件"
+  },
   "chatInput": {
     "abortFailed": "停止生成失败",
     "addContextFolder": "为 @ 文件引用添加上下文文件夹",
@@ -303,11 +312,12 @@
     "exportedToFiles": "已导出到文件管理"
   },
   "fileBrowser": {
-    "allTasks": "全部任务",
+    "allTypes": "全部类型",
     "searchFiles": "搜索文件…",
-    "sortByDate": "按时间",
-    "sortByName": "按名称",
-    "sortByType": "按类型"
+    "typeCode": "代码",
+    "typeFiles": "文件",
+    "typeImages": "图片",
+    "typeOther": "其他"
   },
   "filePreview": {
     "cannotPreview": "无法预览此文件类型",
@@ -380,6 +390,7 @@
     "toolCount": "{{count}} 个工具"
   },
   "search": {
+    "fileMatch": "文件匹配",
     "files": "文件",
     "messages": "消息",
     "noResults": "未找到结果",

--- a/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
+++ b/packages/desktop/src/renderer/layouts/FileBrowser/index.tsx
@@ -7,6 +7,7 @@ import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
 import { useUiStore } from '@/stores/uiStore';
 import { cn } from '@/lib/utils';
+import { getArtifactKindFilter, getArtifactLabel, type ArtifactKindFilter } from '@/lib/artifact-labels';
 import { motionDuration, motionEase } from '@/styles/design-tokens';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import FileCard from '@/components/FileCard';
@@ -20,16 +21,8 @@ import ListItem from '@/components/semantic/ListItem';
 import SectionCard from '@/components/semantic/SectionCard';
 import WindowTitlebar from '@/components/semantic/WindowTitlebar';
 
-function sortArtifacts(list: Artifact[], sortBy: 'date' | 'name' | 'type'): Artifact[] {
-  const sorted = [...list];
-  switch (sortBy) {
-    case 'date':
-      return sorted.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-    case 'name':
-      return sorted.sort((a, b) => a.name.localeCompare(b.name));
-    case 'type':
-      return sorted.sort((a, b) => a.type.localeCompare(b.type));
-  }
+function sortArtifacts(list: Artifact[]): Artifact[] {
+  return [...list].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 }
 
 function SnippetHighlight({ snippet }: { snippet: string }) {
@@ -54,15 +47,13 @@ type FileMenuState = { artifact: Artifact; position: { x: number; y: number } } 
 export default function FileBrowser() {
   const { t } = useTranslation();
   const artifacts = useFileStore((s) => s.artifacts);
-  const filterTaskId = useFileStore((s) => s.filterTaskId);
-  const sortBy = useFileStore((s) => s.sortBy);
+  const typeFilter = useFileStore((s) => s.typeFilter);
   const selectedId = useFileStore((s) => s.selectedArtifactId);
   const searchQuery = useFileStore((s) => s.searchQuery);
   const searchResults = useFileStore((s) => s.searchResults);
   const isSearching = useFileStore((s) => s.isSearching);
   const setArtifacts = useFileStore((s) => s.setArtifacts);
-  const setFilterTaskId = useFileStore((s) => s.setFilterTaskId);
-  const setSortBy = useFileStore((s) => s.setSortBy);
+  const setTypeFilter = useFileStore((s) => s.setTypeFilter);
   const setSelectedArtifact = useFileStore((s) => s.setSelectedArtifact);
   const setSearchQuery = useFileStore((s) => s.setSearchQuery);
   const setSearchResults = useFileStore((s) => s.setSearchResults);
@@ -152,7 +143,9 @@ export default function FileBrowser() {
     const requestId = ++searchRequestIdRef.current;
     debounceRef.current = setTimeout(() => {
       window.clawwork
-        .searchArtifacts(searchQuery)
+        .searchArtifacts(searchQuery, {
+          kind: typeFilter,
+        })
         .then((res) => {
           if (searchRequestIdRef.current !== requestId) return;
           setIsSearching(false);
@@ -171,7 +164,7 @@ export default function FileBrowser() {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [searchQuery, setSearchResults, setIsSearching]);
+  }, [searchQuery, setSearchResults, setIsSearching, typeFilter]);
 
   const taskMap = useMemo(() => {
     const m = new Map<string, string>();
@@ -180,11 +173,13 @@ export default function FileBrowser() {
   }, [tasks, t]);
 
   const filteredArtifacts = useMemo(() => {
-    if (filterTaskId) return artifacts.filter((a) => a.taskId === filterTaskId);
-    return artifacts;
-  }, [artifacts, filterTaskId]);
+    return artifacts.filter((a) => {
+      if (typeFilter !== 'all' && getArtifactKindFilter(a) !== typeFilter) return false;
+      return true;
+    });
+  }, [artifacts, typeFilter]);
 
-  const sorted = useMemo(() => sortArtifacts(filteredArtifacts, sortBy), [filteredArtifacts, sortBy]);
+  const sorted = useMemo(() => sortArtifacts(filteredArtifacts), [filteredArtifacts]);
 
   const selectedArtifact = useMemo(
     () => (selectedId ? (artifacts.find((a) => a.id === selectedId) ?? null) : null),
@@ -200,12 +195,6 @@ export default function FileBrowser() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [selectedArtifact, setSelectedArtifact]);
 
-  const taskIdsWithArtifacts = useMemo(() => {
-    const ids = new Set<string>();
-    for (const a of artifacts) ids.add(a.taskId);
-    return Array.from(ids);
-  }, [artifacts]);
-
   const {
     width: panelWidth,
     isDragging,
@@ -218,6 +207,13 @@ export default function FileBrowser() {
   });
 
   const isSearchMode = searchQuery.trim().length > 0;
+  const typeFilterOptions: Array<{ value: ArtifactKindFilter; label: string }> = [
+    { value: 'all', label: t('fileBrowser.allTypes') },
+    { value: 'image', label: t('fileBrowser.typeImages') },
+    { value: 'code', label: t('fileBrowser.typeCode') },
+    { value: 'file', label: t('fileBrowser.typeFiles') },
+    { value: 'other', label: t('fileBrowser.typeOther') },
+  ];
 
   return (
     <div className="relative flex h-full overflow-hidden">
@@ -225,35 +221,20 @@ export default function FileBrowser() {
         <WindowTitlebar
           left={<h2 className="type-section-title text-[var(--text-primary)]">{t('common.fileManager')}</h2>}
           right={
-            <>
-              <select
-                value={filterTaskId ?? ''}
-                onChange={(e) => setFilterTaskId(e.target.value || null)}
-                className={cn(
-                  'glow-focus h-7 px-2 rounded-md bg-[var(--bg-tertiary)] border border-[var(--border)]',
-                  'type-label text-[var(--text-secondary)] cursor-pointer',
-                )}
-              >
-                <option value="">{t('fileBrowser.allTasks')}</option>
-                {taskIdsWithArtifacts.map((id) => (
-                  <option key={id} value={id}>
-                    {taskMap.get(id) ?? id}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as 'date' | 'name' | 'type')}
-                className={cn(
-                  'glow-focus h-7 px-2 rounded-md bg-[var(--bg-tertiary)] border border-[var(--border)]',
-                  'type-label text-[var(--text-secondary)] cursor-pointer',
-                )}
-              >
-                <option value="date">{t('fileBrowser.sortByDate')}</option>
-                <option value="name">{t('fileBrowser.sortByName')}</option>
-                <option value="type">{t('fileBrowser.sortByType')}</option>
-              </select>
-            </>
+            <select
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value as ArtifactKindFilter)}
+              className={cn(
+                'glow-focus h-7 px-2 rounded-md bg-[var(--bg-tertiary)] border border-[var(--border)]',
+                'type-label text-[var(--text-secondary)] cursor-pointer',
+              )}
+            >
+              {typeFilterOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
           }
         />
 
@@ -315,7 +296,7 @@ export default function FileBrowser() {
                       )}
                     >
                       <ListItem
-                        title={r.name}
+                        title={getArtifactLabel(r, t)}
                         subtitle={r.contentSnippet ? <SnippetHighlight snippet={r.contentSnippet} /> : undefined}
                         meta={taskMap.get(r.taskId) ?? r.taskId}
                         active={r.id === selectedId}

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from 'react-i18next';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
 import { useUiStore } from '@/stores/uiStore';
+import { useFileStore } from '@/stores/fileStore';
 import { useTaskContextMenu, TaskContextMenuPopover, type SessionActions } from '@/components/ContextMenu';
 import SearchResults, { type SearchResult } from '@/components/SearchResults';
 import { cn } from '@/lib/utils';
@@ -162,6 +163,7 @@ export default function LeftNav() {
   const setHighlightedMessage = useMessageStore((s) => s.setHighlightedMessage);
   const mainView = useUiStore((s) => s.mainView);
   const setMainView = useUiStore((s) => s.setMainView);
+  const setSelectedArtifact = useFileStore((s) => s.setSelectedArtifact);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
   const gwStatusMap = useUiStore((s) => s.gatewayStatusMap);
@@ -272,6 +274,7 @@ export default function LeftNav() {
     setSearchQuery('');
     setSearchResults([]);
     if (result.type === 'artifact') {
+      setSelectedArtifact(result.id);
       setMainView('files');
     } else {
       const targetId = result.type === 'task' ? result.id : result.taskId;

--- a/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
+++ b/packages/desktop/src/renderer/layouts/RightPanel/index.tsx
@@ -4,7 +4,8 @@ import { FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useTaskStore } from '@/stores/taskStore';
 import { useMessageStore } from '@/stores/messageStore';
-import { cn, formatRelativeTime } from '@/lib/utils';
+import { cn, formatRelativeTime, formatFileSize } from '@/lib/utils';
+import { getArtifactLabel } from '@/lib/artifact-labels';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { STAGGER_STEP, motionDuration } from '@/styles/design-tokens';
 import type { Artifact } from '@clawwork/shared';
@@ -24,11 +25,6 @@ const listItemVariants = {
 
 function sortArtifacts(artifacts: Artifact[]) {
   return [...artifacts].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-}
-
-function formatArtifactSubtitle(localPath: string) {
-  const [, ...segments] = localPath.split('/');
-  return segments.join('/') || localPath;
 }
 
 export default function RightPanel() {
@@ -84,14 +80,14 @@ export default function RightPanel() {
                       'group block w-full min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-secondary)] text-left',
                       'transition-all duration-150 hover:border-[var(--border)] hover:bg-[var(--bg-hover)]',
                     )}
-                    title={a.localPath}
+                    title={getArtifactLabel(a, t)}
                   >
                     <ListItem
                       leading={
                         <ArtifactThumbnail artifact={a} className="h-10 w-10 border border-[var(--border-subtle)]" />
                       }
-                      title={a.name}
-                      subtitle={formatArtifactSubtitle(a.localPath)}
+                      title={getArtifactLabel(a, t)}
+                      subtitle={formatFileSize(a.size)}
                       meta={formatRelativeTime(new Date(a.createdAt))}
                       className="rounded-xl px-3 py-2.5"
                     />

--- a/packages/desktop/src/renderer/lib/artifact-labels.ts
+++ b/packages/desktop/src/renderer/lib/artifact-labels.ts
@@ -1,0 +1,31 @@
+import type { Artifact } from '@clawwork/shared';
+
+export type ArtifactKindFilter = 'all' | 'image' | 'code' | 'file' | 'other';
+
+type Translate = (key: string) => string;
+
+function normalizedName(artifact: Pick<Artifact, 'name'>): string {
+  return artifact.name.toLowerCase();
+}
+
+export function getArtifactKindFilter(artifact: Pick<Artifact, 'type' | 'mimeType' | 'name'>): ArtifactKindFilter {
+  if (artifact.type === 'image' || artifact.mimeType.startsWith('image/')) return 'image';
+  if (artifact.type === 'code') return 'code';
+  if (artifact.type === 'file') return 'file';
+  return 'other';
+}
+
+function getArtifactLabelKey(artifact: Pick<Artifact, 'type' | 'mimeType' | 'name'>): string {
+  const name = normalizedName(artifact);
+  if (artifact.type === 'image' || artifact.mimeType.startsWith('image/')) return 'artifactKinds.image';
+  if (artifact.type === 'code') return 'artifactKinds.code';
+  if (artifact.type === 'link') return 'artifactKinds.link';
+  if (artifact.type === 'structured_data') return 'artifactKinds.data';
+  if (artifact.mimeType === 'text/markdown' || name.endsWith('.md')) return 'artifactKinds.markdown';
+  if (artifact.mimeType.startsWith('text/') || name.endsWith('.txt')) return 'artifactKinds.text';
+  return 'artifactKinds.file';
+}
+
+export function getArtifactLabel(artifact: Pick<Artifact, 'type' | 'mimeType' | 'name'>, t: Translate): string {
+  return t(getArtifactLabelKey(artifact));
+}

--- a/packages/desktop/src/renderer/stores/fileStore.ts
+++ b/packages/desktop/src/renderer/stores/fileStore.ts
@@ -1,13 +1,12 @@
 import { create } from 'zustand';
 import type { Artifact } from '@clawwork/shared';
-
-type SortBy = 'date' | 'name' | 'type';
+import type { ArtifactKindFilter } from '@/lib/artifact-labels';
 
 export interface ArtifactSearchResult {
   id: string;
   taskId: string;
   name: string;
-  type: string;
+  type: Artifact['type'];
   localPath: string;
   mimeType: string;
   size: number;
@@ -19,32 +18,29 @@ export interface ArtifactSearchResult {
 
 interface FileState {
   artifacts: Artifact[];
-  filterTaskId: string | null;
-  sortBy: SortBy;
   selectedArtifactId: string | null;
   searchQuery: string;
   searchResults: ArtifactSearchResult[] | null;
   isSearching: boolean;
+  typeFilter: ArtifactKindFilter;
 
   setArtifacts: (artifacts: Artifact[]) => void;
   addArtifact: (artifact: Artifact) => void;
   addArtifactIfNew: (artifact: Artifact) => void;
-  setFilterTaskId: (taskId: string | null) => void;
-  setSortBy: (sortBy: SortBy) => void;
   setSelectedArtifact: (id: string | null) => void;
   setSearchQuery: (query: string) => void;
   setSearchResults: (results: ArtifactSearchResult[] | null) => void;
   setIsSearching: (v: boolean) => void;
+  setTypeFilter: (filter: ArtifactKindFilter) => void;
 }
 
 export const useFileStore = create<FileState>((set) => ({
   artifacts: [],
-  filterTaskId: null,
-  sortBy: 'date',
   selectedArtifactId: null,
   searchQuery: '',
   searchResults: null,
   isSearching: false,
+  typeFilter: 'all',
 
   setArtifacts: (artifacts) => set({ artifacts }),
 
@@ -56,10 +52,6 @@ export const useFileStore = create<FileState>((set) => ({
       return { artifacts: [artifact, ...s.artifacts] };
     }),
 
-  setFilterTaskId: (taskId) => set({ filterTaskId: taskId }),
-
-  setSortBy: (sortBy) => set({ sortBy }),
-
   setSelectedArtifact: (id) => set({ selectedArtifactId: id }),
 
   setSearchQuery: (query) => set({ searchQuery: query }),
@@ -67,4 +59,6 @@ export const useFileStore = create<FileState>((set) => ({
   setSearchResults: (results) => set({ searchResults: results }),
 
   setIsSearching: (v) => set({ isSearching: v }),
+
+  setTypeFilter: (filter) => set({ typeFilter: filter }),
 }));

--- a/packages/desktop/test/artifact-search.test.ts
+++ b/packages/desktop/test/artifact-search.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { globalSearch, searchArtifacts } from '../src/main/db/search.js';
+
+function mockDb(rows: unknown[]) {
+  const all = vi.fn((..._args: unknown[]) => rows);
+  const prepare = vi.fn((_sql: string) => ({ all }));
+  return {
+    db: { prepare },
+    prepare,
+    all,
+  };
+}
+
+describe('artifact search', () => {
+  it('filters full-text artifact results by kind', () => {
+    const { db, prepare, all } = mockDb([
+      {
+        id: 'artifact-code',
+        task_id: 'task-a',
+        name: 'snippet-a1b2c3d4.ts',
+        type: 'code',
+        local_path: 'task-a/snippet-a1b2c3d4.ts',
+        mime_type: 'text/typescript',
+        size: 10,
+        created_at: '2026-01-01T00:00:00.000Z',
+        file_path: '',
+        message_id: 'msg-a',
+        content_snippet: '<mark>render</mark> button',
+      },
+    ]);
+
+    const result = searchArtifacts(db as never, 'render', { kind: 'code' });
+
+    expect(prepare.mock.calls[0][0]).toContain("a.type = 'code'");
+    expect(all).toHaveBeenCalledWith('render*');
+    expect(result.map((r) => r.id)).toEqual(['artifact-code']);
+  });
+
+  it('does not expose stored filenames as search snippets', () => {
+    const { db } = mockDb([
+      {
+        id: 'artifact-image',
+        task_id: 'task-b',
+        name: 'image-1---11111111-1111-4111-8111-111111111111-deadbeef.png',
+        type: 'image',
+        local_path: 'task-b/image-1---11111111-1111-4111-8111-111111111111-deadbeef.png',
+        mime_type: 'image/png',
+        size: 20,
+        created_at: '2026-01-02T00:00:00.000Z',
+        file_path: '',
+        message_id: 'msg-b',
+        content_snippet: '',
+      },
+    ]);
+
+    const [result] = searchArtifacts(db as never, 'image', { kind: 'image' });
+
+    expect(result.name).toContain('deadbeef.png');
+    expect(result.contentSnippet).toBeUndefined();
+  });
+
+  it('does not use stored artifact filenames as global search titles', () => {
+    const { db } = mockDb([
+      {
+        type: 'artifact',
+        id: 'artifact-image',
+        title: 'image',
+        snippet: '',
+        task_id: 'task-b',
+      },
+    ]);
+
+    const [result] = globalSearch(db as never, 'image').filter((item) => item.type === 'artifact');
+
+    expect(result.title).toBe('image');
+    expect(result.snippet).not.toContain('deadbeef');
+  });
+});


### PR DESCRIPTION
## Summary

Hide stored artifact filenames from user-facing file surfaces while keeping artifact content searchable and navigable.

## Type of change

- [x] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Generated artifact filenames are implementation details and are often unreadable. Users should see stable, meaningful artifact labels and search by content rather than raw storage names.

## What changed?

- Replaced user-facing artifact filenames with generic localized labels across File Manager cards, preview, right panel, mention picker, selected attachment tags, and global search results.
- Removed task and sort dropdowns from File Manager, keeping a simpler type filter plus full-text search.
- Added artifact search type filtering through the main/preload/renderer boundary while preserving FTS ranking for search results.
- Added coverage for hidden filename search snippets and artifact type filtering.

## Architecture impact

- Owning layer: main / preload / renderer
- Cross-layer impact: yes, artifact search options now flow from renderer through preload IPC to main-process DB search.
- Invariants touched from `docs/architecture-invariants.md`: artifact persistence and renderer/main IPC boundary; no artifact schema or message persistence write path changed.
- Why those invariants remain protected: persistence remains owned by the main process, renderer still calls through preload APIs, and search output presentation changes do not alter artifact storage or message writes.

## Linked issues

N/A

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [x] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
Manual Electron smoke: File Manager top bar shows only type filter and search; artifact cards and preview show generic labels instead of stored filenames.
pre-ship --committed: 0 MUST-FIX findings, 0 deferred findings
```

## Screenshots or recordings

No screenshot attached. UI smoke was performed locally against the File Manager view; design tokens and existing semantic components were preserved.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
File Manager now hides stored artifact filenames and supports type filtering for artifact search.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
