### PR TITLE
fix(debug): buffer events before initDebugLogger and replay on init (#412)

### DIFF
--- a/packages/desktop/src/main/debug/index.ts
+++ b/packages/desktop/src/main/debug/index.ts
@@ -1,15 +1,45 @@
 import { BrowserWindow } from 'electron';
 import type { DebugEvent } from '@clawwork/shared';
-import type { DebugLogger } from './logger.js';
+import type { DebugLogger, LogEventInput } from './logger.js';
 import { createDebugLogger } from './logger.js';
 
-const noop = (): DebugEvent => ({ ts: '', level: 'debug', domain: 'app', event: '' }) as DebugEvent;
+// Pre-init buffer: 50+ getDebugLogger() call sites can fire during early
+// boot before initDebugLogger runs; the previous noop fallback dropped
+// those events silently, hiding the exact errors that matter most. Cache
+// up to PRE_INIT_BUFFER_LIMIT events and replay them through the real
+// logger when init lands. Cap protects against unbounded allocation if
+// init is delayed or never happens.
+const PRE_INIT_BUFFER_LIMIT = 256;
+type PreInitCall =
+  | { kind: 'debug' | 'info' | 'warn' | 'error'; input: LogEventInput }
+  | { kind: 'log'; input: LogEventInput & { level: DebugEvent['level'] } };
+const preInitBuffer: PreInitCall[] = [];
+let preInitOverflowed = false;
+
+function record(call: PreInitCall): DebugEvent {
+  if (preInitBuffer.length < PRE_INIT_BUFFER_LIMIT) {
+    preInitBuffer.push(call);
+  } else if (!preInitOverflowed) {
+    preInitOverflowed = true;
+    console.warn(
+      `[debug] pre-init buffer cap (${PRE_INIT_BUFFER_LIMIT}) reached; ` +
+        'further events before initDebugLogger will be dropped.',
+    );
+  }
+  return {
+    ts: new Date().toISOString(),
+    level: call.kind === 'log' ? call.input.level : call.kind,
+    domain: call.input.domain,
+    event: call.input.event,
+  } as DebugEvent;
+}
+
 let debugLogger: DebugLogger = {
-  debug: noop,
-  info: noop,
-  warn: noop,
-  error: noop,
-  log: noop,
+  debug: (input) => record({ kind: 'debug', input }),
+  info: (input) => record({ kind: 'info', input }),
+  warn: (input) => record({ kind: 'warn', input }),
+  error: (input) => record({ kind: 'error', input }),
+  log: (input) => record({ kind: 'log', input }),
   getRecentEvents: () => [],
   currentFilePath: () => '',
 };
@@ -20,6 +50,16 @@ export function initDebugLogger(debugDir: string): DebugLogger {
     console: true,
     onEvent: broadcastDebugEvent,
   });
+  // Replay any events that were captured before init landed.
+  for (const call of preInitBuffer) {
+    if (call.kind === 'log') {
+      debugLogger.log(call.input);
+    } else {
+      debugLogger[call.kind](call.input);
+    }
+  }
+  preInitBuffer.length = 0;
+  preInitOverflowed = false;
   return debugLogger;
 }
 

--- a/packages/desktop/src/main/debug/index.ts
+++ b/packages/desktop/src/main/debug/index.ts
@@ -1,24 +1,21 @@
 import { BrowserWindow } from 'electron';
-import type { DebugEvent } from '@clawwork/shared';
+import { sanitizeForLog, type DebugEvent } from '@clawwork/shared';
 import type { DebugLogger, LogEventInput } from './logger.js';
 import { createDebugLogger } from './logger.js';
 
-// Pre-init buffer: 50+ getDebugLogger() call sites can fire during early
-// boot before initDebugLogger runs; the previous noop fallback dropped
-// those events silently, hiding the exact errors that matter most. Cache
-// up to PRE_INIT_BUFFER_LIMIT events and replay them through the real
-// logger when init lands. Cap protects against unbounded allocation if
-// init is delayed or never happens.
 const PRE_INIT_BUFFER_LIMIT = 256;
-type PreInitCall =
-  | { kind: 'debug' | 'info' | 'warn' | 'error'; input: LogEventInput }
-  | { kind: 'log'; input: LogEventInput & { level: DebugEvent['level'] } };
-const preInitBuffer: PreInitCall[] = [];
+const preInitBuffer: DebugEvent[] = [];
 let preInitOverflowed = false;
 
-function record(call: PreInitCall): DebugEvent {
+function record(level: DebugEvent['level'], input: LogEventInput): DebugEvent {
+  const event = sanitizeForLog({
+    ...input,
+    ts: new Date().toISOString(),
+    level,
+  });
+
   if (preInitBuffer.length < PRE_INIT_BUFFER_LIMIT) {
-    preInitBuffer.push(call);
+    preInitBuffer.push(event);
   } else if (!preInitOverflowed) {
     preInitOverflowed = true;
     console.warn(
@@ -26,20 +23,15 @@ function record(call: PreInitCall): DebugEvent {
         'further events before initDebugLogger will be dropped.',
     );
   }
-  return {
-    ts: new Date().toISOString(),
-    level: call.kind === 'log' ? call.input.level : call.kind,
-    domain: call.input.domain,
-    event: call.input.event,
-  } as DebugEvent;
+  return event;
 }
 
 let debugLogger: DebugLogger = {
-  debug: (input) => record({ kind: 'debug', input }),
-  info: (input) => record({ kind: 'info', input }),
-  warn: (input) => record({ kind: 'warn', input }),
-  error: (input) => record({ kind: 'error', input }),
-  log: (input) => record({ kind: 'log', input }),
+  debug: (input) => record('debug', input),
+  info: (input) => record('info', input),
+  warn: (input) => record('warn', input),
+  error: (input) => record('error', input),
+  log: (input) => record(input.level, input),
   getRecentEvents: () => [],
   currentFilePath: () => '',
 };
@@ -50,13 +42,8 @@ export function initDebugLogger(debugDir: string): DebugLogger {
     console: true,
     onEvent: broadcastDebugEvent,
   });
-  // Replay any events that were captured before init landed.
-  for (const call of preInitBuffer) {
-    if (call.kind === 'log') {
-      debugLogger.log(call.input);
-    } else {
-      debugLogger[call.kind](call.input);
-    }
+  for (const event of preInitBuffer) {
+    debugLogger.log(event);
   }
   preInitBuffer.length = 0;
   preInitOverflowed = false;

--- a/packages/desktop/test/debug-pre-init-buffer.test.ts
+++ b/packages/desktop/test/debug-pre-init-buffer.test.ts
@@ -1,13 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock electron BrowserWindow up-front so importing the module under test doesn't
-// hit the real electron native binding.
 vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: () => [] },
 }));
 
-// The debug module is module-level singleton state, so we re-import via dynamic
-// import inside each test to get a fresh copy of the buffer.
 async function loadDebugModule() {
   vi.resetModules();
   return await import('../src/main/debug/index.js');
@@ -29,12 +25,19 @@ describe('debug logger pre-init buffer (#412)', () => {
     const { getDebugLogger, initDebugLogger } = debugModule;
 
     const logger = getDebugLogger();
-    const beforeInit = logger.error({ domain: 'app', event: 'pre-init-error' });
+    const beforeInit = logger.error({
+      domain: 'app',
+      event: 'pre-init-error',
+      traceId: 'trace-1',
+      error: { message: 'boom' },
+      data: { token: 'secret-token', ok: true },
+    });
 
     expect(beforeInit.event).toBe('pre-init-error');
     expect(beforeInit.level).toBe('error');
+    expect(beforeInit.traceId).toBe('trace-1');
+    expect(beforeInit.data).toEqual({ token: '***redacted***', ok: true });
 
-    // Init with a temp dir; the real logger writes ndjson to a file there.
     const os = await import('node:os');
     const fs = await import('node:fs');
     const path = await import('node:path');
@@ -42,9 +45,15 @@ describe('debug logger pre-init buffer (#412)', () => {
 
     const realLogger = initDebugLogger(tmp);
     const recent = realLogger.getRecentEvents();
-    expect(recent.some((e) => e.event === 'pre-init-error' && e.level === 'error')).toBe(true);
+    const replayed = recent.find((e) => e.event === 'pre-init-error');
+    expect(replayed).toMatchObject({
+      ts: beforeInit.ts,
+      level: 'error',
+      traceId: 'trace-1',
+      data: { token: '***redacted***', ok: true },
+      error: { message: 'boom' },
+    });
 
-    // Subsequent calls go directly to the real logger.
     realLogger.info({ domain: 'app', event: 'post-init-info' });
     expect(realLogger.getRecentEvents().some((e) => e.event === 'post-init-info')).toBe(true);
   });
@@ -53,26 +62,19 @@ describe('debug logger pre-init buffer (#412)', () => {
     const { getDebugLogger, initDebugLogger } = await loadDebugModule();
     const logger = getDebugLogger();
 
-    // Slam in more than 256 events to trip the cap.
     for (let i = 0; i < 300; i++) {
       logger.debug({ domain: 'app', event: `evt-${i}` });
     }
 
-    // Warn fires exactly once even though many events overflowed.
-    const warnCalls = consoleWarnSpy.mock.calls.filter((c) =>
-      String(c[0]).includes('pre-init buffer cap'),
-    );
+    const warnCalls = consoleWarnSpy.mock.calls.filter((c) => String(c[0]).includes('pre-init buffer cap'));
     expect(warnCalls).toHaveLength(1);
 
-    // Init flushes only the first 256.
     const os = await import('node:os');
     const fs = await import('node:fs');
     const path = await import('node:path');
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-debug-'));
     const realLogger = initDebugLogger(tmp);
-    const replayedBuffered = realLogger
-      .getRecentEvents()
-      .filter((e) => /^evt-\d+$/.test(e.event));
+    const replayedBuffered = realLogger.getRecentEvents().filter((e) => /^evt-\d+$/.test(e.event));
     expect(replayedBuffered.length).toBe(256);
   });
 });

--- a/packages/desktop/test/debug-pre-init-buffer.test.ts
+++ b/packages/desktop/test/debug-pre-init-buffer.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock electron BrowserWindow up-front so importing the module under test doesn't
+// hit the real electron native binding.
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+// The debug module is module-level singleton state, so we re-import via dynamic
+// import inside each test to get a fresh copy of the buffer.
+async function loadDebugModule() {
+  vi.resetModules();
+  return await import('../src/main/debug/index.js');
+}
+
+describe('debug logger pre-init buffer (#412)', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('captures events before initDebugLogger and replays them on init', async () => {
+    const debugModule = await loadDebugModule();
+    const { getDebugLogger, initDebugLogger } = debugModule;
+
+    const logger = getDebugLogger();
+    const beforeInit = logger.error({ domain: 'app', event: 'pre-init-error' });
+
+    expect(beforeInit.event).toBe('pre-init-error');
+    expect(beforeInit.level).toBe('error');
+
+    // Init with a temp dir; the real logger writes ndjson to a file there.
+    const os = await import('node:os');
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-debug-'));
+
+    const realLogger = initDebugLogger(tmp);
+    const recent = realLogger.getRecentEvents();
+    expect(recent.some((e) => e.event === 'pre-init-error' && e.level === 'error')).toBe(true);
+
+    // Subsequent calls go directly to the real logger.
+    realLogger.info({ domain: 'app', event: 'post-init-info' });
+    expect(realLogger.getRecentEvents().some((e) => e.event === 'post-init-info')).toBe(true);
+  });
+
+  it('stops buffering past PRE_INIT_BUFFER_LIMIT and warns once', async () => {
+    const { getDebugLogger, initDebugLogger } = await loadDebugModule();
+    const logger = getDebugLogger();
+
+    // Slam in more than 256 events to trip the cap.
+    for (let i = 0; i < 300; i++) {
+      logger.debug({ domain: 'app', event: `evt-${i}` });
+    }
+
+    // Warn fires exactly once even though many events overflowed.
+    const warnCalls = consoleWarnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('pre-init buffer cap'),
+    );
+    expect(warnCalls).toHaveLength(1);
+
+    // Init flushes only the first 256.
+    const os = await import('node:os');
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-debug-'));
+    const realLogger = initDebugLogger(tmp);
+    const replayedBuffered = realLogger
+      .getRecentEvents()
+      .filter((e) => /^evt-\d+$/.test(e.event));
+    expect(replayedBuffered.length).toBe(256);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #412. The module-level ``debugLogger`` in ``packages/desktop/src/main/debug/index.ts`` was a set of stub no-ops until ``initDebugLogger`` ran. With ~50 ``getDebugLogger()`` call sites across gateway-client, auto-updater, tray, quick-launch, and workspace init, any event fired during the early-boot window was silently dropped — which is exactly the window where boot-time errors matter most.

## Change

Took the issue's option 2 (buffer + replay):

- Replace the noop fallback with shims that record each call into a ``preInitBuffer`` (capped at ``PRE_INIT_BUFFER_LIMIT = 256`` to bound allocation if init is delayed or never lands).
- ``initDebugLogger`` flushes the buffer through the real logger after it's installed, then clears the buffer.
- If the cap is reached, emit a single ``console.warn`` so a developer running with a stuck init sees that further events are being dropped.

The recorded shape preserves enough of ``DebugEvent`` for callers that use the return value (e.g. ``ts``, ``level``, ``domain``, ``event``); the full event record materialises during replay through ``createDebugLogger``.

## Test plan

- [x] ``pnpm --filter @clawwork/desktop test debug-pre-init-buffer`` — 2 passed
- [x] New ``test/debug-pre-init-buffer.test.ts``:
  - ``captures events before initDebugLogger and replays them on init`` — fires ``error`` pre-init, calls ``initDebugLogger(tmpdir)``, asserts the event reappears in ``getRecentEvents()``; also checks the post-init path still works directly
  - ``stops buffering past PRE_INIT_BUFFER_LIMIT and warns once`` — fires 300 events, asserts ``console.warn`` fires exactly once with the cap message and that exactly 256 events are replayed on init