### PR TITLE
[Fix] validate spawnedBy in listSessionsBySpawner

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -237,10 +237,14 @@ export function registerWsHandlers(): void {
   );
 
   ipcMain.handle('ws:list-sessions-by-spawner', async (_event, payload: { gatewayId: string; spawnedBy: string }) => {
+    const { spawnedBy } = payload;
+    if (!spawnedBy || typeof spawnedBy !== 'string' || spawnedBy.length === 0) {
+      return { ok: false, error: 'invalid spawnedBy parameter' };
+    }
     const gw = getGatewayClient(payload.gatewayId);
     if (!gw?.isConnected) return { ok: false, error: 'gateway not connected' };
     try {
-      const result = await gw.listSessionsBySpawner(payload.spawnedBy);
+      const result = await gw.listSessionsBySpawner(spawnedBy);
       return { ok: true, result };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -596,6 +596,9 @@ export class GatewayClient {
   }
 
   async listSessionsBySpawner(spawnedBy: string): Promise<Record<string, unknown>> {
+    if (!spawnedBy || typeof spawnedBy !== 'string' || spawnedBy.length === 0) {
+      throw new Error('invalid spawnedBy parameter');
+    }
     return this.sendReq('sessions.list', { spawnedBy }, { requestId: randomUUID() });
   }
 

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -11,6 +11,7 @@ const patchConfigMock = vi.fn();
 const getConfigSchemaMock = vi.fn();
 const lookupConfigSchemaMock = vi.fn();
 const getChatHistoryMock = vi.fn();
+const listSessionsBySpawnerMock = vi.fn();
 
 const fakeGatewayClient = {
   isConnected: true,
@@ -24,6 +25,7 @@ const fakeGatewayClient = {
   getConfigSchema: getConfigSchemaMock,
   lookupConfigSchema: lookupConfigSchemaMock,
   getChatHistory: getChatHistoryMock,
+  listSessionsBySpawner: listSessionsBySpawnerMock,
 };
 
 vi.mock('electron', () => ({
@@ -354,6 +356,32 @@ describe('ws-handlers: skills + config IPC channels', () => {
 
       expect(lookupConfigSchemaMock).toHaveBeenCalledWith('model');
       expect(result).toEqual({ ok: true, result: lookupResult });
+    });
+  });
+
+  describe('ws:list-sessions-by-spawner', () => {
+    it('rejects missing or empty spawnedBy before calling the gateway', async () => {
+      for (const spawnedBy of [undefined, null, '', 123]) {
+        listSessionsBySpawnerMock.mockClear();
+
+        const result = await invoke('ws:list-sessions-by-spawner', { gatewayId: 'gw-1', spawnedBy });
+
+        expect(result).toEqual({ ok: false, error: 'invalid spawnedBy parameter' });
+        expect(listSessionsBySpawnerMock).not.toHaveBeenCalled();
+      }
+    });
+
+    it('forwards a valid spawnedBy key to the gateway', async () => {
+      const sessions = { sessions: [{ key: 'agent:coder:subagent:abc' }] };
+      listSessionsBySpawnerMock.mockResolvedValue(sessions);
+
+      const result = await invoke('ws:list-sessions-by-spawner', {
+        gatewayId: 'gw-1',
+        spawnedBy: 'agent:conductor:clawwork:task:task-1',
+      });
+
+      expect(listSessionsBySpawnerMock).toHaveBeenCalledWith('agent:conductor:clawwork:task:task-1');
+      expect(result).toEqual({ ok: true, result: sessions });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Validate `spawnedBy` in the `ws:list-sessions-by-spawner` IPC handler before calling the gateway
- Add matching defense-in-depth validation in `GatewayClient.listSessionsBySpawner()`
- Add tests covering invalid and valid `spawnedBy` values

Closes #213

## Test plan

- [x] `pnpm --dir packages/desktop test -- ws-handlers-skills-config.test.ts`
- [x] Pre-commit hooks (eslint, prettier, architecture guardrails)

release-note: NONE

Made with [Cursor](https://cursor.com)