### PR TITLE
[Fix] Clean up taskGateways map when room reaches stopped

### DIFF
--- a/packages/core/src/stores/room-store.ts
+++ b/packages/core/src/stores/room-store.ts
@@ -66,9 +66,15 @@ export interface RoomState {
 
 const VERIFY_COOLDOWN_MS = 2000;
 
+const TERMINAL_ROOM_STATUSES: ReadonlySet<RoomStatus> = new Set(['stopped']);
+
 export function createRoomStore(deps: RoomStoreDeps) {
   const taskGateways = new Map<string, string>();
   const verifyInFlight = new Set<string>();
+
+  function cleanupRoomResources(taskId: string): void {
+    taskGateways.delete(taskId);
+  }
 
   function updateRoom(
     taskId: string,
@@ -159,6 +165,18 @@ export function createRoomStore(deps: RoomStoreDeps) {
 
     setRoomStatus: (taskId, status) => {
       updateRoom(taskId, { status }, set);
+      if (TERMINAL_ROOM_STATUSES.has(status)) {
+        cleanupRoomResources(taskId);
+        set((s) => {
+          const nextMap = { ...s.subagentKeyMap };
+          for (const [key, id] of Object.entries(nextMap)) {
+            if (id === taskId) {
+              delete nextMap[key];
+            }
+          }
+          return { subagentKeyMap: nextMap };
+        });
+      }
       const room = get().rooms[taskId];
       if (room) {
         deps.persistRoom({ taskId, status, conductorReady: room.conductorReady }).catch((err) => {

--- a/packages/core/test/room-store.test.ts
+++ b/packages/core/test/room-store.test.ts
@@ -99,3 +99,82 @@ describe('room-store persistence failures', () => {
     expect(store.getState().lookupTaskIdBySubagentKey(subagentKey)).toBe(taskId);
   });
 });
+
+describe('room store', () => {
+  it('setRoomStatus persists stopped rooms and allows re-init for the same task', async () => {
+    const deps = createDeps({
+      loadRoom: vi.fn(async () => ({ ok: false, room: null, performers: [] })),
+    });
+    const store = createRoomStore(deps);
+    const sessionKey = buildSessionKey('task-1');
+
+    const ok = await store.getState().initConductor('task-1', 'gw-1', sessionKey, '[]');
+    expect(ok).toBe(true);
+    expect(store.getState().getRoom('task-1')?.status).toBe('active');
+
+    store.getState().setRoomStatus('task-1', 'stopped');
+    expect(store.getState().getRoom('task-1')?.status).toBe('stopped');
+    expect(deps.persistRoom).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      status: 'stopped',
+      conductorReady: true,
+    });
+
+    const okAgain = await store.getState().initConductor('task-1', 'gw-2', sessionKey, '[]');
+    expect(okAgain).toBe(true);
+    expect(store.getState().getRoom('task-1')?.status).toBe('active');
+    expect(deps.createSession).toHaveBeenLastCalledWith('gw-2', expect.any(Object));
+  });
+
+  it('clears subagentKeyMap entries when room reaches stopped', async () => {
+    const taskId = 'task-1';
+    const sessionKey = buildSessionKey(taskId);
+    const subagentKey = 'agent:main:subagent:abc-123-def4-5678-90ab-cdef12345678';
+    const deps = createDeps({
+      loadRoom: vi.fn(async () => ({
+        ok: true,
+        room: { status: 'active', conductorReady: true },
+        performers: [],
+      })),
+    });
+    const store = createRoomStore(deps);
+    await store.getState().hydrateRoom(taskId, sessionKey);
+    store.getState().registerPerformerKey(taskId, subagentKey, 'performer-1', 'Performer');
+
+    expect(store.getState().lookupTaskIdBySubagentKey(subagentKey)).toBe(taskId);
+
+    store.getState().setRoomStatus(taskId, 'stopped');
+
+    expect(store.getState().lookupTaskIdBySubagentKey(subagentKey)).toBeUndefined();
+  });
+
+  it('clears subagentKeyMap entries hydrated from persisted performers when room stops', async () => {
+    const taskId = 'task-1';
+    const sessionKey = buildSessionKey(taskId);
+    const subagentKey = 'agent:main:subagent:abc-123-def4-5678-90ab-cdef12345678';
+    const deps = createDeps({
+      loadRoom: vi.fn(async () => ({
+        ok: true,
+        room: { status: 'active', conductorReady: true },
+        performers: [
+          {
+            sessionKey: subagentKey,
+            taskId,
+            agentId: 'performer-1',
+            agentName: 'Performer',
+            emoji: null,
+            verifiedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      })),
+    });
+    const store = createRoomStore(deps);
+    await store.getState().hydrateRoom(taskId, sessionKey);
+
+    expect(store.getState().lookupTaskIdBySubagentKey(subagentKey)).toBe(taskId);
+
+    store.getState().setRoomStatus(taskId, 'stopped');
+
+    expect(store.getState().lookupTaskIdBySubagentKey(subagentKey)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `cleanupRoomResources()` in `room-store` to remove per-task entries from the module-scoped `taskGateways` map when a room transitions to the `stopped` terminal state via `setRoomStatus()`.
- Purge `subagentKeyMap` entries for the stopped task to prevent stale routing and memory growth.
- Add unit tests covering init → stop → re-init lifecycle for the same task, and subagentKeyMap cleanup on stop.

Closes #212

## Test plan

- [x] `pnpm --filter @clawwork/core test` (room-store.test.ts passes)
- [x] `pnpm check`

release-note: NONE