### PR TITLE
[Docs] Add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Desktop client for [OpenClaw](https://github.com/openclaw/openclaw) — run agen
 [![GitHub release](https://img.shields.io/github/v/release/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork/releases/latest)
 [![License](https://img.shields.io/github/license/clawwork-ai/clawwork?style=flat-square)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/clawwork-ai/clawwork?style=flat-square)](https://github.com/clawwork-ai/clawwork)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/n9fCgBMgm)
 
 [Download](#download) · [**PWA**](https://cpwa.pages.dev) · [Quick start](#quick-start) · [Teams](#teams) · [What you get](#what-you-get) · [Data & architecture](#data--architecture) · [Repo layout](#repo-layout) · [Roadmap](#roadmap) · [Contributing](#contributing) · [Keynote](https://clawwork-ai.github.io/ClawWork/keynote/)
 


### PR DESCRIPTION
## Summary

Adds a Discord community badge to the README header so visitors can find the ClawWork community server more easily.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [x] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The Discord invite was easy to miss as a plain navigation link. A badge places it beside the existing project badges at the top of the README.

## What changed?

- Added a Discord `Join Community` shields badge linking to the ClawWork Discord invite.

## Architecture impact

- Owning layer: docs
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: README-only change; no runtime, IPC, persistence, or UI architecture code changed.

## Linked issues

None

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm check
```

## Screenshots or recordings

README-only badge change. No app UI screenshots required.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate