### PR TITLE
[Fix] propagate non-duplicate ALTER TABLE migration errors

### DIFF
--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -15,9 +15,10 @@ function migrateAddColumn(database: Database.Database, sql: string): void {
     database.exec(sql);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    if (!msg.includes('duplicate column')) {
-      console.error('[db:migration]', msg);
+    if (msg.includes('duplicate column')) {
+      return;
     }
+    throw e;
   }
 }
 

--- a/packages/desktop/test/db.test.ts
+++ b/packages/desktop/test/db.test.ts
@@ -68,4 +68,24 @@ describe('initDatabase', () => {
       'initDatabase called with different workspace path; use reinitDatabase to switch',
     );
   });
+
+  it('ignores duplicate column errors during ALTER TABLE migrations', () => {
+    mockDbInstance.exec.mockImplementation((sql: string) => {
+      if (sql.includes('ADD COLUMN')) {
+        throw new Error('SQLITE_ERROR: duplicate column name: gateway_id');
+      }
+    });
+
+    expect(() => initDatabase('/tmp/workspace-a')).not.toThrow();
+  });
+
+  it('propagates non-duplicate ALTER TABLE migration errors', () => {
+    mockDbInstance.exec.mockImplementation((sql: string) => {
+      if (sql.includes('ADD COLUMN')) {
+        throw new Error('SQLITE_ERROR: near "BOGUS": syntax error');
+      }
+    });
+
+    expect(() => initDatabase('/tmp/workspace-a')).toThrow('syntax error');
+  });
 });


### PR DESCRIPTION
## Summary
- `migrateAddColumn` now re-throws SQLite errors that are not duplicate-column failures instead of logging and swallowing them
- Added tests covering both the expected duplicate-column ignore path and the error propagation path

Fixes clawwork-ai/ClawWork#215

## Test plan
- [x] `pnpm check`
- [x] `pnpm --filter @clawwork/desktop test test/db.test.ts`

## release-note
NONE

Made with [Cursor](https://cursor.com)