### PR TITLE
fix(desktop): build team workspace path on host platform

### DIFF
--- a/packages/desktop/src/main/ipc/workspace-handlers.ts
+++ b/packages/desktop/src/main/ipc/workspace-handlers.ts
@@ -1,4 +1,5 @@
 import { ipcMain, dialog, BrowserWindow, shell } from 'electron';
+import { join } from 'path';
 import {
   getWorkspacePath,
   writeConfig,
@@ -65,5 +66,11 @@ export function registerWorkspaceHandlers(): void {
 
   ipcMain.handle('workspace:get-device-id', () => {
     return ensureDeviceId();
+  });
+
+  ipcMain.handle('workspace:team-path', (_event, slug: string) => {
+    const base = getWorkspacePath();
+    if (!base) return slug;
+    return join(base, slug);
   });
 }

--- a/packages/desktop/src/main/ipc/workspace-handlers.ts
+++ b/packages/desktop/src/main/ipc/workspace-handlers.ts
@@ -11,6 +11,8 @@ import {
 import { initWorkspace, migrateWorkspace } from '../workspace/init.js';
 import { reinitDatabase, closeDatabase } from '../db/index.js';
 
+const TEAM_WORKSPACE_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 export function registerWorkspaceHandlers(): void {
   ipcMain.handle('workspace:open-folder', () => {
     const p = getWorkspacePath();
@@ -69,6 +71,9 @@ export function registerWorkspaceHandlers(): void {
   });
 
   ipcMain.handle('workspace:team-path', (_event, slug: string) => {
+    if (typeof slug !== 'string' || !TEAM_WORKSPACE_SLUG_RE.test(slug)) {
+      throw new Error('Invalid team slug');
+    }
     const base = getWorkspacePath();
     if (!base) return slug;
     return join(base, slug);

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -348,6 +348,7 @@ export interface ClawWorkAPI {
   isWorkspaceConfigured: () => Promise<boolean>;
   getWorkspacePath: () => Promise<string | null>;
   getDefaultWorkspacePath: () => Promise<string>;
+  getTeamWorkspacePath: (slug: string) => Promise<string>;
   browseWorkspace: () => Promise<string | null>;
   setupWorkspace: (path: string) => Promise<IpcResult>;
   changeWorkspace: (path: string) => Promise<IpcResult>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -160,6 +160,7 @@ function buildApi(): ClawWorkAPI {
     isWorkspaceConfigured: () => ipcRenderer.invoke('workspace:is-configured') as Promise<boolean>,
     getWorkspacePath: () => ipcRenderer.invoke('workspace:get-path') as Promise<string | null>,
     getDefaultWorkspacePath: () => ipcRenderer.invoke('workspace:get-default') as Promise<string>,
+    getTeamWorkspacePath: (slug: string) => ipcRenderer.invoke('workspace:team-path', slug) as Promise<string>,
     browseWorkspace: () => ipcRenderer.invoke('workspace:browse') as Promise<string | null>,
     setupWorkspace: (path: string) => ipcRenderer.invoke('workspace:setup', path),
     changeWorkspace: (path: string) => ipcRenderer.invoke('workspace:change', path),

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/useTeamInstall.ts
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/useTeamInstall.ts
@@ -136,8 +136,7 @@ export function useTeamInstall(onDone?: () => void) {
       };
 
       try {
-        const wsBase = await window.clawwork.getWorkspacePath();
-        const workspace = wsBase ? `${wsBase}/${toSlug(teamInfo.name)}` : toSlug(teamInfo.name);
+        const workspace = await window.clawwork.getTeamWorkspacePath(toSlug(teamInfo.name));
         for await (const event of installTeam(parsed, agentFiles, teamInfo.gatewayId, workspace, deps, hubMeta)) {
           setInstallEvents((prev) => [...prev, event]);
 

--- a/packages/desktop/test/workspace-handlers.test.ts
+++ b/packages/desktop/test/workspace-handlers.test.ts
@@ -118,4 +118,31 @@ describe('registerWorkspaceHandlers', () => {
     expect(closeDatabaseMock).toHaveBeenCalledTimes(1);
     expect(reinitDatabaseMock).toHaveBeenCalledWith('/tmp/old-workspace');
   });
+
+  it('joins workspace and slug using path.join so the host separator is used', async () => {
+    const { registerWorkspaceHandlers } = await import('../src/main/ipc/workspace-handlers.js');
+    registerWorkspaceHandlers();
+
+    const handler = handleMap.get('workspace:team-path');
+    expect(handler).toBeTypeOf('function');
+
+    getWorkspacePathMock.mockReturnValue('/tmp/claw-workspace');
+    const result = (await handler?.({}, 'test-team')) as string;
+    const expected = (await import('path')).join('/tmp/claw-workspace', 'test-team');
+
+    expect(result).toBe(expected);
+    expect(result.endsWith(`${(await import('path')).sep}test-team`)).toBe(true);
+    expect(result.includes('//test-team')).toBe(false);
+  });
+
+  it('returns slug alone when no workspace is configured', async () => {
+    getWorkspacePathMock.mockReturnValue(null);
+    const { registerWorkspaceHandlers } = await import('../src/main/ipc/workspace-handlers.js');
+    registerWorkspaceHandlers();
+
+    const handler = handleMap.get('workspace:team-path');
+    expect(handler).toBeTypeOf('function');
+
+    expect(handler?.({}, 'lonely-team')).toBe('lonely-team');
+  });
 });

--- a/packages/desktop/test/workspace-handlers.test.ts
+++ b/packages/desktop/test/workspace-handlers.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const handleMap = new Map<string, (...args: unknown[]) => unknown>();
 
 const isWorkspaceConfiguredMock = vi.fn(() => false);
-const getWorkspacePathMock = vi.fn(() => '/tmp/old-workspace');
+const getWorkspacePathMock = vi.fn<() => string | null>(() => '/tmp/old-workspace');
 const writeConfigMock = vi.fn();
 const updateConfigMock = vi.fn();
 const getDefaultWorkspacePathMock = vi.fn(() => '/tmp/default-workspace');
@@ -144,5 +144,17 @@ describe('registerWorkspaceHandlers', () => {
     expect(handler).toBeTypeOf('function');
 
     expect(handler?.({}, 'lonely-team')).toBe('lonely-team');
+  });
+
+  it('rejects invalid team workspace slugs', async () => {
+    const { registerWorkspaceHandlers } = await import('../src/main/ipc/workspace-handlers.js');
+    registerWorkspaceHandlers();
+
+    const handler = handleMap.get('workspace:team-path');
+    expect(handler).toBeTypeOf('function');
+
+    for (const slug of ['', '../invalid', 'invalid/path', String.raw`invalid\path`, 'bad..slug', 123]) {
+      expect(() => handler?.({}, slug)).toThrow('Invalid team slug');
+    }
   });
 });


### PR DESCRIPTION
Fixes the path part of #507.

## Problem
On Windows clients, `useTeamInstall` concatenated the team slug with a hard-coded `/` via a template string. The resulting workspace string (e.g. `C:\Users\<name>\ClawWork-Workspace/test-team`) was then sent to a POSIX gateway and persisted into `openclaw.config` as an invalid path (see issue screenshot).

## Fix
Move the join into the main process so it uses the host's path separator. The renderer now asks for a full team workspace path through a new `workspace:team-path` IPC handler backed by `path.join`.

## Changes
- `packages/desktop/src/main/ipc/workspace-handlers.ts`: add `workspace:team-path` handler using `path.join`.
- `packages/desktop/src/preload/index.ts` + `clawwork.d.ts`: expose `getTeamWorkspacePath(slug)`.
- `packages/desktop/src/renderer/layouts/TeamsPanel/useTeamInstall.ts`: replace the template-string concatenation with the new IPC call.
- `packages/desktop/test/workspace-handlers.test.ts`: cover the new handler.

The subagents.allowAgents part of #507 (coordinator cannot dispatch to workers) is not addressed here and will be handled in a follow-up PR. See issue comment for the diagnosis.