### PR TITLE
[Build] Harden ci-bot workflow against CI/CD injection

### DIFF
--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -80,9 +80,8 @@ env:
     </details>
 
 permissions:
-  actions: write
   checks: read
-  contents: write
+  contents: read
   deployments: none
   id-token: none
   issues: write
@@ -99,13 +98,36 @@ jobs:
     name: Bot
     runs-on: ubuntu-latest
     steps:
+      # Fetch comment bodies via API instead of embedding untrusted event payloads
+      # in workflow expressions (see clawwork-ai/ClawWork#132).
+      - name: Load message body safely
+        if: >-
+          github.event_name == 'issue_comment' ||
+          github.event_name == 'pull_request_review_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            body=$(gh api "repos/${GH_REPOSITORY}/pulls/comments/${{ github.event.comment.id }}" --jq '.body')
+          else
+            body=$(gh api "repos/${GH_REPOSITORY}/issues/comments/${{ github.event.comment.id }}" --jq '.body')
+          fi
+          delimiter=$(openssl rand -hex 16)
+          {
+            echo "MESSAGE<<${delimiter}"
+            printf '%s' "$body"
+            echo
+            echo "${delimiter}"
+          } >> "$GITHUB_ENV"
+
       - name: Issue Opened
-        uses: wzshiming/gh-ci-bot@v1.5.0
+        uses: wzshiming/gh-ci-bot@7bce89588aeb39494eefafef4ede1d845f61d403 # v1.5.0
         if: ${{ github.event_name == 'issues' }}
         env:
           LOGIN: ${{ github.event.issue.user.login }}
           AUTHOR: ${{ github.event.issue.user.login }}
-          MESSAGE: ${{ github.event.issue.body }}
+          MESSAGE: ''
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           AUTHOR_ASSOCIATION: ${{ github.event.issue.author_association }}
           ISSUE_KIND: issue
@@ -116,12 +138,12 @@ jobs:
             We will look into it as soon as possible.
 
       - name: PR Opened
-        uses: wzshiming/gh-ci-bot@v1.5.0
+        uses: wzshiming/gh-ci-bot@7bce89588aeb39494eefafef4ede1d845f61d403 # v1.5.0
         if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'opened' }}
         env:
           LOGIN: ${{ github.event.pull_request.user.login }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
-          MESSAGE: ${{ github.event.pull_request.body }}
+          MESSAGE: ''
           ISSUE_NUMBER: ${{ github.event.pull_request.number }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           ISSUE_KIND: pr
@@ -133,7 +155,7 @@ jobs:
             We will review it shortly.
 
       - name: PR Synchronize
-        uses: wzshiming/gh-ci-bot@v1.5.0
+        uses: wzshiming/gh-ci-bot@7bce89588aeb39494eefafef4ede1d845f61d403 # v1.5.0
         if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'synchronize' }}
         env:
           LOGIN: ${{ github.event.pull_request.user.login }}
@@ -145,36 +167,33 @@ jobs:
           TYPE: synchronize
 
       - name: Issue Commented
-        uses: wzshiming/gh-ci-bot@v1.5.0
+        uses: wzshiming/gh-ci-bot@7bce89588aeb39494eefafef4ede1d845f61d403 # v1.5.0
         if: ${{ github.event_name == 'issue_comment' && !github.event.issue.pull_request }}
         env:
           LOGIN: ${{ github.event.comment.user.login }}
           AUTHOR: ${{ github.event.issue.user.login }}
-          MESSAGE: ${{ github.event.comment.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
           ISSUE_KIND: issue
           TYPE: comment
 
       - name: PR Review Commented
-        uses: wzshiming/gh-ci-bot@v1.5.0
+        uses: wzshiming/gh-ci-bot@7bce89588aeb39494eefafef4ede1d845f61d403 # v1.5.0
         if: ${{ github.event_name == 'pull_request_review_comment' }}
         env:
           LOGIN: ${{ github.event.comment.user.login }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
-          MESSAGE: ${{ github.event.comment.body }}
           ISSUE_NUMBER: ${{ github.event.pull_request.number }}
           AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
           ISSUE_KIND: pr
           TYPE: comment
 
       - name: PR Commented
-        uses: wzshiming/gh-ci-bot@v1.5.0
+        uses: wzshiming/gh-ci-bot@7bce89588aeb39494eefafef4ede1d845f61d403 # v1.5.0
         if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
         env:
           LOGIN: ${{ github.event.comment.user.login }}
           AUTHOR: ${{ github.event.issue.user.login }}
-          MESSAGE: ${{ github.event.comment.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
           ISSUE_KIND: pr

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -46,6 +46,7 @@ jobs:
               - 'eslint.config.mjs'
               - 'knip.json'
               - 'scripts/**'
+              - '.github/workflows/ci-bot.yml'
               - '.github/workflows/pr-check.yml'
               - '.github/workflows/e2e.yml'
             shared:
@@ -141,6 +142,9 @@ jobs:
 
       - name: Format check
         run: pnpm format:check
+
+      - name: CI bot security guardrails
+        run: pnpm check:ci-bot-security
 
       - name: Architecture guardrails
         if: needs.changes.outputs.architecture == 'true'

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:slides:dev": "pnpm --filter @clawwork/keynote dev:dev",
     "build": "pnpm -r build",
     "check:architecture": "node scripts/check-architecture.mjs",
+    "check:ci-bot-security": "node scripts/check-ci-bot-security.mjs",
     "check:renderer-copy": "node scripts/check-renderer-copy.mjs",
     "check:ui-contract": "node scripts/check-ui-contract.mjs",
     "typecheck": "pnpm --filter @clawwork/shared exec tsc -b && pnpm --filter @clawwork/core exec tsc -b && pnpm --filter @clawwork/pwa exec tsc --noEmit && pnpm --filter @clawwork/desktop exec tsc --noEmit && pnpm --filter @clawwork/website exec tsc --noEmit",
@@ -30,7 +31,7 @@
     "check:dead-code": "knip",
     "typecheck:e2e": "pnpm --filter @clawwork/desktop exec tsc --noEmit -p ../../e2e/tsconfig.json",
     "release-notes": "node scripts/generate-release-notes.mjs",
-    "check": "pnpm lint && pnpm check:architecture && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm typecheck:tests && pnpm typecheck:e2e && pnpm test"
+    "check": "pnpm lint && pnpm check:architecture && pnpm check:ci-bot-security && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm typecheck:tests && pnpm typecheck:e2e && pnpm test"
   },
   "lint-staged": {
     "*.{ts,tsx,mts,cts,js,mjs,cjs}": [

--- a/scripts/check-ci-bot-security.mjs
+++ b/scripts/check-ci-bot-security.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const workflowPath = '.github/workflows/ci-bot.yml';
+const content = readFileSync(path.join(root, workflowPath), 'utf8');
+const violations = [];
+
+function record(line, message, match = '') {
+  violations.push({ line, message, match });
+}
+
+for (const [index, line] of content.split('\n').entries()) {
+  const lineNo = index + 1;
+
+  if (/MESSAGE:\s*\$\{\{\s*github\.event\.[^}]+\.body\s*\}\}/.test(line)) {
+    record(lineNo, 'Untrusted issue/PR/comment bodies must not be interpolated into MESSAGE env vars.', line.trim());
+  }
+
+  if (/uses:\s*wzshiming\/gh-ci-bot@v/.test(line)) {
+    record(lineNo, 'gh-ci-bot must be pinned to a commit SHA, not a mutable version tag.', line.trim());
+  }
+
+  if (/^\s*actions:\s*write\s*$/.test(line)) {
+    record(lineNo, 'ci-bot must not request actions: write permission.', line.trim());
+  }
+
+  if (/^\s*contents:\s*write\s*$/.test(line)) {
+    record(lineNo, 'ci-bot must not request contents: write permission.', line.trim());
+  }
+}
+
+if (!/uses:\s*wzshiming\/gh-ci-bot@[0-9a-f]{40}/.test(content)) {
+  record(0, 'Expected at least one gh-ci-bot action pinned to a 40-character commit SHA.');
+}
+
+if (!/name:\s*Load message body safely/.test(content)) {
+  record(0, 'Expected a step that loads comment bodies via the GitHub API.');
+}
+
+if (violations.length > 0) {
+  console.error('CI bot workflow security violations found:\n');
+  for (const v of violations) {
+    const prefix = v.line > 0 ? `${workflowPath}:${v.line}` : workflowPath;
+    console.error(`  ${prefix}  ${v.message}`);
+    if (v.match) console.error(`    ${v.match}`);
+  }
+  process.exit(1);
+}
+
+console.log('CI bot workflow security guardrails passed.');


### PR DESCRIPTION
## Summary

Addresses security findings in #132 for the `ci-bot.yml` workflow:

- **Pin third-party action**: `wzshiming/gh-ci-bot` is pinned to commit `7bce89588aeb39494eefafef4ede1d845f61d403` (v1.5.0) instead of a mutable version tag.
- **Least-privilege permissions**: Removed `actions: write` and downgraded `contents: write` to `contents: read`. The bot only needs `issues: write` and `pull-requests: write` for labels and comments.
- **Stop embedding untrusted bodies in workflow expressions**: Issue/PR bodies no longer flow into `MESSAGE` env vars. Comment bodies are fetched via the GitHub API in a dedicated step and written to `GITHUB_ENV`, avoiding direct interpolation of attacker-controlled payloads into workflow YAML.

Closes #132

## Test plan

- [x] `pnpm check` passes locally
- [ ] CI Bot workflow still greets on new issues/PRs
- [ ] Slash commands in issue/PR comments still work (e.g. `/label-bug`, `/retest`)

## Release note

NONE