### PR TITLE
fix(debug): CI fixes for #448

### DIFF
--- a/packages/desktop/src/main/debug/index.ts
+++ b/packages/desktop/src/main/debug/index.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow } from 'electron';
 import { sanitizeForLog } from '@clawwork/shared';
-import type { DebugEvent, LogEventInput } from '@clawwork/shared';
-import type { DebugLogger } from './logger.js';
+import type { DebugEvent } from '@clawwork/shared';
+import type { DebugLogger, LogEventInput } from './logger.js';
 import { createDebugLogger } from './logger.js';
 
 const MAX_PRE_INIT_BUFFER = 256;

--- a/packages/desktop/test/debug/debug-logger.test.ts
+++ b/packages/desktop/test/debug/debug-logger.test.ts
@@ -13,9 +13,7 @@ describe('debug logger pre-init behavior', () => {
   });
 
   it('buffers events before initDebugLogger runs', async () => {
-    const { getDebugLogger, isDebugLoggerInitialized } = await import(
-      '../../src/main/debug/index.js'
-    );
+    const { getDebugLogger, isDebugLoggerInitialized } = await import('../../src/main/debug/index.js');
 
     const logger = getDebugLogger();
     const event1 = logger.info({ domain: 'app', event: 'test-event-1' });
@@ -32,9 +30,7 @@ describe('debug logger pre-init behavior', () => {
   });
 
   it('flushes buffered events to real logger after init', async () => {
-    const { getDebugLogger, initDebugLogger, isDebugLoggerInitialized } = await import(
-      '../../src/main/debug/index.js'
-    );
+    const { getDebugLogger, initDebugLogger, isDebugLoggerInitialized } = await import('../../src/main/debug/index.js');
 
     const logger = getDebugLogger();
 
@@ -53,9 +49,7 @@ describe('debug logger pre-init behavior', () => {
   });
 
   it('drops oldest events when buffer is full (keeps most recent 256)', async () => {
-    const { getDebugLogger, initDebugLogger } = await import(
-      '../../src/main/debug/index.js'
-    );
+    const { getDebugLogger, initDebugLogger } = await import('../../src/main/debug/index.js');
 
     const logger = getDebugLogger();
 
@@ -77,9 +71,7 @@ describe('debug logger pre-init behavior', () => {
   });
 
   it('warns via console when logging before init', async () => {
-    const { getDebugLogger, isDebugLoggerInitialized } = await import(
-      '../../src/main/debug/index.js'
-    );
+    const { getDebugLogger, isDebugLoggerInitialized } = await import('../../src/main/debug/index.js');
 
     if (isDebugLoggerInitialized()) {
       return;


### PR DESCRIPTION
## Summary

CI fixes for #448:

- Import `LogEventInput` from `./logger.js` instead of `@clawwork/shared` (fixes `tsc` failure)
- Run Prettier on `debug-logger.test.ts` (fixes `format:check` failure)

## Test plan

- [x] `pnpm --filter @clawwork/desktop exec tsc --noEmit` passes
- [x] `pnpm format:check` passes on changed files
- [x] `pnpm --filter @clawwork/desktop test` — debug-logger tests pass (4/4)

Made with [Cursor](https://cursor.com)