### PR TITLE
[Fix] Support self-signed Gateway TLS

### DIFF
--- a/packages/desktop/src/main/ipc/settings-handlers.ts
+++ b/packages/desktop/src/main/ipc/settings-handlers.ts
@@ -38,7 +38,13 @@ export function registerSettingsHandlers(): void {
       config.defaultGatewayId = gateway.id;
     }
     writeConfig(config);
-    addGateway({ id: gateway.id, name: gateway.name, url: gateway.url, auth: buildGatewayAuth(gateway) });
+    addGateway({
+      id: gateway.id,
+      name: gateway.name,
+      url: gateway.url,
+      auth: buildGatewayAuth(gateway),
+      tlsVerify: gateway.tlsVerify,
+    });
     return { ok: true };
   });
 
@@ -70,7 +76,7 @@ export function registerSettingsHandlers(): void {
       const client = getGatewayClient(gatewayId);
       if (client) {
         const gw = config.gateways[idx];
-        client.updateConfig({ url: gw.url, auth: buildGatewayAuth(gw) });
+        client.updateConfig({ url: gw.url, auth: buildGatewayAuth(gw), tlsVerify: gw.tlsVerify });
       }
       return { ok: true, gateway: config.gateways[idx] };
     },
@@ -89,7 +95,11 @@ export function registerSettingsHandlers(): void {
 
   ipcMain.handle(
     'settings:test-gateway',
-    async (_event, url: string, auth: { token?: string; password?: string; pairingCode?: string }) => {
+    async (
+      _event,
+      url: string,
+      auth: { token?: string; password?: string; pairingCode?: string; tlsVerify?: boolean },
+    ) => {
       if (auth.pairingCode) {
         return { ok: false, error: 'pairing-code test is not supported' };
       }
@@ -99,7 +109,7 @@ export function registerSettingsHandlers(): void {
           ? { password: auth.password.trim() }
           : { token: '' };
       const testClient = new GatewayClient(
-        { id: `test-${Date.now()}`, name: 'test', url: url.trim(), auth: testAuth },
+        { id: `test-${Date.now()}`, name: 'test', url: url.trim(), auth: testAuth, tlsVerify: auth.tlsVerify },
         { noReconnect: true },
       );
       try {

--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -14,6 +14,7 @@ export interface GatewayServerConfig {
   password?: string;
   pairingCode?: string;
   authMode?: 'token' | 'password' | 'pairingCode';
+  tlsVerify?: boolean;
   isDefault?: boolean;
   color?: string;
 }

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'ws';
+import WebSocket, { type ClientOptions } from 'ws';
 import { app } from 'electron';
 import { randomUUID } from 'crypto';
 import {
@@ -50,6 +50,15 @@ type PendingReq = {
 
 const REQ_TIMEOUT_MS = 15_000;
 
+function isSecureGatewayWebSocketUrl(raw: string): boolean {
+  try {
+    const protocol = new URL(raw.trim()).protocol;
+    return protocol === 'wss:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export class GatewayClient {
   private ws: WebSocket | null = null;
   private authenticated = false;
@@ -61,6 +70,7 @@ export class GatewayClient {
   private noReconnect = false;
   private wsUrl: string;
   private auth: GatewayAuth;
+  private tlsVerify: boolean;
   private gatewayId: string;
   private gatewayName: string;
   private connectNonce: string | null = null;
@@ -75,6 +85,7 @@ export class GatewayClient {
     this.gatewayName = config.name;
     this.wsUrl = config.url;
     this.auth = config.auth;
+    this.tlsVerify = config.tlsVerify !== false;
     this.deviceIdentity = loadOrCreateDeviceIdentity();
     if (opts?.noReconnect) this.noReconnect = true;
     this.onPairingSuccess = opts?.onPairingSuccess;
@@ -93,6 +104,7 @@ export class GatewayClient {
     if (config.name !== undefined) this.gatewayName = config.name;
     if (config.url !== undefined) this.wsUrl = config.url;
     if (config.auth !== undefined) this.auth = config.auth;
+    if (config.tlsVerify !== undefined) this.tlsVerify = config.tlsVerify !== false;
     this.reconnectAttempts = 0;
     this.connect();
   }
@@ -110,7 +122,11 @@ export class GatewayClient {
       attempt: this.reconnectAttempts + 1,
       data: { wsUrl: this.wsUrl },
     });
-    this.ws = new WebSocket(this.wsUrl, { handshakeTimeout: WS_HANDSHAKE_TIMEOUT_MS });
+    const wsOptions: ClientOptions = { handshakeTimeout: WS_HANDSHAKE_TIMEOUT_MS };
+    if (isSecureGatewayWebSocketUrl(this.wsUrl) && !this.tlsVerify) {
+      wsOptions.rejectUnauthorized = false;
+    }
+    this.ws = new WebSocket(this.wsUrl, wsOptions);
 
     this.ws.on('open', () => {
       getDebugLogger().info({
@@ -782,7 +798,7 @@ export class GatewayClient {
 
   get httpBase(): string {
     const parsed = new URL(this.wsUrl);
-    const protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+    const protocol = parsed.protocol === 'wss:' || parsed.protocol === 'https:' ? 'https:' : 'http:';
     return `${protocol}//${parsed.host}`;
   }
 

--- a/packages/desktop/src/main/ws/index.ts
+++ b/packages/desktop/src/main/ws/index.ts
@@ -17,7 +17,13 @@ export function initAllGateways(): void {
   const config = readConfig();
   const gateways = config?.gateways ?? [];
   for (const gw of gateways) {
-    const client = createGatewayClient({ id: gw.id, name: gw.name, url: gw.url, auth: buildGatewayAuth(gw) });
+    const client = createGatewayClient({
+      id: gw.id,
+      name: gw.name,
+      url: gw.url,
+      auth: buildGatewayAuth(gw),
+      tlsVerify: gw.tlsVerify,
+    });
     client.connect();
     gatewayClients.set(gw.id, client);
   }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -82,6 +82,7 @@ export interface GatewayServerConfig {
   password?: string;
   pairingCode?: string;
   authMode?: 'token' | 'password' | 'pairingCode';
+  tlsVerify?: boolean;
   isDefault?: boolean;
   color?: string;
 }
@@ -370,7 +371,10 @@ export interface ClawWorkAPI {
   removeGateway: (gatewayId: string) => Promise<IpcResult>;
   updateGateway: (gatewayId: string, partial: Partial<GatewayServerConfig>) => Promise<IpcResult>;
   setDefaultGateway: (gatewayId: string) => Promise<IpcResult>;
-  testGateway: (url: string, auth: { token?: string; password?: string; pairingCode?: string }) => Promise<IpcResult>;
+  testGateway: (
+    url: string,
+    auth: { token?: string; password?: string; pairingCode?: string; tlsVerify?: boolean },
+  ) => Promise<IpcResult>;
 
   getAppVersion: () => Promise<string>;
   checkForUpdates: () => Promise<UpdateCheckResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -179,8 +179,10 @@ function buildApi(): ClawWorkAPI {
     updateGateway: (gatewayId: string, partial: Partial<GatewayServerConfig>) =>
       ipcRenderer.invoke('settings:update-gateway', gatewayId, partial),
     setDefaultGateway: (gatewayId: string) => ipcRenderer.invoke('settings:set-default-gateway', gatewayId),
-    testGateway: (url: string, auth: { token?: string; password?: string; pairingCode?: string }) =>
-      ipcRenderer.invoke('settings:test-gateway', url, auth),
+    testGateway: (
+      url: string,
+      auth: { token?: string; password?: string; pairingCode?: string; tlsVerify?: boolean },
+    ) => ipcRenderer.invoke('settings:test-gateway', url, auth),
 
     getAppVersion: () => ipcRenderer.invoke('app:get-version'),
     checkForUpdates: () => ipcRenderer.invoke('app:check-for-updates'),

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -631,6 +631,8 @@
     "theme": "Design",
     "themeAuto": "Automatisch",
     "themeUpdated": "Design aktualisiert",
+    "tlsVerify": "TLS-Zertifikat prüfen",
+    "tlsVerifyHint": "Nur für vertrauenswürdige private Gateways mit selbstsignierten Zertifikaten deaktivieren.",
     "token": "Token",
     "tokenPlaceholder": "Gateway-Token",
     "tokenRequired": "Token ist erforderlich",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -631,6 +631,8 @@
     "theme": "Theme",
     "themeAuto": "Auto",
     "themeUpdated": "Theme updated",
+    "tlsVerify": "Verify TLS certificate",
+    "tlsVerifyHint": "Turn off only for trusted private gateways with self-signed certificates.",
     "token": "Token",
     "tokenPlaceholder": "Gateway token",
     "tokenRequired": "Token is required",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -631,6 +631,8 @@
     "theme": "Tema",
     "themeAuto": "Automático",
     "themeUpdated": "Tema actualizado",
+    "tlsVerify": "Verificar certificado TLS",
+    "tlsVerifyHint": "Desactívalo solo para gateways privados de confianza con certificados autofirmados.",
     "token": "Token",
     "tokenPlaceholder": "Token del Gateway",
     "tokenRequired": "El Token es obligatorio",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -631,6 +631,8 @@
     "theme": "テーマ",
     "themeAuto": "自動",
     "themeUpdated": "テーマを更新しました",
+    "tlsVerify": "TLS 証明書を検証",
+    "tlsVerifyHint": "信頼済みのプライベート Gateway で自己署名証明書を使う場合のみオフにしてください。",
     "token": "トークン",
     "tokenPlaceholder": "ゲートウェイトークン",
     "tokenRequired": "トークンは必須です",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -631,6 +631,8 @@
     "theme": "테마",
     "themeAuto": "자동",
     "themeUpdated": "테마가 변경되었습니다",
+    "tlsVerify": "TLS 인증서 확인",
+    "tlsVerifyHint": "신뢰할 수 있는 사설 게이트웨이의 자체 서명 인증서에만 끄세요.",
     "token": "토큰",
     "tokenPlaceholder": "게이트웨이 토큰",
     "tokenRequired": "토큰을 입력해 주세요",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -631,6 +631,8 @@
     "theme": "Tema",
     "themeAuto": "Automático",
     "themeUpdated": "Tema atualizado",
+    "tlsVerify": "Verificar certificado TLS",
+    "tlsVerifyHint": "Desative apenas para gateways privados confiáveis com certificados autoassinados.",
     "token": "Token",
     "tokenPlaceholder": "Token do Gateway",
     "tokenRequired": "O Token é obrigatório",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -631,6 +631,8 @@
     "theme": "主題",
     "themeAuto": "自動",
     "themeUpdated": "主題已更新",
+    "tlsVerify": "驗證 TLS 憑證",
+    "tlsVerifyHint": "僅在可信任的私有 Gateway 使用自簽憑證時關閉。",
     "token": "Token",
     "tokenPlaceholder": "Gateway Token",
     "tokenRequired": "請輸入 Token",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -631,6 +631,8 @@
     "theme": "主题",
     "themeAuto": "自动",
     "themeUpdated": "主题已更新",
+    "tlsVerify": "校验 TLS 证书",
+    "tlsVerifyHint": "仅在可信私有网关使用自签名证书时关闭。",
     "token": "Token",
     "tokenPlaceholder": "Gateway Token",
     "tokenRequired": "Token 不能为空",

--- a/packages/desktop/src/renderer/layouts/Settings/components/Toggle.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/components/Toggle.tsx
@@ -4,11 +4,14 @@ export default function Toggle({
   checked,
   onChange,
   ariaLabel,
+  size = 'md',
 }: {
   checked: boolean;
   onChange: (v: boolean) => void;
   ariaLabel?: string;
+  size?: 'sm' | 'md';
 }) {
+  const isSmall = size === 'sm';
   return (
     <button
       type="button"
@@ -17,16 +20,18 @@ export default function Toggle({
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
       className={cn(
-        'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full p-0.5 transition-colors duration-200',
+        'relative inline-flex flex-shrink-0 cursor-pointer rounded-full p-0.5 transition-colors duration-200',
+        isSmall ? 'h-5 w-9' : 'h-6 w-11',
         'focus-visible:outline-none glow-focus',
         checked ? 'bg-[var(--accent)]' : 'bg-[var(--bg-tertiary)] border border-[var(--border)]',
       )}
     >
       <span
         className={cn(
-          'pointer-events-none block h-5 w-5 rounded-full bg-[var(--bg-elevated)] shadow-[var(--shadow-card)]',
+          'pointer-events-none block rounded-full bg-[var(--bg-elevated)] shadow-[var(--shadow-card)]',
           'transition-transform duration-200',
-          checked ? 'translate-x-5' : 'translate-x-0',
+          isSmall ? 'h-4 w-4' : 'h-5 w-5',
+          checked ? (isSmall ? 'translate-x-4' : 'translate-x-5') : 'translate-x-0',
         )}
       />
     </button>

--- a/packages/desktop/src/renderer/layouts/Settings/sections/GatewaysSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GatewaysSection.tsx
@@ -26,8 +26,10 @@ import EmptyState from '@/components/semantic/EmptyState';
 import InlineNotice from '@/components/semantic/InlineNotice';
 import SettingGroup from '@/components/semantic/SettingGroup';
 import ToolbarButton from '@/components/semantic/ToolbarButton';
+import Toggle from '../components/Toggle';
 import {
   inferGatewayAuthMode,
+  isWssGatewayUrl,
   parseGatewaySetupCode,
   validateGatewayForm,
   type GatewayAuthMode,
@@ -42,6 +44,7 @@ interface GatewayFormData {
   password: string;
   pairingCode: string;
   authMode?: GatewayAuthMode;
+  tlsVerify: boolean;
 }
 
 interface GatewayServerConfig {
@@ -52,6 +55,7 @@ interface GatewayServerConfig {
   password?: string;
   pairingCode?: string;
   authMode?: GatewayAuthMode;
+  tlsVerify?: boolean;
   isDefault?: boolean;
   color?: string;
   type?: GatewayType;
@@ -64,6 +68,7 @@ const EMPTY_FORM: GatewayFormData = {
   password: '',
   pairingCode: '',
   authMode: 'token',
+  tlsVerify: true,
 };
 
 const STATUS_ICON: Record<GatewayConnectionStatus, { icon: typeof CheckCircle2; color: string }> = {
@@ -258,6 +263,7 @@ function GatewayForm({
         : t('settings.pairingCodePlaceholder');
 
   const authValue = authMode === 'token' ? form.token : authMode === 'password' ? form.password : form.pairingCode;
+  const showTlsVerify = isWssGatewayUrl(form.url);
 
   const handleAuthChange = (v: string) => {
     if (authMode === 'token') setForm((f) => ({ ...f, token: v }));
@@ -326,6 +332,20 @@ function GatewayForm({
               onChange={(e) => setForm((f) => ({ ...f, url: e.target.value }))}
               placeholder="ws://127.0.0.1:18789"
               className={cn(inputClass, 'w-full')}
+            />
+          </div>
+        )}
+        {showTlsVerify && (
+          <div className="flex items-start justify-between gap-3 py-1">
+            <div className="min-w-0">
+              <div className="type-label text-[var(--text-secondary)]">{t('settings.tlsVerify')}</div>
+              <p className="type-support mt-1 text-[var(--text-muted)]">{t('settings.tlsVerifyHint')}</p>
+            </div>
+            <Toggle
+              checked={form.tlsVerify}
+              onChange={(checked) => setForm((f) => ({ ...f, tlsVerify: checked }))}
+              ariaLabel={t('settings.tlsVerify')}
+              size="sm"
             />
           </div>
         )}
@@ -457,6 +477,7 @@ export default function GatewaysSection() {
       password: gw.password ?? '',
       pairingCode: gw.pairingCode ?? '',
       authMode: gw.authMode,
+      tlsVerify: gw.tlsVerify !== false,
     });
     setShowForm(true);
   }, []);
@@ -484,6 +505,7 @@ export default function GatewaysSection() {
       const auth = {
         token: form.token || undefined,
         password: form.password || undefined,
+        tlsVerify: isWssGatewayUrl(form.url) ? form.tlsVerify : undefined,
       };
       const res = await window.clawwork.testGateway(form.url, auth);
       if (res.ok) {
@@ -507,6 +529,7 @@ export default function GatewaysSection() {
       const auth = {
         token: form.token || undefined,
         password: form.password || undefined,
+        tlsVerify: isWssGatewayUrl(form.url) ? form.tlsVerify : undefined,
       };
       const res = await window.clawwork.testGateway(form.url, auth);
       if (res.ok) {
@@ -521,7 +544,7 @@ export default function GatewaysSection() {
     } finally {
       setPairingRetrying(false);
     }
-  }, [form.url, form.token, form.password, t]);
+  }, [form.url, form.token, form.password, form.tlsVerify, t]);
 
   const handleSave = useCallback(async () => {
     const authMode = inferGatewayAuthMode(form);
@@ -548,6 +571,7 @@ export default function GatewaysSection() {
           password: form.password.trim() || undefined,
           pairingCode: form.pairingCode.trim() || undefined,
           authMode,
+          tlsVerify: isWssGatewayUrl(form.url) ? form.tlsVerify : undefined,
         });
         if (res.ok) {
           toast.success(t('settings.gatewayUpdated'));
@@ -565,6 +589,7 @@ export default function GatewaysSection() {
           password: form.password.trim() || undefined,
           pairingCode: form.pairingCode.trim() || undefined,
           authMode,
+          tlsVerify: isWssGatewayUrl(form.url) ? form.tlsVerify : undefined,
           type: 'openclaw',
         };
         const res = await window.clawwork.addGateway(newGw);

--- a/packages/desktop/src/renderer/layouts/Setup/index.tsx
+++ b/packages/desktop/src/renderer/layouts/Setup/index.tsx
@@ -5,10 +5,11 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { motionDuration, motionEase, motion as motionPresets } from '@/styles/design-tokens';
 import logo from '@/assets/logo.png';
-import { parseGatewaySetupCode, validateGatewayForm, type GatewayAuthMode } from '@/lib/gateway-auth';
+import { isWssGatewayUrl, parseGatewaySetupCode, validateGatewayForm, type GatewayAuthMode } from '@/lib/gateway-auth';
 import SectionCard from '@/components/semantic/SectionCard';
 import ToolbarButton from '@/components/semantic/ToolbarButton';
 import InlineNotice from '@/components/semantic/InlineNotice';
+import Toggle from '@/layouts/Settings/components/Toggle';
 
 interface SetupProps {
   onSetupComplete: () => void;
@@ -31,6 +32,7 @@ export default function Setup({ onSetupComplete, initialStep = 'workspace' }: Se
   const [gwToken, setGwToken] = useState('');
   const [gwPassword, setGwPassword] = useState('');
   const [gwPairingCode, setGwPairingCode] = useState('');
+  const [gwTlsVerify, setGwTlsVerify] = useState(true);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<'success' | 'fail' | null>(null);
   const [saving, setSaving] = useState(false);
@@ -58,6 +60,7 @@ export default function Setup({ onSetupComplete, initialStep = 'workspace' }: Se
   };
 
   const gwAuthValue = gwAuthMode === 'token' ? gwToken : gwAuthMode === 'password' ? gwPassword : gwPairingCode;
+  const showTlsVerify = isWssGatewayUrl(gwUrl);
   const handleGwAuthChange = (v: string) => {
     if (gwAuthMode === 'token') setGwToken(v);
     else if (gwAuthMode === 'password') setGwPassword(v);
@@ -114,13 +117,14 @@ export default function Setup({ onSetupComplete, initialStep = 'workspace' }: Se
     const res = await window.clawwork.testGateway(gwUrl, {
       token: gwToken || undefined,
       password: gwPassword || undefined,
+      tlsVerify: isWssGatewayUrl(gwUrl) ? gwTlsVerify : undefined,
     });
     setTesting(false);
     setTestResult(res.ok || res.pairingRequired ? 'success' : 'fail');
     if (res.pairingRequired) {
       setError(t('pairing.instructions'));
     }
-  }, [gwAuthMode, gwUrl, gwToken, gwPassword, t]);
+  }, [gwAuthMode, gwUrl, gwToken, gwPassword, gwTlsVerify, t]);
 
   const handleFinish = useCallback(async () => {
     const validationError = validateGatewayForm({
@@ -145,6 +149,7 @@ export default function Setup({ onSetupComplete, initialStep = 'workspace' }: Se
       password: gwPassword.trim() || undefined,
       pairingCode: gwPairingCode.trim() || undefined,
       authMode: gwAuthMode,
+      tlsVerify: isWssGatewayUrl(gwUrl) ? gwTlsVerify : undefined,
       isDefault: true,
     };
     const res = await window.clawwork.addGateway(gw);
@@ -154,7 +159,7 @@ export default function Setup({ onSetupComplete, initialStep = 'workspace' }: Se
     } else {
       setError(res.error ?? t('errors.failed'));
     }
-  }, [gwAuthMode, gwName, gwUrl, gwToken, gwPassword, gwPairingCode, onSetupComplete, t]);
+  }, [gwAuthMode, gwName, gwUrl, gwToken, gwPassword, gwPairingCode, gwTlsVerify, onSetupComplete, t]);
 
   const handleSkipGateway = useCallback(() => {
     onSetupComplete();
@@ -357,6 +362,20 @@ export default function Setup({ onSetupComplete, initialStep = 'workspace' }: Se
                         className={cn(inputClass, 'w-full')}
                       />
                       <p className="type-support text-[var(--text-muted)] opacity-70 mt-1">{t('setup.urlHint')}</p>
+                    </div>
+                  )}
+                  {showTlsVerify && (
+                    <div className="flex items-start justify-between gap-3 py-1">
+                      <div className="min-w-0">
+                        <div className="type-label text-[var(--text-secondary)]">{t('settings.tlsVerify')}</div>
+                        <p className="type-support mt-1 text-[var(--text-muted)]">{t('settings.tlsVerifyHint')}</p>
+                      </div>
+                      <Toggle
+                        checked={gwTlsVerify}
+                        onChange={setGwTlsVerify}
+                        ariaLabel={t('settings.tlsVerify')}
+                        size="sm"
+                      />
                     </div>
                   )}
                   <div>

--- a/packages/desktop/src/renderer/lib/gateway-auth.ts
+++ b/packages/desktop/src/renderer/lib/gateway-auth.ts
@@ -52,6 +52,15 @@ export function parseGatewaySetupCode(raw: string): { url: string; pairingCode: 
   }
 }
 
+export function isWssGatewayUrl(raw: string): boolean {
+  try {
+    const protocol = new URL(raw.trim()).protocol;
+    return protocol === 'wss:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export function validateGatewayForm(input: GatewayFormValidationInput): GatewayFormErrorKey | null {
   if (!input.name.trim()) return 'nameRequired';
 

--- a/packages/desktop/test/gateway-auth.test.ts
+++ b/packages/desktop/test/gateway-auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { inferGatewayAuthMode, parseGatewaySetupCode, validateGatewayForm } from '../src/renderer/lib/gateway-auth.js';
+import {
+  inferGatewayAuthMode,
+  isWssGatewayUrl,
+  parseGatewaySetupCode,
+  validateGatewayForm,
+} from '../src/renderer/lib/gateway-auth.js';
 import { buildGatewayAuth } from '../src/main/workspace/config.js';
 
 describe('gateway auth helpers', () => {
@@ -35,6 +40,13 @@ describe('gateway auth helpers', () => {
     expect(inferGatewayAuthMode({ token: 'secret', password: 'pw', pairingCode: 'pair' })).toBe('token');
     expect(inferGatewayAuthMode({ password: 'pw', pairingCode: 'pair' })).toBe('password');
     expect(inferGatewayAuthMode({ pairingCode: 'pair' })).toBe('pairingCode');
+  });
+
+  it('detects secure gateway URLs for TLS settings', () => {
+    expect(isWssGatewayUrl('wss://gateway.example.com')).toBe(true);
+    expect(isWssGatewayUrl('https://gateway.example.com')).toBe(true);
+    expect(isWssGatewayUrl(' ws://127.0.0.1:18789 ')).toBe(false);
+    expect(isWssGatewayUrl('not a url')).toBe(false);
   });
 
   it('requires token and password fields for their respective auth modes', () => {

--- a/packages/desktop/test/gateway-client-tls-verify.test.ts
+++ b/packages/desktop/test/gateway-client-tls-verify.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const websocketConstructor = vi.hoisted(() =>
+  vi.fn().mockImplementation(() => ({
+    on: vi.fn(),
+    removeAllListeners: vi.fn(),
+    readyState: 0,
+    close: vi.fn(),
+  })),
+);
+
+vi.mock('ws', () => ({
+  default: websocketConstructor,
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '0.0.0-test'),
+  },
+}));
+
+vi.mock('../src/main/ws/window-utils.js', () => ({
+  sendToWindow: vi.fn(),
+}));
+
+vi.mock('../src/main/window-manager.js', () => ({
+  getMainWindow: vi.fn(() => null),
+}));
+
+vi.mock('../src/main/ws/device-identity.js', () => ({
+  loadOrCreateDeviceIdentity: vi.fn(() => ({ deviceId: 'device', publicKeyPem: 'public', privateKeyPem: 'private' })),
+  buildDeviceConnectPayload: vi.fn(() => ({})),
+  saveDeviceToken: vi.fn(),
+  loadDeviceToken: vi.fn(() => null),
+}));
+
+vi.mock('../src/main/debug/index.js', () => ({
+  getDebugLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock('../src/main/ws/tls-trust.js', () => ({
+  ensureGatewayWindowsSystemTrust: vi.fn(),
+}));
+
+describe('GatewayClient TLS verification option', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables websocket certificate verification for https gateway aliases when requested', async () => {
+    const { GatewayClient } = await import('../src/main/ws/gateway-client.js');
+
+    const client = new GatewayClient({
+      id: 'gw-1',
+      name: 'Gateway',
+      url: 'https://gateway.example.com',
+      auth: { token: 'token' },
+      tlsVerify: false,
+    });
+
+    client.connect();
+
+    expect(websocketConstructor).toHaveBeenCalledWith(
+      'https://gateway.example.com',
+      expect.objectContaining({ handshakeTimeout: 10000, rejectUnauthorized: false }),
+    );
+  });
+
+  it('keeps https gateway aliases as https media origins', async () => {
+    const { GatewayClient } = await import('../src/main/ws/gateway-client.js');
+
+    const client = new GatewayClient({
+      id: 'gw-1',
+      name: 'Gateway',
+      url: 'https://gateway.example.com',
+      auth: { token: 'token' },
+      tlsVerify: false,
+    });
+
+    expect(client.httpBase).toBe('https://gateway.example.com');
+  });
+
+  it('keeps default websocket certificate verification enabled', async () => {
+    const { GatewayClient } = await import('../src/main/ws/gateway-client.js');
+
+    const client = new GatewayClient({
+      id: 'gw-1',
+      name: 'Gateway',
+      url: 'wss://gateway.example.com',
+      auth: { token: 'token' },
+    });
+
+    client.connect();
+
+    expect(websocketConstructor).toHaveBeenCalledWith(
+      'wss://gateway.example.com',
+      expect.not.objectContaining({ rejectUnauthorized: false }),
+    );
+  });
+
+  it('does not apply TLS verification options to plaintext ws gateways', async () => {
+    const { GatewayClient } = await import('../src/main/ws/gateway-client.js');
+
+    const client = new GatewayClient({
+      id: 'gw-1',
+      name: 'Gateway',
+      url: 'ws://127.0.0.1:18789',
+      auth: { token: 'token' },
+      tlsVerify: false,
+    });
+
+    client.connect();
+
+    expect(websocketConstructor).toHaveBeenCalledWith(
+      'ws://127.0.0.1:18789',
+      expect.not.objectContaining({ rejectUnauthorized: false }),
+    );
+  });
+
+  it('handles uppercase wss schemes when disabling certificate verification', async () => {
+    const { GatewayClient } = await import('../src/main/ws/gateway-client.js');
+
+    const client = new GatewayClient({
+      id: 'gw-1',
+      name: 'Gateway',
+      url: 'WSS://gateway.example.com',
+      auth: { token: 'token' },
+      tlsVerify: false,
+    });
+
+    client.connect();
+
+    expect(websocketConstructor).toHaveBeenCalledWith(
+      'WSS://gateway.example.com',
+      expect.objectContaining({ handshakeTimeout: 10000, rejectUnauthorized: false }),
+    );
+  });
+});

--- a/packages/desktop/test/gateway-settings-flow.test.tsx
+++ b/packages/desktop/test/gateway-settings-flow.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import GatewaysSection from '../src/renderer/layouts/Settings/sections/GatewaysSection';
+import { resetSettingsStore } from '../src/renderer/stores/settingsStore';
 import { useUiStore } from '../src/renderer/stores/uiStore';
 
 vi.mock('sonner', () => ({
@@ -61,6 +62,12 @@ async function flushAsync(): Promise<void> {
   });
 }
 
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new InputEvent('input', { bubbles: true, data: value }));
+}
+
 describe('gateway settings flow', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -70,6 +77,7 @@ describe('gateway settings flow', () => {
       defaultGatewayId: null,
       gatewayInfoMap: {},
     });
+    resetSettingsStore();
     (globalThis.window as unknown as Window & typeof globalThis & { clawwork: Record<string, unknown> }).clawwork = {
       getSettings: vi.fn().mockResolvedValue({ gateways: [], defaultGatewayId: null }),
       addGateway: vi.fn().mockResolvedValue({ ok: true }),
@@ -117,6 +125,88 @@ describe('gateway settings flow', () => {
         button.textContent?.includes('Test Connection'),
       ),
     ).toBe(false);
+
+    const inputs = Array.from(container.querySelectorAll('input')) as HTMLInputElement[];
+
+    await act(async () => {
+      setInputValue(
+        inputs[1],
+        Buffer.from(JSON.stringify({ url: 'wss://pair.example.com', bootstrapToken: 'pair-token' })).toString('base64'),
+      );
+    });
+
+    await flushAsync();
+
+    expect(container.textContent).toContain('Verify TLS certificate');
+
+    unmount();
+  });
+
+  it('shows TLS verification only for WSS gateways and saves disabled verification', async () => {
+    const { container, unmount } = render(<GatewaysSection />);
+
+    await flushAsync();
+
+    const addButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Add Gateway'),
+    );
+    expect(addButton).toBeTruthy();
+
+    act(() => {
+      addButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await flushAsync();
+
+    expect(container.textContent).not.toContain('Verify TLS certificate');
+
+    const inputs = Array.from(container.querySelectorAll('input')) as HTMLInputElement[];
+    expect(inputs.length).toBeGreaterThanOrEqual(3);
+
+    await act(async () => {
+      setInputValue(inputs[0], 'Private Gateway');
+      setInputValue(inputs[1], 'wss://gateway.example.com');
+      setInputValue(inputs[2], 'secret');
+    });
+
+    await flushAsync();
+
+    expect(container.textContent).toContain('Verify TLS certificate');
+
+    const tlsSwitch = container.querySelector(
+      'button[role="switch"][aria-label="Verify TLS certificate"]',
+    ) as HTMLButtonElement | null;
+    expect(tlsSwitch).toBeTruthy();
+    expect(tlsSwitch?.getAttribute('aria-checked')).toBe('true');
+
+    act(() => {
+      tlsSwitch?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await flushAsync();
+
+    expect(tlsSwitch?.getAttribute('aria-checked')).toBe('false');
+
+    const saveButtons = Array.from(container.querySelectorAll('button')).filter((button) =>
+      button.textContent?.includes('Add Gateway'),
+    );
+    const saveButton = saveButtons[saveButtons.length - 1];
+
+    await act(async () => {
+      saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    await flushAsync();
+
+    expect(window.clawwork.addGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Private Gateway',
+        url: 'wss://gateway.example.com',
+        token: 'secret',
+        tlsVerify: false,
+      }),
+    );
 
     unmount();
   });

--- a/packages/desktop/test/settings-handlers.test.ts
+++ b/packages/desktop/test/settings-handlers.test.ts
@@ -45,6 +45,7 @@ vi.mock('../src/main/ws/gateway-client.js', () => ({
 describe('registerSettingsHandlers', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.clearAllMocks();
     handleMap.clear();
     connected = false;
     connectMock.mockReset();
@@ -133,5 +134,121 @@ describe('registerSettingsHandlers', () => {
     };
     expect(result).toEqual({ ok: false, error: 'no config' });
     expect(configModule.writeConfig).not.toHaveBeenCalled();
+  });
+
+  it('passes TLS verification through when testing a gateway', async () => {
+    const { registerSettingsHandlers } = await import('../src/main/ipc/settings-handlers.js');
+    const gatewayModule = await import('../src/main/ws/gateway-client.js');
+
+    registerSettingsHandlers();
+
+    const handler = handleMap.get('settings:test-gateway');
+    expect(handler).toBeTypeOf('function');
+
+    const pending = handler?.({}, ' wss://gateway.example.com ', {
+      token: 'secret',
+      tlsVerify: false,
+    }) as Promise<{ ok: boolean }>;
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    await expect(pending).resolves.toEqual({ ok: true });
+    expect(gatewayModule.GatewayClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'wss://gateway.example.com',
+        tlsVerify: false,
+      }),
+      { noReconnect: true },
+    );
+  });
+
+  it('persists TLS verification when adding a gateway', async () => {
+    const { registerSettingsHandlers } = await import('../src/main/ipc/settings-handlers.js');
+    const configModule = await import('../src/main/workspace/config.js');
+    const wsModule = await import('../src/main/ws/index.js');
+    const config = { workspacePath: '/tmp/workspace', gateways: [] };
+
+    vi.mocked(configModule.readConfig).mockReturnValue(config);
+    vi.mocked(configModule.buildGatewayAuth).mockReturnValue({ token: 'tok' });
+
+    registerSettingsHandlers();
+
+    const handler = handleMap.get('settings:add-gateway');
+    expect(handler).toBeTypeOf('function');
+
+    const gateway = {
+      id: 'gw1',
+      name: 'gw',
+      url: 'wss://gw.example.com',
+      authMode: 'token' as const,
+      token: 'tok',
+      tlsVerify: false,
+    };
+    const result = (await handler?.({}, gateway)) as { ok: boolean };
+
+    expect(result).toEqual({ ok: true });
+    expect(configModule.writeConfig).toHaveBeenCalledWith({
+      workspacePath: '/tmp/workspace',
+      gateways: [gateway],
+      defaultGatewayId: 'gw1',
+    });
+    expect(wsModule.addGateway).toHaveBeenCalledWith({
+      id: 'gw1',
+      name: 'gw',
+      url: 'wss://gw.example.com',
+      auth: { token: 'tok' },
+      tlsVerify: false,
+    });
+  });
+
+  it('updates an existing gateway client with TLS verification changes', async () => {
+    const { registerSettingsHandlers } = await import('../src/main/ipc/settings-handlers.js');
+    const configModule = await import('../src/main/workspace/config.js');
+    const wsModule = await import('../src/main/ws/index.js');
+    const updateConfig = vi.fn();
+    const config = {
+      workspacePath: '/tmp/workspace',
+      gateways: [
+        {
+          id: 'gw1',
+          name: 'gw',
+          url: 'wss://gw.example.com',
+          authMode: 'token' as const,
+          token: 'tok',
+          tlsVerify: true,
+        },
+      ],
+    };
+
+    vi.mocked(configModule.readConfig).mockReturnValue(config);
+    vi.mocked(configModule.buildGatewayAuth).mockReturnValue({ token: 'tok' });
+    vi.mocked(wsModule.getGatewayClient).mockReturnValue({ updateConfig } as never);
+
+    registerSettingsHandlers();
+
+    const handler = handleMap.get('settings:update-gateway');
+    expect(handler).toBeTypeOf('function');
+
+    const result = (await handler?.({}, 'gw1', { tlsVerify: false })) as { ok: boolean };
+
+    expect(result.ok).toBe(true);
+    expect(configModule.writeConfig).toHaveBeenCalledWith({
+      workspacePath: '/tmp/workspace',
+      gateways: [
+        {
+          id: 'gw1',
+          name: 'gw',
+          url: 'wss://gw.example.com',
+          authMode: 'token',
+          token: 'tok',
+          tlsVerify: false,
+        },
+      ],
+    });
+    expect(updateConfig).toHaveBeenCalledWith({
+      url: 'wss://gw.example.com',
+      auth: { token: 'tok' },
+      tlsVerify: false,
+    });
   });
 });

--- a/packages/shared/src/gateway-protocol.ts
+++ b/packages/shared/src/gateway-protocol.ts
@@ -50,7 +50,7 @@ export type GatewayAuth =
 
 export interface GatewayConnectParams {
   minProtocol: 3;
-  maxProtocol: 3;
+  maxProtocol: 3 | 4;
   client: {
     id: string;
     displayName: string;
@@ -77,4 +77,5 @@ export interface GatewayClientConfig {
   name: string;
   url: string;
   auth: GatewayAuth;
+  tlsVerify?: boolean;
 }


### PR DESCRIPTION
## Summary

Adds a secure Gateway TLS verification setting so trusted private WSS/HTTPS Gateway connections with self-signed certificates can be used without disabling verification globally.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [x] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Private OpenClaw Gateways can use self-signed TLS certificates. ClawWork previously always verified the WebSocket certificate, so those Gateways could not connect even when the user trusted the endpoint.

## What changed?

- Added `tlsVerify` to the shared Gateway client config, preload bridge, persisted settings, settings IPC handlers, and desktop WebSocket client.
- Shows a small TLS verification switch only when the entered Gateway URL is secure (`wss://` or `https://`).
- Applies `rejectUnauthorized: false` only for secure Gateway WebSocket connections when the user disables verification.
- Covered default verification, disabled verification, plaintext WS behavior, HTTPS aliases, setup-code pairing, settings UI, and settings handler flows.

## Architecture impact

- Owning layer: shared / main / preload / renderer
- Cross-layer impact: yes. `tlsVerify` is a Gateway configuration field that must cross renderer -> preload -> main so the main-process WebSocket client can apply TLS policy.
- Invariants touched from `docs/architecture-invariants.md`: Gateway protocol/shared domain types stay in `packages/shared/src/`; main owns WebSocket and workspace config; preload owns the typed renderer bridge; renderer owns UI state and presentation.
- Why those invariants remain protected: renderer still crosses the process boundary only through `window.clawwork`, TLS behavior is applied only in the main-process Gateway client, and UI styling uses existing CSS variables/tokens with `pnpm check:ui-contract` passing.

## Linked issues

Closes #501

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
rtk pnpm check
pnpm --filter @clawwork/desktop exec vitest run test/gateway-client-tls-verify.test.ts test/settings-handlers.test.ts test/gateway-settings-flow.test.tsx test/gateway-auth.test.ts
pnpm --filter @clawwork/desktop exec tsc --noEmit
git diff --check
```

## Screenshots or recordings

No screenshot attached. The UI change uses the existing `Toggle` component with a new small size and preserves CSS variable styling; `pnpm check:ui-contract` passed.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Added an opt-in setting to skip TLS certificate verification for trusted private secure Gateways with self-signed certificates.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
