### PR TITLE
[Fix] Configure team subagent allowlists

### DIFF
--- a/packages/core/src/services/team-installer.ts
+++ b/packages/core/src/services/team-installer.ts
@@ -6,6 +6,9 @@ import type {
   AgentCreateParams,
   AgentCreateResponse,
   AgentDeleteParams,
+  ConfigPatchParams,
+  ConfigPatchResult,
+  ConfigSnapshot,
   IpcResult,
   SkillInstallParams,
   SkillInstallResult,
@@ -17,6 +20,8 @@ export interface InstallerDeps {
   deleteAgent: (params: AgentDeleteParams) => Promise<IpcResult>;
   setAgentFile: (agentId: string, name: string, content: string) => Promise<IpcResult>;
   installSkill: (params: SkillInstallParams) => Promise<IpcResult<SkillInstallResult>>;
+  getConfig: () => Promise<IpcResult<ConfigSnapshot>>;
+  patchConfig: (params: ConfigPatchParams) => Promise<IpcResult<ConfigPatchResult>>;
   persistTeam: (team: {
     id: string;
     name: string;
@@ -45,6 +50,45 @@ function buildSkillInstallParams(skill: SkillRef): SkillInstallParams | null {
     return { source: 'clawhub', slug: skill.id };
   }
   return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readAllowAgents(config: Record<string, unknown>, agentId: string): string[] {
+  const agents = config.agents;
+  const list = isRecord(agents) && Array.isArray(agents.list) ? agents.list : [];
+  const entry = list.find((item) => isRecord(item) && item.id === agentId);
+  if (!isRecord(entry) || !isRecord(entry.subagents) || !Array.isArray(entry.subagents.allowAgents)) return [];
+  return entry.subagents.allowAgents.filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+}
+
+async function configureTeamSubagents(
+  teamAgents: Array<{ agentId: string; role?: string; isManager?: boolean; skills?: string[] }>,
+  deps: InstallerDeps,
+): Promise<IpcResult> {
+  const managerIds = teamAgents.filter((agent) => agent.role === 'coordinator').map((agent) => agent.agentId);
+  const workerIds = teamAgents.filter((agent) => agent.role === 'worker').map((agent) => agent.agentId);
+  if (managerIds.length === 0 || workerIds.length === 0) return { ok: true };
+
+  const configRes = await deps.getConfig();
+  if (!configRes.ok || !configRes.result) return { ok: false, error: configRes.error ?? 'failed to read config' };
+  const snapshot = configRes.result;
+
+  const list = managerIds.map((agentId) => ({
+    id: agentId,
+    subagents: {
+      allowAgents: [...new Set([...readAllowAgents(snapshot.config, agentId), ...workerIds])],
+    },
+  }));
+
+  const patchRes = await deps.patchConfig({
+    baseHash: snapshot.hash,
+    raw: JSON.stringify({ agents: { list } }),
+  });
+  if (!patchRes.ok) return { ok: false, error: patchRes.error ?? 'failed to configure subagents' };
+  return { ok: true };
 }
 
 export async function* installTeam(
@@ -181,6 +225,13 @@ export async function* installTeam(
   if (teamAgents.length === 0) {
     yield* rollback(createdAgentIds, deps);
     yield { type: 'error', message: 'No agents were created successfully' };
+    return;
+  }
+
+  const subagentsRes = await configureTeamSubagents(teamAgents, deps);
+  if (!subagentsRes.ok) {
+    yield* rollback(createdAgentIds, deps);
+    yield { type: 'error', message: `Failed to configure subagents: ${subagentsRes.error}` };
     return;
   }
 

--- a/packages/core/test/team-installer.test.ts
+++ b/packages/core/test/team-installer.test.ts
@@ -29,6 +29,16 @@ function makeDeps(overrides?: Partial<InstallerDeps>): InstallerDeps {
     installSkill: vi
       .fn()
       .mockResolvedValue({ ok: true, result: { ok: true, message: 'ok', stdout: '', stderr: '', code: 0 } }),
+    getConfig: vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        raw: '{}',
+        hash: 'config-hash',
+        config: { agents: { list: [{ id: 'agent-1' }, { id: 'agent-2' }] } },
+        path: '/openclaw.json',
+      },
+    }),
+    patchConfig: vi.fn().mockResolvedValue({ ok: true, result: { ok: true, path: '/openclaw.json', config: {} } }),
     persistTeam: vi.fn().mockResolvedValue({ ok: true }),
     ...overrides,
   };
@@ -245,6 +255,57 @@ describe('installTeam', () => {
       { agentId: 'agent-1', role: 'coordinator', isManager: true, skills: ['plan'] },
       { agentId: 'agent-2', role: 'worker', isManager: false, skills: ['code', 'review'] },
     ]);
+  });
+
+  it('configures coordinator subagent allowlists for worker agents', async () => {
+    const parsed = makeParsed();
+    const deps = makeDeps({
+      getConfig: vi.fn().mockResolvedValue({
+        ok: true,
+        result: {
+          raw: '{}',
+          hash: 'config-hash',
+          config: {
+            agents: {
+              list: [
+                { id: 'agent-1', subagents: { allowAgents: ['existing-worker'] } },
+                { id: 'existing-worker' },
+                { id: 'agent-2' },
+              ],
+            },
+          },
+          path: '/openclaw.json',
+        },
+      }),
+    });
+
+    await collect(installTeam(parsed, {}, 'gw-1', '/w', deps));
+
+    expect(deps.getConfig).toHaveBeenCalledTimes(1);
+    expect(deps.patchConfig).toHaveBeenCalledTimes(1);
+    expect(deps.patchConfig).toHaveBeenCalledWith({
+      baseHash: 'config-hash',
+      raw: JSON.stringify({
+        agents: {
+          list: [{ id: 'agent-1', subagents: { allowAgents: ['existing-worker', 'agent-2'] } }],
+        },
+      }),
+    });
+  });
+
+  it('rolls back and errors when subagent configuration fails', async () => {
+    const parsed = makeParsed();
+    const deps = makeDeps({
+      patchConfig: vi.fn().mockResolvedValue({ ok: false, error: 'config changed' }),
+    });
+
+    const events = await collect(installTeam(parsed, {}, 'gw-1', '/w', deps));
+
+    expect(deps.deleteAgent).toHaveBeenCalledWith({ agentId: 'agent-1' });
+    expect(deps.deleteAgent).toHaveBeenCalledWith({ agentId: 'agent-2' });
+    expect(deps.persistTeam).not.toHaveBeenCalled();
+    const errorEvent = events.find((e) => e.type === 'error')!;
+    expect(errorEvent.message).toContain('Failed to configure subagents');
   });
 
   it('progress total includes file and skill operations', async () => {

--- a/packages/desktop/src/renderer/layouts/TeamsPanel/useTeamInstall.ts
+++ b/packages/desktop/src/renderer/layouts/TeamsPanel/useTeamInstall.ts
@@ -76,6 +76,7 @@ export function useTeamInstall(onDone?: () => void) {
       for (const a of agents) {
         if (a.model) agentModelMap.set(toSlug(a.name), a.model);
       }
+      const pendingModelUpdates: Promise<void>[] = [];
 
       const gwId = teamInfo.gatewayId;
       let cachedGatewayAgents: AgentInfo[] | null = null;
@@ -123,6 +124,11 @@ export function useTeamInstall(onDone?: () => void) {
           if (!res.ok) return { ok: false, error: res.error } as IpcResult<SkillInstallResult>;
           return { ok: true, result: res.result as unknown as SkillInstallResult };
         },
+        getConfig: async () => {
+          await Promise.all(pendingModelUpdates);
+          return window.clawwork.getConfig(gwId);
+        },
+        patchConfig: (params) => window.clawwork.patchConfig(gwId, params),
         persistTeam: editContext
           ? (team) =>
               window.clawwork.persistTeam({
@@ -143,9 +149,11 @@ export function useTeamInstall(onDone?: () => void) {
           if (event.type === 'agent_created' && event.agentSlug && event.agentId) {
             const model = agentModelMap.get(event.agentSlug);
             if (model) {
-              window.clawwork
+              const update = window.clawwork
                 .updateAgent(teamInfo.gatewayId, { agentId: event.agentId, model })
+                .then(() => undefined)
                 .catch((err) => console.error('Failed to update agent model', err));
+              pendingModelUpdates.push(update);
             }
           }
 


### PR DESCRIPTION
Closes #507.

## Summary
- Configure coordinator agents with worker `subagents.allowAgents` during team install.
- Preserve existing coordinator allowlist entries while adding team worker ids.
- Wait for pending model updates before reading config for the allowlist patch to avoid base-hash races.

## Context
PR #508 fixed the workspace-path part of #507. This PR fixes the remaining coordinator-to-worker delegation setup.

Longer-term OpenClaw typed Gateway API request: https://github.com/openclaw/openclaw/issues/89372

## Verification
- `pnpm --filter @clawwork/core exec vitest run test/team-installer.test.ts`
- `pnpm --filter @clawwork/desktop exec tsc --noEmit -p tsconfig.test.json`
- `git diff --check`
- `pnpm check`
