### PR TITLE
[Fix] Resolve gateway media URLs

### DIFF
--- a/packages/core/src/ports/gateway-transport.ts
+++ b/packages/core/src/ports/gateway-transport.ts
@@ -70,6 +70,7 @@ export interface ChatAttachment {
 }
 
 export interface GatewayTransportPort {
+  getHttpBase?: (gatewayId: string) => string | undefined | Promise<string | undefined>;
   sendMessage: (
     gatewayId: string,
     sessionKey: string,

--- a/packages/core/src/protocol/normalize-history.ts
+++ b/packages/core/src/protocol/normalize-history.ts
@@ -17,6 +17,7 @@ export function isVisibleAssistantContent(content: string): boolean {
 
 const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|avif)(?:[?#].*)?$/i;
 const DATA_IMAGE_RE = /^data:image\/(png|jpe?g|gif|webp|avif);base64,/i;
+const GATEWAY_MEDIA_PATH_RE = /^\/(?:api\/chat\/media\/outgoing\/|media\/|__openclaw__\/media\/)/;
 
 function cleanMediaCandidate(raw: string): string {
   const trimmed = raw.trim();
@@ -55,6 +56,75 @@ function fileNameFromSource(source: string, fallback: string): string {
   }
 }
 
+function normalizeRemoteHostname(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '')
+    .replace(/\.+$/, '');
+  if (normalized.split('.').some((label) => label.length === 0)) return '';
+  return normalized;
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split('.').map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    a >= 224 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19))
+  );
+}
+
+function isBlockedRemoteHostname(hostname: string): boolean {
+  const normalized = normalizeRemoteHostname(hostname);
+  if (!normalized || !normalized.includes('.')) return true;
+  if (
+    normalized === 'localhost' ||
+    normalized === 'localhost.localdomain' ||
+    normalized === 'metadata.google.internal' ||
+    normalized.endsWith('.localhost') ||
+    normalized.endsWith('.local') ||
+    normalized.endsWith('.internal')
+  ) {
+    return true;
+  }
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(normalized)) return isPrivateIpv4(normalized);
+  if (normalized.includes(':')) return true;
+  return false;
+}
+
+function isAllowedRemoteMediaUrl(candidate: string): boolean {
+  try {
+    const parsed = new URL(candidate);
+    return (
+      parsed.protocol === 'https:' && !parsed.username && !parsed.password && !isBlockedRemoteHostname(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function resolveGatewayMediaSource(candidate: string, httpBase?: string): string | null {
+  try {
+    const parsed = new URL(candidate);
+    const base = httpBase ? new URL(httpBase) : null;
+    if (base && parsed.origin === base.origin && GATEWAY_MEDIA_PATH_RE.test(parsed.pathname)) return parsed.toString();
+    return null;
+  } catch {
+    if (!candidate.startsWith('/') || !GATEWAY_MEDIA_PATH_RE.test(candidate)) return null;
+    if (!httpBase) return null;
+    return new URL(candidate, httpBase).toString();
+  }
+}
+
 function mimeTypeFromSource(source: string, fallback?: string): string | undefined {
   if (fallback?.startsWith('image/')) return fallback;
   const lower = source.split(/[?#]/)[0]?.toLowerCase() ?? '';
@@ -67,7 +137,12 @@ function mimeTypeFromSource(source: string, fallback?: string): string | undefin
   return dataMatch?.[1] ?? fallback;
 }
 
-function attachmentFromMediaSource(source: string, alt?: string, mimeType?: string): MessageAttachment | null {
+function attachmentFromMediaSource(
+  source: string,
+  alt?: string,
+  mimeType?: string,
+  httpBase?: string,
+): MessageAttachment | null {
   const candidate = cleanMediaCandidate(source);
   if (!candidate || candidate.length > 4096 || hasUnsafePathSegment(candidate) || candidate.startsWith('~'))
     return null;
@@ -80,7 +155,17 @@ function attachmentFromMediaSource(source: string, alt?: string, mimeType?: stri
     };
   }
 
-  if (/^https:\/\//i.test(candidate) && IMAGE_EXT_RE.test(candidate)) {
+  const gatewayMedia = resolveGatewayMediaSource(candidate, httpBase);
+  if (gatewayMedia && (IMAGE_EXT_RE.test(gatewayMedia) || mimeType?.startsWith('image/'))) {
+    return {
+      fileName: alt?.trim() || fileNameFromSource(gatewayMedia, 'image.png'),
+      dataUrl: gatewayMedia,
+      mimeType: mimeTypeFromSource(gatewayMedia, mimeType),
+    };
+  }
+  if (candidate.startsWith('/') && GATEWAY_MEDIA_PATH_RE.test(candidate)) return null;
+
+  if (isAllowedRemoteMediaUrl(candidate) && (IMAGE_EXT_RE.test(candidate) || mimeType?.startsWith('image/'))) {
     return {
       fileName: alt?.trim() || fileNameFromSource(candidate, 'image.png'),
       dataUrl: candidate,
@@ -102,7 +187,7 @@ function attachmentFromMediaSource(source: string, alt?: string, mimeType?: stri
   return null;
 }
 
-function splitTextMediaDirectives(text: string): { text: string; attachments: MessageAttachment[] } {
+function splitTextMediaDirectives(text: string, httpBase?: string): { text: string; attachments: MessageAttachment[] } {
   const attachments: MessageAttachment[] = [];
   const kept: string[] = [];
   let inFence = false;
@@ -116,7 +201,7 @@ function splitTextMediaDirectives(text: string): { text: string; attachments: Me
     }
 
     if (!inFence && trimmed.toUpperCase().startsWith('MEDIA:')) {
-      const media = attachmentFromMediaSource(trimmed.slice('MEDIA:'.length));
+      const media = attachmentFromMediaSource(trimmed.slice('MEDIA:'.length), undefined, undefined, httpBase);
       if (media) {
         attachments.push(media);
         continue;
@@ -148,7 +233,10 @@ export function mergeMessageAttachments(
   return merged.length ? merged : undefined;
 }
 
-export function normalizeContentBlocks(blocks: RawContentBlock[]): {
+export function normalizeContentBlocks(
+  blocks: RawContentBlock[],
+  httpBase?: string,
+): {
   content: string;
   attachments?: MessageAttachment[];
 } {
@@ -157,16 +245,18 @@ export function normalizeContentBlocks(blocks: RawContentBlock[]): {
 
   for (const block of blocks) {
     if (block.type === 'text' && block.text) {
-      const parsed = splitTextMediaDirectives(block.text);
+      const parsed = splitTextMediaDirectives(block.text, httpBase);
       content += parsed.text;
       attachments = mergeMessageAttachments(attachments, parsed.attachments);
       continue;
     }
 
     if (block.type === 'image') {
-      const source = block.url ?? block.openUrl;
-      const attachment = source ? attachmentFromMediaSource(source, block.alt, block.mimeType) : null;
-      attachments = mergeMessageAttachments(attachments, attachment ? [attachment] : undefined);
+      const rawSource = block.url ?? block.openUrl;
+      if (rawSource) {
+        const attachment = attachmentFromMediaSource(rawSource, block.alt, block.mimeType, httpBase);
+        attachments = mergeMessageAttachments(attachments, attachment ? [attachment] : undefined);
+      }
     }
   }
 
@@ -225,7 +315,7 @@ function shouldStartVisibleAssistantTurn(
   return Boolean((turn?.content || turn?.attachments?.length) && turn.timestamp !== timestamp && !canMergeToolFinal);
 }
 
-export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): NormalizedAssistantTurn[] {
+export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[], httpBase?: string): NormalizedAssistantTurn[] {
   const messages = deduplicateRawHistoryMessages(rawMsgs);
   const toolResultMap = new Map<string, string>();
   for (const msg of messages) {
@@ -261,7 +351,7 @@ export function normalizeAssistantTurns(rawMsgs: RawHistoryMessage[]): Normalize
     if (msg.role !== 'assistant') continue;
 
     const timestamp = toISOTimestamp(msg.timestamp);
-    const normalizedContent = normalizeContentBlocks(msg.content ?? []);
+    const normalizedContent = normalizeContentBlocks(msg.content ?? [], httpBase);
     const text = normalizedContent.content;
     const toolCalls = (msg.content ?? [])
       .filter((block: RawContentBlock) => block.type === 'toolCall' && block.id && block.name)

--- a/packages/core/src/services/session-sync.ts
+++ b/packages/core/src/services/session-sync.ts
@@ -50,6 +50,7 @@ export interface SessionSyncDeps {
     }) => Promise<IpcResult>;
   };
   gateway: {
+    getHttpBase?: (gatewayId: string) => string | undefined | Promise<string | undefined>;
     chatHistory: (gatewayId: string, sessionKey: string, limit?: number) => Promise<IpcResult>;
     syncSessions: () => Promise<{
       ok: boolean;
@@ -232,6 +233,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
     const sessionKey = sessionKeyOverride ?? task?.sessionKey;
     if (!task?.gatewayId || !sessionKey) return;
 
+    const httpBase = await deps.gateway.getHttpBase?.(task.gatewayId);
     const res = await deps.gateway.chatHistory(task.gatewayId, sessionKey);
     if (!res.ok || !res.result) return;
 
@@ -249,7 +251,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
       undefined,
     );
 
-    const gatewayAssistant = normalizeAssistantTurns(rawMsgs);
+    const gatewayAssistant = normalizeAssistantTurns(rawMsgs, httpBase);
     backfillAssistantAttachments(taskId, sessionKey, gatewayAssistant);
 
     const newest = gatewayAssistant.filter(

--- a/packages/core/test/normalize-history.test.ts
+++ b/packages/core/test/normalize-history.test.ts
@@ -127,6 +127,80 @@ describe('normalizeAssistantTurns', () => {
     });
   });
 
+  it('resolves OpenClaw relative image blocks through the gateway HTTP base', () => {
+    const normalized = normalizeContentBlocks(
+      [
+        {
+          type: 'image',
+          url: '/api/chat/media/outgoing/agent%3Amain%3Amain/11111111-1111-4111-8111-111111111111/full',
+          alt: 'generated.png',
+          mimeType: 'image/png',
+        },
+      ],
+      'http://127.0.0.1:18789',
+    );
+
+    expect(normalized.attachments).toEqual([
+      {
+        fileName: 'generated.png',
+        dataUrl:
+          'http://127.0.0.1:18789/api/chat/media/outgoing/agent%3Amain%3Amain/11111111-1111-4111-8111-111111111111/full',
+        mimeType: 'image/png',
+      },
+    ]);
+  });
+
+  it('treats OpenClaw same-origin MEDIA paths as gateway media instead of local files', () => {
+    const normalized = normalizeContentBlocks(
+      [{ type: 'text', text: 'MEDIA:/media/inbound/test-image.png' }],
+      'http://127.0.0.1:18789',
+    );
+
+    expect(normalized.attachments).toEqual([
+      {
+        fileName: 'test-image.png',
+        dataUrl: 'http://127.0.0.1:18789/media/inbound/test-image.png',
+        mimeType: 'image/png',
+      },
+    ]);
+  });
+
+  it('does not treat OpenClaw gateway media paths as local files without an HTTP base', () => {
+    const normalized = normalizeContentBlocks([{ type: 'text', text: 'MEDIA:/media/inbound/test-image.png' }]);
+
+    expect(normalized).toEqual({ content: 'MEDIA:/media/inbound/test-image.png' });
+  });
+
+  it('rejects third-party HTTP image blocks even when MIME says image', () => {
+    const normalized = normalizeContentBlocks([
+      { type: 'image', url: 'http://example.com/result.png', alt: 'result.png', mimeType: 'image/png' },
+    ]);
+
+    expect(normalized).toEqual({ content: '' });
+  });
+
+  it('allows HTTP image blocks only on the configured gateway origin', () => {
+    const normalized = normalizeContentBlocks(
+      [
+        {
+          type: 'image',
+          url: 'http://127.0.0.1:18789/media/inbound/test-image.png',
+          alt: 'test-image.png',
+          mimeType: 'image/png',
+        },
+      ],
+      'http://127.0.0.1:18789',
+    );
+
+    expect(normalized.attachments).toEqual([
+      {
+        fileName: 'test-image.png',
+        dataUrl: 'http://127.0.0.1:18789/media/inbound/test-image.png',
+        mimeType: 'image/png',
+      },
+    ]);
+  });
+
   it('preserves media-only assistant turns', () => {
     const rawMsgs: RawHistoryMessage[] = [
       {

--- a/packages/desktop/src/main/artifact/auto-extract.ts
+++ b/packages/desktop/src/main/artifact/auto-extract.ts
@@ -17,6 +17,7 @@ interface AutoExtractParams {
   messageId: string;
   content: string;
   attachments?: MessageAttachment[];
+  gatewayHttpBase?: string;
 }
 
 const DATA_IMAGE_RE = /^data:(image\/(?:png|jpe?g|gif|webp|avif));base64,(.+)$/i;
@@ -58,7 +59,7 @@ function safeImageFileName(fileName: string | undefined, mimeType: string | unde
   return `${clean || 'image'}.${ext}`;
 }
 
-async function readAttachmentImage(attachment: MessageAttachment): Promise<Buffer | null> {
+async function readAttachmentImage(attachment: MessageAttachment, trustedOrigin?: string): Promise<Buffer | null> {
   if (attachment.sourcePath) {
     const base64 = await readOpenClawMediaFile(attachment.sourcePath);
     return base64 ? Buffer.from(base64, 'base64') : null;
@@ -67,15 +68,15 @@ async function readAttachmentImage(attachment: MessageAttachment): Promise<Buffe
   const dataMatch = attachment.dataUrl.match(DATA_IMAGE_RE);
   if (dataMatch) return Buffer.from(dataMatch[2], 'base64');
 
-  if (/^https:\/\//i.test(attachment.dataUrl)) {
-    return safeFetch(attachment.dataUrl);
+  if (/^https?:\/\//i.test(attachment.dataUrl)) {
+    return safeFetch(attachment.dataUrl, { trustedOrigin });
   }
 
   return null;
 }
 
 async function doAutoExtractArtifacts(params: AutoExtractParams): Promise<void> {
-  const { workspacePath, taskId, messageId, content, attachments = [] } = params;
+  const { workspacePath, taskId, messageId, content, attachments = [], gatewayHttpBase } = params;
 
   const db = getDb();
   const existingForMsg = db.select().from(artifacts).where(eq(artifacts.messageId, messageId)).all();
@@ -164,7 +165,7 @@ async function doAutoExtractArtifacts(params: AutoExtractParams): Promise<void> 
       if (attachment.mimeType && !attachment.mimeType.startsWith('image/')) continue;
       const key = sourceKey('attachment', attachment.sourcePath ?? attachment.dataUrl);
       if (existingSourceKeys.has(key)) continue;
-      const buffer = await readAttachmentImage(attachment);
+      const buffer = await readAttachmentImage(attachment, gatewayHttpBase);
       if (!buffer) continue;
       const fileName = safeImageFileName(attachment.fileName, attachment.mimeType);
       await saveExtracted({

--- a/packages/desktop/src/main/ipc/data-handlers.ts
+++ b/packages/desktop/src/main/ipc/data-handlers.ts
@@ -5,6 +5,7 @@ import { tasks, messages, artifacts, taskRooms, taskRoomSessions, teams, teamAge
 import { autoExtractArtifacts } from '../artifact/auto-extract.js';
 import type { MessageAttachment } from '@clawwork/shared';
 import { getWorkspacePath } from '../workspace/config.js';
+import { getGatewayClient } from '../ws/index.js';
 
 function ipcError(err: unknown): { ok: false; error: string } {
   return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
@@ -188,12 +189,15 @@ export function registerDataHandlers(): void {
         if (msg.role === 'assistant' && (msg.content.length > 0 || (msg.attachments?.length ?? 0) > 0)) {
           const workspacePath = getWorkspacePath();
           if (workspacePath) {
+            const taskRow = db.select({ gid: tasks.gatewayId }).from(tasks).where(eq(tasks.id, msg.taskId)).get();
+            const gatewayHttpBase = taskRow ? getGatewayClient(taskRow.gid)?.httpBase : undefined;
             autoExtractArtifacts({
               workspacePath,
               taskId: msg.taskId,
               messageId: persistedMessageId,
               content: msg.content,
               attachments: msg.attachments as MessageAttachment[] | undefined,
+              gatewayHttpBase,
             }).catch((err: unknown) => console.error('[auto-extract]', err));
           }
         }

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -89,6 +89,7 @@ interface ChatHistoryPayload {
 }
 
 const INTERNAL_ASSISTANT_MARKERS = new Set(['NO_REPLY']);
+const RELATIVE_GATEWAY_MEDIA_PATH_RE = /^\/(?:api\/chat\/media\/outgoing\/|media\/|__openclaw__\/media\/)/;
 
 /** Parsed tool call for transport to renderer */
 interface ParsedToolCall {
@@ -109,10 +110,10 @@ function resolveRelativeImageUrls(messages: Record<string, unknown>[], httpBase:
       if (typeof block !== 'object' || block === null) continue;
       const imageBlock = block as Record<string, unknown>;
       if (imageBlock.type !== 'image') continue;
-      if (typeof imageBlock.url === 'string' && imageBlock.url.startsWith('/')) {
+      if (typeof imageBlock.url === 'string' && RELATIVE_GATEWAY_MEDIA_PATH_RE.test(imageBlock.url)) {
         imageBlock.url = new URL(imageBlock.url, httpBase).toString();
       }
-      if (typeof imageBlock.openUrl === 'string' && imageBlock.openUrl.startsWith('/')) {
+      if (typeof imageBlock.openUrl === 'string' && RELATIVE_GATEWAY_MEDIA_PATH_RE.test(imageBlock.openUrl)) {
         imageBlock.openUrl = new URL(imageBlock.openUrl, httpBase).toString();
       }
     }

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -101,7 +101,30 @@ interface ParsedToolCall {
   completedAt?: string;
 }
 
+function resolveRelativeImageUrls(messages: Record<string, unknown>[], httpBase: string): void {
+  for (const msg of messages) {
+    const blocks = msg.content;
+    if (!Array.isArray(blocks)) continue;
+    for (const block of blocks) {
+      if (typeof block !== 'object' || block === null) continue;
+      const imageBlock = block as Record<string, unknown>;
+      if (imageBlock.type !== 'image') continue;
+      if (typeof imageBlock.url === 'string' && imageBlock.url.startsWith('/')) {
+        imageBlock.url = new URL(imageBlock.url, httpBase).toString();
+      }
+      if (typeof imageBlock.openUrl === 'string' && imageBlock.openUrl.startsWith('/')) {
+        imageBlock.openUrl = new URL(imageBlock.openUrl, httpBase).toString();
+      }
+    }
+  }
+}
+
 export function registerWsHandlers(): void {
+  ipcMain.handle('ws:get-http-base', async (_event, payload: { gatewayId: string }) => {
+    const gw = getGatewayClient(payload.gatewayId);
+    return gw?.httpBase;
+  });
+
   ipcMain.handle(
     'ws:send-message',
     async (
@@ -176,7 +199,12 @@ export function registerWsHandlers(): void {
         return { ok: false, error: 'gateway not connected' };
       }
       try {
-        const result = await gw.getChatHistory(payload.sessionKey, payload.limit);
+        const result = (await gw.getChatHistory(payload.sessionKey, payload.limit)) as Record<string, unknown> & {
+          messages?: Record<string, unknown>[];
+        };
+        if (result?.messages?.length) {
+          resolveRelativeImageUrls(result.messages, gw.httpBase);
+        }
         return { ok: true, result };
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'unknown error';
@@ -311,7 +339,7 @@ export function registerWsHandlers(): void {
             .map((m) => {
               const normalizedContent =
                 m.role === 'assistant'
-                  ? normalizeContentBlocks(m.content ?? [])
+                  ? normalizeContentBlocks(m.content ?? [], gw.httpBase)
                   : {
                       content: (m.content ?? [])
                         .filter((b) => b.type === 'text' && b.text)

--- a/packages/desktop/src/main/net/safe-fetch.ts
+++ b/packages/desktop/src/main/net/safe-fetch.ts
@@ -7,12 +7,23 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 interface SafeFetchOptions {
   maxSize?: number;
   timeoutMs?: number;
+  trustedOrigin?: string;
+}
+
+function isSameOrigin(parsed: URL, trustedOrigin?: string): boolean {
+  if (!trustedOrigin) return false;
+  try {
+    return parsed.origin === new URL(trustedOrigin).origin;
+  } catch {
+    return false;
+  }
 }
 
 export async function safeFetch(url: string, opts: SafeFetchOptions = {}): Promise<Buffer> {
   const parsed = new URL(url);
-  if (parsed.protocol !== 'https:') throw new Error('HTTPS required');
-  await assertNotPrivateHost(parsed.hostname);
+  const isTrustedOrigin = isSameOrigin(parsed, opts.trustedOrigin);
+  if (parsed.protocol !== 'https:' && !isTrustedOrigin) throw new Error('HTTPS required');
+  if (!isTrustedOrigin) await assertNotPrivateHost(parsed.hostname);
 
   const maxSize = opts.maxSize ?? DEFAULT_MAX_SIZE;
   const controller = new AbortController();

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -780,6 +780,12 @@ export class GatewayClient {
     return this.lastErrorCode;
   }
 
+  get httpBase(): string {
+    const parsed = new URL(this.wsUrl);
+    const protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+    return `${protocol}//${parsed.host}`;
+  }
+
   get version(): string | undefined {
     return this.serverVersion;
   }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -234,6 +234,7 @@ interface ListResult<T> {
 type ChatAttachment = SharedChatAttachment;
 
 export interface ClawWorkAPI {
+  getHttpBase: (gatewayId: string) => Promise<string | undefined>;
   sendMessage: (
     gatewayId: string,
     sessionKey: string,

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -17,6 +17,7 @@ import type { ClawWorkAPI, GatewayServerConfig } from './clawwork';
 
 function buildApi(): ClawWorkAPI {
   return {
+    getHttpBase: (gatewayId: string) => ipcRenderer.invoke('ws:get-http-base', { gatewayId }),
     sendMessage: (
       gatewayId: string,
       sessionKey: string,

--- a/packages/desktop/src/renderer/platform/electron-adapter.ts
+++ b/packages/desktop/src/renderer/platform/electron-adapter.ts
@@ -13,6 +13,7 @@ export function createElectronPorts(): PlatformPorts {
       deleteTask: api.deleteTask,
     },
     gateway: {
+      getHttpBase: api.getHttpBase,
       sendMessage: api.sendMessage,
       chatHistory: api.chatHistory,
       abortChat: api.abortChat,

--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -36,6 +36,23 @@ describe('safeFetch', () => {
     expect(netFetchMock).not.toHaveBeenCalled();
   });
 
+  it('allows HTTP only for the configured trusted origin', async () => {
+    const body = new ArrayBuffer(4);
+    netFetchMock.mockResolvedValue(mockResponse(body));
+
+    await safeFetch('http://127.0.0.1:18789/media/test.png', { trustedOrigin: 'http://127.0.0.1:18789/' });
+    expect(assertNotPrivateHostMock).not.toHaveBeenCalled();
+    expect(netFetchMock).toHaveBeenCalled();
+  });
+
+  it('treats malformed trusted origins as untrusted', async () => {
+    await expect(
+      safeFetch('http://127.0.0.1:18789/media/test.png', { trustedOrigin: 'http://[invalid' }),
+    ).rejects.toThrow('HTTPS required');
+    expect(assertNotPrivateHostMock).not.toHaveBeenCalled();
+    expect(netFetchMock).not.toHaveBeenCalled();
+  });
+
   it('calls assertNotPrivateHost with parsed hostname', async () => {
     assertNotPrivateHostMock.mockResolvedValue(undefined);
     const body = new ArrayBuffer(4);

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -10,9 +10,11 @@ const setConfigMock = vi.fn();
 const patchConfigMock = vi.fn();
 const getConfigSchemaMock = vi.fn();
 const lookupConfigSchemaMock = vi.fn();
+const getChatHistoryMock = vi.fn();
 
 const fakeGatewayClient = {
   isConnected: true,
+  httpBase: 'http://127.0.0.1:18789',
   installSkill: installSkillMock,
   updateSkill: updateSkillMock,
   getSkillBins: getSkillBinsMock,
@@ -21,6 +23,7 @@ const fakeGatewayClient = {
   patchConfig: patchConfigMock,
   getConfigSchema: getConfigSchemaMock,
   lookupConfigSchema: lookupConfigSchemaMock,
+  getChatHistory: getChatHistoryMock,
 };
 
 vi.mock('electron', () => ({
@@ -67,6 +70,7 @@ describe('ws-handlers: skills + config IPC channels', () => {
   beforeEach(async () => {
     handleMap.clear();
     vi.clearAllMocks();
+    getChatHistoryMock.mockReset();
     fakeGatewayClient.isConnected = true;
 
     vi.resetModules();
@@ -122,6 +126,37 @@ describe('ws-handlers: skills + config IPC channels', () => {
         errorCode: 'INSTALL_ERROR',
         errorDetails: { bin: 'npm', reason: 'not found' },
       });
+    });
+  });
+
+  describe('ws:chat-history', () => {
+    it('resolves only OpenClaw media paths against the gateway origin', async () => {
+      getChatHistoryMock.mockResolvedValue({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'image', url: '/media/out.png', openUrl: '/api/chat/media/outgoing/open.png' },
+              { type: 'image', url: '/Users/x/out.png', openUrl: '/tmp/open.png' },
+              { type: 'image', url: '/__openclaw__/media/screenshot.png' },
+            ],
+          },
+        ],
+      });
+
+      const response = (await invoke('ws:chat-history', {
+        gatewayId: 'gw-1',
+        sessionKey: 'agent:main:clawwork:task:t1',
+      })) as { ok: boolean; result: { messages: { content: Record<string, unknown>[] }[] } };
+
+      expect(response.ok).toBe(true);
+      const content = response.result.messages[0].content;
+      expect(content[0]).toMatchObject({
+        url: 'http://127.0.0.1:18789/media/out.png',
+        openUrl: 'http://127.0.0.1:18789/api/chat/media/outgoing/open.png',
+      });
+      expect(content[1]).toMatchObject({ url: '/Users/x/out.png', openUrl: '/tmp/open.png' });
+      expect(content[2]).toMatchObject({ url: 'http://127.0.0.1:18789/__openclaw__/media/screenshot.png' });
     });
   });
 

--- a/packages/pwa/src/gateway/client.ts
+++ b/packages/pwa/src/gateway/client.ts
@@ -101,6 +101,12 @@ export class BrowserGatewayClient {
     return this.gatewayName;
   }
 
+  get httpBase(): string {
+    const parsed = new URL(this.url);
+    const protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+    return `${protocol}//${parsed.host}`;
+  }
+
   get isConnected(): boolean {
     return this.state === 'connected' && this.ws?.readyState === WebSocket.OPEN;
   }

--- a/packages/pwa/src/platform/gateway-adapter.ts
+++ b/packages/pwa/src/platform/gateway-adapter.ts
@@ -110,6 +110,9 @@ export function createBrowserGatewayTransport(
   }
 
   const transport: GatewayTransportPort = {
+    getHttpBase(gatewayId) {
+      return getClient(gatewayId)?.httpBase;
+    },
     async sendMessage(gatewayId, sessionKey, content, attachments) {
       const client = getClient(gatewayId);
       if (!client?.isConnected)


### PR DESCRIPTION
## Summary

Resolve OpenClaw media attachments through the configured gateway HTTP origin so ClawWork can render and extract media when OpenClaw and ClawWork are not deployed at the same filesystem location.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

OpenClaw can emit managed media as relative gateway URLs such as `/api/chat/media/outgoing/...` or `/media/...`. ClawWork previously treated media too locally, which fails when ClawWork and OpenClaw run in different deployment locations. This keeps explicit OpenClaw media URLs gateway-relative while preserving SSRF protections for arbitrary remote media.

## What changed?

- Added gateway HTTP base propagation through desktop, PWA, and core session sync paths.
- Resolved explicit OpenClaw gateway media paths against the configured gateway HTTP origin.
- Allowed HTTP fetching only for exact trusted gateway origins while keeping non-gateway remote media HTTPS-only and SSRF-guarded.
- Added regression coverage for gateway media paths, third-party HTTP rejection, trusted gateway fetches, and malformed trusted origins.

## Architecture impact

- Owning layer: core / main / preload / renderer
- Cross-layer impact: yes. The gateway transport now exposes an optional HTTP base so core history normalization can resolve OpenClaw-managed media without knowing platform-specific gateway clients.
- Invariants touched from `docs/architecture-invariants.md`: gateway/session transport boundaries and SSRF-safe media handling.
- Why those invariants remain protected: core receives only the gateway HTTP origin through the existing port boundary; main-process fetching still goes through `safeFetch`, which preserves HTTPS and private-host checks except for exact configured gateway origin matches.

## Linked issues

Closes #

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm --filter @clawwork/core test -- normalize-history.test.ts
pnpm --filter @clawwork/desktop test -- safe-fetch.test.ts
pnpm --filter @clawwork/core exec tsc --noEmit -p tsconfig.test.json
pnpm check
pre-ship --staged
pre-ship --committed
```

## Screenshots or recordings

No UI layout or renderer styling changes.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Fix OpenClaw media attachments so gateway-relative images load when ClawWork and OpenClaw run from different locations.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate