### PR TITLE
[Fix] validate spawnedBy in listSessionsBySpawner IPC handler

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -237,10 +237,14 @@ export function registerWsHandlers(): void {
   );
 
   ipcMain.handle('ws:list-sessions-by-spawner', async (_event, payload: { gatewayId: string; spawnedBy: string }) => {
+    const { spawnedBy } = payload;
+    if (!spawnedBy || typeof spawnedBy !== 'string' || spawnedBy.length === 0) {
+      return { ok: false, error: 'invalid spawnedBy parameter' };
+    }
     const gw = getGatewayClient(payload.gatewayId);
     if (!gw?.isConnected) return { ok: false, error: 'gateway not connected' };
     try {
-      const result = await gw.listSessionsBySpawner(payload.spawnedBy);
+      const result = await gw.listSessionsBySpawner(spawnedBy);
       return { ok: true, result };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -596,6 +596,9 @@ export class GatewayClient {
   }
 
   async listSessionsBySpawner(spawnedBy: string): Promise<Record<string, unknown>> {
+    if (!spawnedBy || typeof spawnedBy !== 'string' || spawnedBy.length === 0) {
+      throw new Error('invalid spawnedBy parameter');
+    }
     return this.sendReq('sessions.list', { spawnedBy }, { requestId: randomUUID() });
   }
 

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -11,6 +11,7 @@ const patchConfigMock = vi.fn();
 const getConfigSchemaMock = vi.fn();
 const lookupConfigSchemaMock = vi.fn();
 const getChatHistoryMock = vi.fn();
+const listSessionsBySpawnerMock = vi.fn();
 
 const fakeGatewayClient = {
   isConnected: true,
@@ -24,6 +25,7 @@ const fakeGatewayClient = {
   getConfigSchema: getConfigSchemaMock,
   lookupConfigSchema: lookupConfigSchemaMock,
   getChatHistory: getChatHistoryMock,
+  listSessionsBySpawner: listSessionsBySpawnerMock,
 };
 
 vi.mock('electron', () => ({
@@ -354,6 +356,37 @@ describe('ws-handlers: skills + config IPC channels', () => {
 
       expect(lookupConfigSchemaMock).toHaveBeenCalledWith('model');
       expect(result).toEqual({ ok: true, result: lookupResult });
+    });
+  });
+
+  describe('ws:list-sessions-by-spawner', () => {
+    it('rejects missing spawnedBy before contacting the gateway', async () => {
+      const result = await invoke('ws:list-sessions-by-spawner', { gatewayId: 'gw-1', spawnedBy: '' });
+
+      expect(result).toEqual({ ok: false, error: 'invalid spawnedBy parameter' });
+      expect(listSessionsBySpawnerMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-string spawnedBy before contacting the gateway', async () => {
+      const result = await invoke('ws:list-sessions-by-spawner', {
+        gatewayId: 'gw-1',
+        spawnedBy: 123 as unknown as string,
+      });
+
+      expect(result).toEqual({ ok: false, error: 'invalid spawnedBy parameter' });
+      expect(listSessionsBySpawnerMock).not.toHaveBeenCalled();
+    });
+
+    it('forwards valid spawnedBy to listSessionsBySpawner', async () => {
+      listSessionsBySpawnerMock.mockResolvedValue({ sessions: [] });
+
+      const result = await invoke('ws:list-sessions-by-spawner', {
+        gatewayId: 'gw-1',
+        spawnedBy: 'agent:main:clawwork:task:task-1',
+      });
+
+      expect(listSessionsBySpawnerMock).toHaveBeenCalledWith('agent:main:clawwork:task:task-1');
+      expect(result).toEqual({ ok: true, result: { sessions: [] } });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add client-side validation for the `spawnedBy` parameter in the `ws:list-sessions-by-spawner` IPC handler before forwarding to the gateway
- Add matching defense-in-depth validation in `GatewayClient.listSessionsBySpawner()`
- Add unit tests covering empty, non-string, and valid `spawnedBy` values

Closes #213

## Test plan

- [x] `pnpm check` passes
- [x] `ws:list-sessions-by-spawner` rejects empty and non-string `spawnedBy` without contacting the gateway
- [x] Valid `spawnedBy` values are forwarded to `listSessionsBySpawner` as before

## Release note

NONE

Made with [Cursor](https://cursor.com)