### PR TITLE
[Build] Default CI bot merges to squash

### DIFF
--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -68,6 +68,7 @@ env:
 
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_REPOSITORY: ${{ github.repository }}
+  DEFAULT_MERGE_METHOD: squash
   DETAILS: |-
 
     <details>


### PR DESCRIPTION
## Summary

Set `DEFAULT_MERGE_METHOD` to `squash` for the gh-ci-bot workflow.

## Why

The repository disables merge commits while gh-ci-bot defaults to `merge` when auto-merging after `lgtm` and `approved` labels are both present. That caused auto-merge to fail even after checks passed.

## Validation

- `pnpm exec prettier --check .github/workflows/ci-bot.yml`
- `pnpm check`

## Release note

```release-note
NONE
```