### PR TITLE
fix(net): prevent SSRF bypass via redirect in safeFetch

### DIFF
--- a/packages/desktop/src/main/net/safe-fetch.ts
+++ b/packages/desktop/src/main/net/safe-fetch.ts
@@ -29,7 +29,7 @@ export async function safeFetch(url: string, opts: SafeFetchOptions = {}): Promi
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   try {
-    const res = await net.fetch(url, { signal: controller.signal });
+    const res = await net.fetch(url, { signal: controller.signal, redirect: 'error' });
     if (!res.ok) throw new Error(`fetch ${url}: ${res.status}`);
     const cl = Number(res.headers.get('content-length') ?? '0');
     if (cl > maxSize) throw new Error('response too large');

--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -99,4 +99,12 @@ describe('safeFetch', () => {
 
     await expect(safeFetch('https://cdn.example.com/missing.png')).rejects.toThrow('404');
   });
+
+  it('passes redirect:error to net.fetch to prevent SSRF bypass via 3xx', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(undefined);
+    netFetchMock.mockResolvedValue(mockResponse(new ArrayBuffer(4)));
+
+    await safeFetch('https://cdn.example.com/img.png');
+    expect(netFetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ redirect: 'error' }));
+  });
 });


### PR DESCRIPTION
## Problem

`safeFetch` runs SSRF guards (HTTPS-only check + `assertNotPrivateHost`) against the initial URL, then calls `net.fetch(url)` without setting `redirect`. Electron's `net.fetch` follows HTTP redirects (3xx) by default — the second request goes completely unchecked. An attacker-controlled HTTPS endpoint can respond with `302 Location: http://127.0.0.1/admin` and bypass the SSRF guard entirely. Protocol downgrade (HTTPS → HTTP) is also allowed for the same reason.

## Fix

Pass `redirect: 'error'` to `net.fetch()` so any 3xx response throws immediately instead of being followed. This is the simplest and safest option — `safeFetch` fetches static assets (images, files) that should never redirect through untrusted hops.

## Verification

- `pnpm check` passes (49 test files, 308 tests, all guards)
- Unit test: asserts `net.fetch` is called with `{ redirect: 'error' }`

Closes #406
