### PR TITLE
[Fix] Include sessionKey on gateway system error messages

### DIFF
--- a/packages/core/src/services/gateway-dispatcher.ts
+++ b/packages/core/src/services/gateway-dispatcher.ts
@@ -543,7 +543,6 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
         const existing = lifecycleErrorBuffer.get(taskId);
         if (existing) clearTimeout(existing.timer);
 
-        const lifecycleSessionKey = sessionKey;
         const timer = setTimeout(() => {
           lifecycleErrorBuffer.delete(taskId);
           const errorText = data.error!;
@@ -557,7 +556,7 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
           };
           if (shouldDisplayError(correlation)) {
             store.addMessage(taskId, 'system', formatErrorForUser(appError, deps.translate), undefined, {
-              sessionKey: lifecycleSessionKey,
+              sessionKey,
             });
             const { title, description } = formatErrorForToast(appError, deps.translate);
             deps.onToast?.('error', title, { description });

--- a/packages/core/src/services/gateway-dispatcher.ts
+++ b/packages/core/src/services/gateway-dispatcher.ts
@@ -354,7 +354,7 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
 
       if (shouldDisplayError(correlation)) {
         const userText = formatErrorForUser(appError, deps.translate);
-        store.addMessage(taskId, 'system', userText);
+        store.addMessage(taskId, 'system', userText, undefined, { sessionKey });
         const { title, description } = formatErrorForToast(appError, deps.translate);
         deps.onToast?.('error', title, { description });
         recordDisplayedError(correlation);
@@ -369,6 +369,8 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
           taskId,
           'system',
           deps.translate('errors.serverAborted', { defaultValue: 'Task interrupted by server' }),
+          undefined,
+          { sessionKey },
         );
       }
     }
@@ -541,6 +543,7 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
         const existing = lifecycleErrorBuffer.get(taskId);
         if (existing) clearTimeout(existing.timer);
 
+        const lifecycleSessionKey = sessionKey;
         const timer = setTimeout(() => {
           lifecycleErrorBuffer.delete(taskId);
           const errorText = data.error!;
@@ -553,7 +556,9 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
             displayedAt: 0,
           };
           if (shouldDisplayError(correlation)) {
-            store.addMessage(taskId, 'system', formatErrorForUser(appError, deps.translate));
+            store.addMessage(taskId, 'system', formatErrorForUser(appError, deps.translate), undefined, {
+              sessionKey: lifecycleSessionKey,
+            });
             const { title, description } = formatErrorForToast(appError, deps.translate);
             deps.onToast?.('error', title, { description });
             recordDisplayedError(correlation);
@@ -575,7 +580,7 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
             model: data.activeModel,
             defaultValue: `Switched to model: ${data.activeModel}`,
           });
-          store.addMessage(taskId, 'system', msg, undefined, { persist: false });
+          store.addMessage(taskId, 'system', msg, undefined, { persist: false, sessionKey });
         }
         break;
     }

--- a/packages/core/src/stores/message-store.ts
+++ b/packages/core/src/stores/message-store.ts
@@ -27,7 +27,7 @@ export interface MessageState {
     role: MessageRole,
     content: string,
     attachments?: MessageAttachment[],
-    options?: { persist?: boolean },
+    options?: { persist?: boolean; sessionKey?: string },
   ) => Message;
   upsertToolCall: (sessionKey: string, taskId: string, tc: ToolCall) => void;
   bulkLoad: (taskId: string, msgs: Message[]) => void;
@@ -163,6 +163,7 @@ export function createMessageStore(deps: MessageStoreDeps) {
     highlightedMessageId: null,
 
     addMessage: (taskId, role, content, attachments?, options?) => {
+      const sessionKey = options?.sessionKey;
       const msg: Message = {
         id: generateId(),
         taskId,
@@ -172,6 +173,8 @@ export function createMessageStore(deps: MessageStoreDeps) {
         toolCalls: [],
         attachments: attachments?.length ? attachments : undefined,
         timestamp: new Date().toISOString(),
+        sessionKey,
+        agentId: sessionKey ? parseAgentIdFromSessionKey(sessionKey) : undefined,
       };
       set((s) => ({
         messagesByTask: {

--- a/packages/desktop/test/gateway-dispatcher-subagent.test.ts
+++ b/packages/desktop/test/gateway-dispatcher-subagent.test.ts
@@ -358,32 +358,35 @@ describe('system error sessionKey correlation', () => {
 
   it('includes sessionKey on agent lifecycle error system messages', async () => {
     vi.useFakeTimers();
-    const performerKey = 'agent:coder:subagent:aaaa0000-bbbb-cccc-dddd-eeee00001111';
-    const subagentMap: Record<string, string> = { [performerKey]: 'task-1' };
-    const h = createHarness({
-      tasks: [
-        {
-          id: 'task-1',
-          title: 'Ensemble task',
-          gatewayId: 'gw-1',
-          sessionKey: 'agent:conductor:clawwork:task:task-1',
-          ensemble: true,
-        },
-      ],
-      lookupTaskIdBySubagentKey: (key) => subagentMap[key],
-    });
+    try {
+      const performerKey = 'agent:coder:subagent:aaaa0000-bbbb-cccc-dddd-eeee00001111';
+      const subagentMap: Record<string, string> = { [performerKey]: 'task-1' };
+      const h = createHarness({
+        tasks: [
+          {
+            id: 'task-1',
+            title: 'Ensemble task',
+            gatewayId: 'gw-1',
+            sessionKey: 'agent:conductor:clawwork:task:task-1',
+            ensemble: true,
+          },
+        ],
+        lookupTaskIdBySubagentKey: (key) => subagentMap[key],
+      });
 
-    h.emit('agent', {
-      sessionKey: performerKey,
-      stream: 'lifecycle',
-      data: { phase: 'error', error: 'provider unavailable' },
-    });
+      h.emit('agent', {
+        sessionKey: performerKey,
+        stream: 'lifecycle',
+        data: { phase: 'error', error: 'provider unavailable' },
+      });
 
-    await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(2000);
 
-    expect(h.messageStore.addMessage).toHaveBeenCalledWith('task-1', 'system', expect.any(String), undefined, {
-      sessionKey: performerKey,
-    });
-    vi.useRealTimers();
+      expect(h.messageStore.addMessage).toHaveBeenCalledWith('task-1', 'system', expect.any(String), undefined, {
+        sessionKey: performerKey,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/desktop/test/gateway-dispatcher-subagent.test.ts
+++ b/packages/desktop/test/gateway-dispatcher-subagent.test.ts
@@ -13,7 +13,7 @@ function createHarness(
   let listener: EventListener | null = null;
 
   const tasks = overrides?.tasks ?? [];
-  const systemMessages: Array<{ taskId: string; content: string }> = [];
+  const systemMessages: Array<{ taskId: string; content: string; sessionKey?: string }> = [];
   const toasts: Array<{ type: string; title: string }> = [];
   const performerCandidates: Array<{ taskId: string; sessionKey: string; gatewayId: string }> = [];
   const subagentCandidates: Array<{ sessionKey: string; gatewayId: string }> = [];
@@ -21,10 +21,18 @@ function createHarness(
   const messageStore = {
     messagesByTask: {} as Record<string, unknown[]>,
     activeTurnBySession: {} as Record<string, unknown>,
-    addMessage: vi.fn((_taskId: string, _role: string, content: string) => {
-      systemMessages.push({ taskId: _taskId, content });
-      return { id: 'msg-1', taskId: _taskId, role: _role, content, artifacts: [], toolCalls: [], timestamp: '' };
-    }),
+    addMessage: vi.fn(
+      (
+        _taskId: string,
+        _role: string,
+        content: string,
+        _attachments?: unknown,
+        options?: { sessionKey?: string },
+      ) => {
+        systemMessages.push({ taskId: _taskId, content, sessionKey: options?.sessionKey });
+        return { id: 'msg-1', taskId: _taskId, role: _role, content, artifacts: [], toolCalls: [], timestamp: '' };
+      },
+    ),
     upsertToolCall: vi.fn(),
     appendStreamDelta: vi.fn(),
     appendThinkingDelta: vi.fn(),
@@ -298,6 +306,9 @@ describe('subagent terminated error suppression', () => {
     });
 
     expect(h.systemMessages.length).toBe(1);
+    expect(h.systemMessages[0].sessionKey).toBe(
+      'agent:coder:subagent:aaaa0000-bbbb-cccc-dddd-eeee00001111',
+    );
     expect(h.toasts.length).toBe(1);
   });
 
@@ -320,6 +331,75 @@ describe('subagent terminated error suppression', () => {
     });
 
     expect(h.systemMessages.length).toBe(1);
+    expect(h.systemMessages[0].sessionKey).toBe('agent:main:clawwork:task:task-1');
     expect(h.toasts.length).toBe(1);
+  });
+});
+
+describe('system error sessionKey correlation', () => {
+  it('includes sessionKey on chat error system messages', () => {
+    const performerKey = 'agent:coder:subagent:aaaa0000-bbbb-cccc-dddd-eeee00001111';
+    const subagentMap: Record<string, string> = { [performerKey]: 'task-1' };
+    const h = createHarness({
+      tasks: [
+        {
+          id: 'task-1',
+          title: 'Ensemble task',
+          gatewayId: 'gw-1',
+          sessionKey: 'agent:conductor:clawwork:task:task-1',
+          ensemble: true,
+        },
+      ],
+      lookupTaskIdBySubagentKey: (key) => subagentMap[key],
+    });
+
+    h.emit('chat', {
+      sessionKey: performerKey,
+      state: 'error',
+      errorMessage: 'context length exceeded',
+    });
+
+    expect(h.messageStore.addMessage).toHaveBeenCalledWith(
+      'task-1',
+      'system',
+      expect.any(String),
+      undefined,
+      { sessionKey: performerKey },
+    );
+  });
+
+  it('includes sessionKey on agent lifecycle error system messages', async () => {
+    vi.useFakeTimers();
+    const performerKey = 'agent:coder:subagent:aaaa0000-bbbb-cccc-dddd-eeee00001111';
+    const subagentMap: Record<string, string> = { [performerKey]: 'task-1' };
+    const h = createHarness({
+      tasks: [
+        {
+          id: 'task-1',
+          title: 'Ensemble task',
+          gatewayId: 'gw-1',
+          sessionKey: 'agent:conductor:clawwork:task:task-1',
+          ensemble: true,
+        },
+      ],
+      lookupTaskIdBySubagentKey: (key) => subagentMap[key],
+    });
+
+    h.emit('agent', {
+      sessionKey: performerKey,
+      stream: 'lifecycle',
+      data: { phase: 'error', error: 'provider unavailable' },
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(h.messageStore.addMessage).toHaveBeenCalledWith(
+      'task-1',
+      'system',
+      expect.any(String),
+      undefined,
+      { sessionKey: performerKey },
+    );
+    vi.useRealTimers();
   });
 });

--- a/packages/desktop/test/gateway-dispatcher-subagent.test.ts
+++ b/packages/desktop/test/gateway-dispatcher-subagent.test.ts
@@ -22,13 +22,7 @@ function createHarness(
     messagesByTask: {} as Record<string, unknown[]>,
     activeTurnBySession: {} as Record<string, unknown>,
     addMessage: vi.fn(
-      (
-        _taskId: string,
-        _role: string,
-        content: string,
-        _attachments?: unknown,
-        options?: { sessionKey?: string },
-      ) => {
+      (_taskId: string, _role: string, content: string, _attachments?: unknown, options?: { sessionKey?: string }) => {
         systemMessages.push({ taskId: _taskId, content, sessionKey: options?.sessionKey });
         return { id: 'msg-1', taskId: _taskId, role: _role, content, artifacts: [], toolCalls: [], timestamp: '' };
       },
@@ -306,9 +300,7 @@ describe('subagent terminated error suppression', () => {
     });
 
     expect(h.systemMessages.length).toBe(1);
-    expect(h.systemMessages[0].sessionKey).toBe(
-      'agent:coder:subagent:aaaa0000-bbbb-cccc-dddd-eeee00001111',
-    );
+    expect(h.systemMessages[0].sessionKey).toBe('agent:coder:subagent:aaaa0000-bbbb-cccc-dddd-eeee00001111');
     expect(h.toasts.length).toBe(1);
   });
 
@@ -359,13 +351,9 @@ describe('system error sessionKey correlation', () => {
       errorMessage: 'context length exceeded',
     });
 
-    expect(h.messageStore.addMessage).toHaveBeenCalledWith(
-      'task-1',
-      'system',
-      expect.any(String),
-      undefined,
-      { sessionKey: performerKey },
-    );
+    expect(h.messageStore.addMessage).toHaveBeenCalledWith('task-1', 'system', expect.any(String), undefined, {
+      sessionKey: performerKey,
+    });
   });
 
   it('includes sessionKey on agent lifecycle error system messages', async () => {
@@ -393,13 +381,9 @@ describe('system error sessionKey correlation', () => {
 
     await vi.advanceTimersByTimeAsync(2000);
 
-    expect(h.messageStore.addMessage).toHaveBeenCalledWith(
-      'task-1',
-      'system',
-      expect.any(String),
-      undefined,
-      { sessionKey: performerKey },
-    );
+    expect(h.messageStore.addMessage).toHaveBeenCalledWith('task-1', 'system', expect.any(String), undefined, {
+      sessionKey: performerKey,
+    });
     vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

- Extend `addMessage()` with an optional `sessionKey` in its options so system messages can be tied to a specific gateway session.
- Pass `sessionKey` from `gateway-dispatcher` when creating system messages for chat errors, server aborts, agent lifecycle errors, and model fallback notices.
- Add regression tests confirming performer session keys are preserved on error paths in ensemble mode.

Closes #214

## Test plan

- [x] `tsc -b packages/shared packages/core`
- [x] `vitest run test/gateway-dispatcher-subagent.test.ts` (11 tests passed)

## Release note

```release-note
Fixed ensemble task error messages so they include the originating session, making it clear which conductor or performer failed.
```