### PR TITLE
[Build] Publish release before Homebrew update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,14 +118,14 @@ jobs:
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
 
-          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $RUNNER_TEMP/certificate.p12
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o "$RUNNER_TEMP/certificate.p12"
 
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security import $RUNNER_TEMP/certificate.p12 -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/certificate.p12" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
 
           echo "✅ Certificate imported successfully"
 
@@ -212,6 +212,7 @@ jobs:
       pull-requests: read
     env:
       RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+      IS_PRERELEASE: ${{ needs.prepare-release.outputs.is_prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -257,11 +258,37 @@ jobs:
             echo "Release body already populated — leaving it alone"
           fi
 
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            gh release edit "$RELEASE_TAG" --repo ${{ github.repository }} --draft=false --prerelease
+          else
+            gh release edit "$RELEASE_TAG" --repo ${{ github.repository }} --draft=false --latest
+          fi
+
   update-homebrew:
-    needs: [prepare-release, release, verify-release]
+    needs: [prepare-release, publish-release-notes]
     if: ${{ needs.prepare-release.outputs.is_prerelease != 'true' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Verify release is public
+        run: |
+          for attempt in {1..12}; do
+            is_draft="$(gh release view "$RELEASE_TAG" --repo clawwork-ai/clawwork --json isDraft --jq .isDraft 2>/dev/null || true)"
+            if [ "$is_draft" = "false" ]; then
+              exit 0
+            fi
+            echo "Release is not public yet; waiting ($attempt/12)"
+            sleep 5
+          done
+          gh release view "$RELEASE_TAG" --repo clawwork-ai/clawwork --json isDraft --jq .isDraft
+          exit 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+
       - name: Trigger Homebrew tap update
         run: |
           gh workflow run update-homebrew.yml \


### PR DESCRIPTION
## Summary

Publish GitHub Releases before dispatching the Homebrew tap update so the tap workflow can resolve public release assets.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [x] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

The stable release flow dispatched `update-homebrew.yml` while electron-builder's GitHub Release was still a draft. The tap update then could not see the public release or macOS DMG assets.

## What changed?

- Publish the GitHub Release after release notes are generated and before Homebrew dispatch.
- Gate the Homebrew dispatch on `isDraft=false`.
- Quote macOS signing paths so `actionlint`/shellcheck passes cleanly.

## Architecture impact

- Owning layer: build/release workflow
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: this only changes GitHub Actions release ordering and shell quoting.

## Linked issues

None.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
pnpm exec prettier --check .github/workflows/release.yml
actionlint .github/workflows/release.yml
git diff HEAD~1..HEAD --check
```

## Screenshots or recordings

Not UI-facing.

If the change touches renderer styles, layout, spacing, component states, or interaction polish, explain which tokens, variables, states, or `pnpm check:ui-contract` rules were intentionally preserved or changed.

Not applicable.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
