### PR TITLE
chore: add reviewer routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,20 +1,8 @@
-- @samzong
+* @samzong
 
-/AGENTS.md @samzong
-/DEVELOPMENT.md @samzong
-/CLAUDE.md @samzong
-/CONTRIBUTING.md @samzong
-/docs/openclaw-desktop-design.md @samzong
+/OWNERS @samzong
+/.github/** @samzong
 
-/packages/shared/src/** @samzong
-/packages/desktop/src/main/ws/** @samzong
-/packages/desktop/src/main/ipc/** @samzong
-/packages/desktop/src/main/artifact/** @samzong
-/packages/desktop/src/main/workspace/** @samzong
-/packages/desktop/src/main/context/** @samzong
-/packages/desktop/src/preload/** @samzong
-/packages/desktop/src/renderer/styles/** @samzong
-
-/.github/workflows/** @samzong
-/.github/PULL_REQUEST_TEMPLATE.md @samzong
-/.github/ISSUE_TEMPLATE/** @samzong
+/packages/core/** @samzong
+/packages/desktop/** @samzong @HiddenPuppy @mvanhorn
+/packages/shared/** @samzong

--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -57,6 +57,8 @@ env:
   REVIEWERS: |-
     samzong
     yankay
+    HiddenPuppy
+    mvanhorn
 
   APPROVERS: |-
     samzong

--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,5 @@ approvers:
 reviewers:
   - samzong
   - yankay
+  - HiddenPuppy
+  - mvanhorn


### PR DESCRIPTION
## Summary

This PR adds @HiddenPuppy and @mvanhorn to the reviewer flow without expanding approver or merge authority.

## Changes

- Add @HiddenPuppy and @mvanhorn to the `OWNERS` reviewer list.
- Add both users to the `gh-ci-bot` `REVIEWERS` pool.
- Simplify CODEOWNERS around work groups:
  - repository default, `.github/**`, `OWNERS`, `packages/core/**`, and `packages/shared/**` stay with @samzong
  - `packages/desktop/**` requests @samzong, @HiddenPuppy, and @mvanhorn

## Notes

This is reviewer routing only. `APPROVERS` is unchanged, so `/approve`, `/merge`, and related maintainer actions remain limited to the existing approvers.

@mvanhorn currently has read access, so CODEOWNERS review requests for him will only become effective after a repository collaborator invite grants write access. @HiddenPuppy already has write access.

## Validation

- `git diff --cached --check`
- `git diff --check`
- YAML parse for `OWNERS` and `.github/workflows/ci-bot.yml`
- pre-commit ran `prettier --write` and `node scripts/check-architecture.mjs`
