### PR TITLE
[Fix] Use stable base for stable release notes

### DIFF
--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -50,6 +50,15 @@ function sh(cmd, { allowFail = false } = {}) {
   }
 }
 
+function isStableTag(ref) {
+  return /^v\d+\.\d+\.\d+$/.test(ref);
+}
+
+function previousTag(head) {
+  const prereleaseFilter = isStableTag(head) ? " --exclude 'v*-*'" : '';
+  return sh(`git describe --tags --abbrev=0${prereleaseFilter} ${head}^`, { allowFail: true });
+}
+
 function parseArgs() {
   const args = argv.slice(2);
   if (args.includes('--help') || args.includes('-h')) {
@@ -58,7 +67,8 @@ function parseArgs() {
         'Usage: node scripts/generate-release-notes.mjs [RANGE]',
         '',
         'RANGE forms:',
-        '  v0.0.14                previous tag..v0.0.14',
+        '  v0.0.15                previous stable tag..v0.0.15',
+        '  v0.0.15-beta.4         previous tag..v0.0.15-beta.4',
         '  v0.0.13..v0.0.14       explicit range',
         '  (no arg)               previous tag..HEAD',
         '',
@@ -74,12 +84,12 @@ function parseArgs() {
   let head;
   if (!arg) {
     head = 'HEAD';
-    base = sh('git describe --tags --abbrev=0 HEAD^', { allowFail: true });
+    base = previousTag(head);
   } else if (arg.includes('..')) {
     [base, head] = arg.split('..');
   } else {
     head = arg;
-    base = sh(`git describe --tags --abbrev=0 ${head}^`, { allowFail: true });
+    base = previousTag(head);
   }
   if (!base || !head) {
     stderr.write('error: could not resolve base..head range\n');


### PR DESCRIPTION
## Summary

Fix release note range resolution so stable tags use the previous stable tag as the base, while prerelease tags continue to use the previous tag.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Stable release notes for tags like `v0.0.15` should summarize changes since the previous stable release, not only since the latest beta tag. Beta release notes should still use the previous prerelease tag.

## What changed?

- Added stable-tag detection for `vX.Y.Z` release refs.
- Added a shared previous-tag resolver that excludes prerelease tags only for stable release refs.
- Updated CLI help examples to show stable and prerelease range behavior.

## Architecture impact

- Owning layer: scripts
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: this only updates a release note helper script and does not affect application layers or runtime imports.

## Linked issues

N/A

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
node scripts/generate-release-notes.mjs --help
# Passed; help now documents stable and prerelease examples.

node scripts/generate-release-notes.mjs v0.0.15 > /tmp/clawwork-release-notes-v0.0.15-after-commit.md
# Passed; stderr showed range: v0.0.14..v0.0.15.
# Existing fallback warning: unresolved gh PR API lookup for #325.

node scripts/generate-release-notes.mjs v0.0.15-beta.4 > /tmp/clawwork-release-notes-v0.0.15-beta.4-after-commit.md
# Passed; stderr showed range: v0.0.15-beta.3..v0.0.15-beta.4.

pnpm exec prettier --check scripts/generate-release-notes.mjs
# Passed.

pnpm exec eslint scripts/generate-release-notes.mjs
# Exited 0 with warning: file ignored by eslint ignore pattern.

pre-commit hook
# Ran eslint --fix, prettier --write, and pnpm check:architecture successfully.
```

## Screenshots or recordings

N/A. This change affects release note script behavior only.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate