### PR TITLE
fix: refresh renderer stores after workspace change

### DIFF
--- a/packages/desktop/src/main/ipc/workspace-handlers.ts
+++ b/packages/desktop/src/main/ipc/workspace-handlers.ts
@@ -59,6 +59,8 @@ export function registerWorkspaceHandlers(): void {
       await migrateWorkspace(oldPath, newWorkspacePath);
       reinitDatabase(newWorkspacePath);
       updateConfig({ workspacePath: newWorkspacePath });
+      const win = BrowserWindow.getAllWindows()[0];
+      if (win) win.webContents.send('workspace:changed', newWorkspacePath);
       return { ok: true };
     } catch (err) {
       reinitDatabase(oldPath);

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -352,6 +352,7 @@ export interface ClawWorkAPI {
   browseWorkspace: () => Promise<string | null>;
   setupWorkspace: (path: string) => Promise<IpcResult>;
   changeWorkspace: (path: string) => Promise<IpcResult>;
+  onWorkspaceChanged: (callback: (newPath: string) => void) => () => void;
 
   getSettings: () => Promise<AppSettings | null>;
   updateSettings: (partial: Partial<AppSettings>) => Promise<{ ok: boolean; config: AppSettings }>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -348,6 +348,16 @@ function buildApi(): ClawWorkAPI {
 
     setWindowButtonVisibility: (visible: boolean) => ipcRenderer.send('ui:set-window-button-visibility', visible),
 
+    onWorkspaceChanged: (callback) => {
+      const listener = (_event: Electron.IpcRendererEvent, newPath: string): void => {
+        callback(newPath);
+      };
+      ipcRenderer.on('workspace:changed', listener);
+      return () => {
+        ipcRenderer.removeListener('workspace:changed', listener);
+      };
+    },
+
     getDeviceId: () => ipcRenderer.invoke('workspace:get-device-id') as Promise<string>,
 
     selectContextFolder: () => ipcRenderer.invoke('context:select-folder'),

--- a/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
@@ -1,4 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useTaskStore, useMessageStore } from '@/platform';
+import { useDashboardStore } from '@/stores/dashboardStore';
+import { useUsageStore } from '@/stores/usageStore';
+import { useApprovalStore } from '@/stores/approvalStore';
 import { MonitorDot, Zap, FolderOpen, Loader2, ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@/lib/toast';
@@ -63,6 +67,21 @@ export default function SystemSection() {
     },
     [quickLaunchShortcut, t],
   );
+
+  useEffect(() => {
+    return window.clawwork.onWorkspaceChanged(async () => {
+      useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+      await useTaskStore.getState().hydrate();
+
+      useMessageStore.setState({ messagesByTask: {}, activeTurnBySession: {}, processingBySession: new Set() });
+
+      useDashboardStore.getState().clear();
+      useUsageStore.getState().clear();
+      useApprovalStore.getState().clear();
+
+      await refreshSettings().catch(() => {});
+    });
+  }, [refreshSettings]);
 
   const handleChangeWorkspace = useCallback(async () => {
     let selected: string | null = null;


### PR DESCRIPTION
## Summary

When the user changes workspace via SystemSection, the main process re-initializes the database for the new path, but the renderer's Zustand stores (task, message, dashboard, usage, approval) still hold stale data from the old workspace. The user would see a blank or incorrect task list and would need to manually refresh or relaunch.

## Changes

- **Main process** (`workspace-handlers.ts`): After reinitDatabase + updateConfig succeed, emit a `workspace:changed` IPC event to the renderer window with the new workspace path
- **Preload** (`index.ts` + `clawwork.d.ts`): Expose `onWorkspaceChanged(callback)` that subscribes to the IPC event and returns an unsubscribe function
- **Renderer** (`SystemSection.tsx`): A useEffect subscribes to onWorkspaceChanged. On receipt:
  - Clears task store + re-calls hydrate() to load from new DB
  - Clears message store (messages, active turns, processing set)
  - Clears dashboard, usage, and approval caches
  - Re-fetches settings from the backend

## Testing

- `pnpm typecheck` — passes
- `pnpm test` — all 311 tests pass (49 test files)
- Architecture guardrails — all 4 rules pass

Fixes clawwork-ai/ClawWork#404