### PR TITLE
[Fix] Handle fetchAgentMeta failure and floating Promise.all in AgentsSection

### DIFF
--- a/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
@@ -699,14 +699,19 @@ export default function AgentsSection() {
     async (agentId: string) => {
       if (!selectedGatewayId) return;
       setLoadingFilesFor(agentId);
-      const res = await window.clawwork.listAgentFiles(selectedGatewayId, agentId);
-      setLoadingFilesFor(null);
-      if (res.ok && res.result) {
-        const data = res.result as unknown as { workspace?: string; files: AgentFileEntry[] };
-        setAgentFilesMap((prev) => (prev[agentId] ? prev : { ...prev, [agentId]: data.files ?? [] }));
-        if (data.workspace) {
-          setAgentWorkspaceMap((prev) => (prev[agentId] ? prev : { ...prev, [agentId]: data.workspace as string }));
+      try {
+        const res = await window.clawwork.listAgentFiles(selectedGatewayId, agentId);
+        if (res.ok && res.result) {
+          const data = res.result as unknown as { workspace?: string; files: AgentFileEntry[] };
+          setAgentFilesMap((prev) => (prev[agentId] ? prev : { ...prev, [agentId]: data.files ?? [] }));
+          if (data.workspace) {
+            setAgentWorkspaceMap((prev) => (prev[agentId] ? prev : { ...prev, [agentId]: data.workspace as string }));
+          }
         }
+      } catch (err) {
+        console.error('AgentsSection: fetchAgentMeta failed', { agentId, err });
+      } finally {
+        setLoadingFilesFor((current) => (current === agentId ? null : current));
       }
     },
     [selectedGatewayId],
@@ -751,7 +756,9 @@ export default function AgentsSection() {
   useEffect(() => {
     if (!selectedGatewayId || agents.length === 0) return;
     const ids = agents.map((a) => a.id);
-    Promise.all(ids.map((id) => fetchAgentMeta(id)));
+    void Promise.all(ids.map((id) => fetchAgentMeta(id))).catch((err) => {
+      console.error('AgentsSection: agent meta fetch batch failed', err);
+    });
   }, [selectedGatewayId, agents, fetchAgentMeta]);
 
   const openAddForm = useCallback(() => {


### PR DESCRIPTION
## Summary

`AgentsSection.fetchAgentMeta` awaits `window.clawwork.listAgentFiles(...)` without try/catch and is fired from a `useEffect` Promise.all with no `.catch`, so an IPC failure both escapes as an unhandled renderer rejection and leaves the agent stuck in the loading state forever (the success-path `setLoadingFilesFor(null)` never runs). This PR catches the failure, clears the loading id with the same race-safe predicate `fetchAgentSkills` already uses, and explicitly handles the floating Promise.all in the discovery effect.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Issue #401 documents two failure modes when the IPC call rejects: a renderer-wide unhandled promise rejection (or strict-mode tab crash) and a permanently stuck `loadingFilesFor` because the cleanup ran on the success branch only. The sibling `fetchAgentSkills` in the same file already shows the desired pattern with a guarded `setLoadingSkillsFor((current) => current === agentId ? null : current)` that protects against a slow earlier call wiping out the loading id of a newer one. This PR brings `fetchAgentMeta` in line and adds the same defensive shape at the call site so any rejection that does escape gets logged rather than swallowed.

## What changed?

The body of `fetchAgentMeta` is now wrapped in `try { ... } catch { ... } finally { ... }`. The success branch is unchanged. The catch logs to `console.error` with the failing `agentId` so the surface is debuggable. The finally clears `loadingFilesFor` using the same race-safe predicate `fetchAgentSkills` already uses, so a slower earlier call cannot wipe the loading id of a newer one. At the call site, the bare `Promise.all(ids.map((id) => fetchAgentMeta(id)));` in the agent-discovery effect is replaced with `void Promise.all(...).catch((err) => console.error(...))` so any rejection that escapes the per-call try/catch gets surfaced rather than silently leaked, and the explicit promise handling is visible to lint configurations that treat floating promises as a problem.

## Architecture impact

The change lives entirely inside the renderer layer at `packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx`. There is no cross-layer impact: no preload bridge changes, no main-process changes, no shared-type changes. The IPC contract (`window.clawwork.listAgentFiles`) is unchanged because this PR only adds error-handling around an existing call. No invariants from `docs/architecture-invariants.md` are touched, so none need re-justifying.

## Linked issues

Closes #401

## Validation

- [x] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Ran `pnpm exec eslint packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx --max-warnings 0` and got a clean exit. The change is purely error-handling around an existing async call path; UI markup, layout, spacing, and component states are untouched, so `pnpm check:ui-contract` is not relevant here.

```text
$ pnpm exec eslint packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx --max-warnings 0
(no output, exit 0)
```

## Screenshots or recordings

No UI changes. The visible behaviour difference is that an agent whose `listAgentFiles` IPC throws no longer stays in the loading spinner forever and no longer prints an unhandled-rejection warning to the renderer console.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
