### PR TITLE
fix(net): stream safeFetch body with incremental maxSize enforcement

### DIFF
--- a/packages/desktop/src/main/net/safe-fetch.ts
+++ b/packages/desktop/src/main/net/safe-fetch.ts
@@ -44,7 +44,7 @@ export async function safeFetch(url: string, opts: SafeFetchOptions = {}): Promi
   try {
     // When the IP is pinned, pass the original hostname as the Host header
     // so the server (and TLS SNI in Chromium) knows which virtual host to serve.
-    const fetchOpts: Record<string, unknown> = { signal: controller.signal };
+    const fetchOpts: Record<string, unknown> = { signal: controller.signal, redirect: 'error' };
     if (fetchUrl !== url) {
       fetchOpts.headers = { Host: parsed.hostname };
     }
@@ -52,9 +52,23 @@ export async function safeFetch(url: string, opts: SafeFetchOptions = {}): Promi
     if (!res.ok) throw new Error(`fetch ${url}: ${res.status}`);
     const cl = Number(res.headers.get('content-length') ?? '0');
     if (cl > maxSize) throw new Error('response too large');
-    const ab = await res.arrayBuffer();
-    if (ab.byteLength > maxSize) throw new Error('response too large');
-    return Buffer.from(ab);
+
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error('no body');
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxSize) {
+        controller.abort();
+        throw new Error('response too large');
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks.map((c) => Buffer.from(c)));
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/desktop/src/main/net/safe-fetch.ts
+++ b/packages/desktop/src/main/net/safe-fetch.ts
@@ -29,7 +29,7 @@ export async function safeFetch(url: string, opts: SafeFetchOptions = {}): Promi
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   try {
-    const res = await net.fetch(url, { signal: controller.signal });
+    const res = await net.fetch(url, { signal: controller.signal, redirect: 'error' });
     if (!res.ok) throw new Error(`fetch ${url}: ${res.status}`);
     const cl = Number(res.headers.get('content-length') ?? '0');
     if (cl > maxSize) throw new Error('response too large');

--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -37,12 +37,31 @@ beforeEach(() => {
   lastFetchOpts = undefined;
 });
 
+function streamReaderFrom(body: ArrayBuffer, chunkSize = 1024): ReadableStreamDefaultReader<Uint8Array> {
+  const u8 = new Uint8Array(body);
+  let offset = 0;
+  return {
+    read: async () => {
+      if (offset >= u8.length) return { done: true as const, value: undefined };
+      const end = Math.min(offset + chunkSize, u8.length);
+      const value = u8.slice(offset, end);
+      offset = end;
+      return { done: false as const, value };
+    },
+    cancel: async () => {},
+    releaseLock: () => {},
+    closed: Promise.resolve(undefined),
+  } as ReadableStreamDefaultReader<Uint8Array>;
+}
+
 function mockResponse(body: ArrayBuffer, status = 200, headers: Record<string, string> = {}): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
     headers: new Headers(headers),
-    arrayBuffer: () => Promise.resolve(body),
+    body: {
+      getReader: () => streamReaderFrom(body),
+    },
   } as unknown as Response;
 }
 
@@ -144,5 +163,39 @@ describe('safeFetch', () => {
     netFetchMock.mockResolvedValue(mockResponse(new ArrayBuffer(0), 404));
 
     await expect(safeFetch('https://cdn.example.com/missing.png')).rejects.toThrow('404');
+  });
+
+  it('passes redirect:error to net.fetch to prevent SSRF bypass via 3xx', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(null);
+    mockFetchWithTracking();
+
+    await safeFetch('https://cdn.example.com/img.png');
+    expect(lastFetchOpts).toEqual(expect.objectContaining({ redirect: 'error' }));
+  });
+
+  it('enforces maxSize incrementally during streaming — no content-length', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(null);
+    const big = new ArrayBuffer(10 * 1024 * 1024 + 1);
+    netFetchMock.mockResolvedValue(mockResponse(big, 200, {}));
+
+    await expect(safeFetch('https://cdn.example.com/streaming.bin')).rejects.toThrow('too large');
+  });
+
+  it('handles empty response body', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(null);
+    netFetchMock.mockResolvedValue(mockResponse(new ArrayBuffer(0)));
+
+    const buf = await safeFetch('https://cdn.example.com/empty.bin');
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.length).toBe(0);
+  });
+
+  it('reads multi-chunk body correctly', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(null);
+    const data = new TextEncoder().encode('hello world').buffer;
+    netFetchMock.mockResolvedValue(mockResponse(data, 200, {}));
+
+    const buf = await safeFetch('https://cdn.example.com/hello.bin');
+    expect(buf.toString()).toBe('hello world');
   });
 });

--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -99,4 +99,12 @@ describe('safeFetch', () => {
 
     await expect(safeFetch('https://cdn.example.com/missing.png')).rejects.toThrow('404');
   });
+
+  it('passes redirect:error to net.fetch to prevent SSRF bypass via 3xx', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(undefined);
+    netFetchMock.mockResolvedValue(mockResponse(new ArrayBuffer(4)));
+
+    await safeFetch('https://cdn.example.com/img.png');
+    expect(netFetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ redirect: 'error' }));
+  });
 });


### PR DESCRIPTION
## Problem

`safeFetch` enforces `maxSize` after `await res.arrayBuffer()` has already buffered the entire response body into memory. A malicious server can omit or lie about `content-length` and stream an endless body, causing the main process to consume gigabytes of memory and OOM crash the entire Electron app.

## Fix

Replace `res.arrayBuffer()` with a streaming reader (`res.body.getReader()`) that accumulates chunks incrementally and **aborts the fetch** as soon as the accumulated byte count exceeds `maxSize`. The `content-length` header pre-check is kept as a cheap short-circuit for well-behaved servers.

## Verification

- `pnpm check` passes (49 test files, 311 tests)
- New tests cover: empty response, multi-chunk body, streaming beyond maxSize without content-length header

Closes #408
