### PR TITLE
[UI] Session preview snippets in LeftNav task list

### DIFF
--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -660,6 +660,23 @@ export function registerWsHandlers(): void {
   );
 
   ipcMain.handle(
+    'ws:session-preview',
+    async (
+      _event,
+      payload: {
+        gatewayId: string;
+        keys: string[];
+        limit?: number;
+        maxChars?: number;
+      },
+    ) => {
+      const { gatewayId, keys, limit, maxChars } = payload;
+      if (!keys.length) return { ok: false, error: 'no session keys provided' };
+      return gatewayRpc(gatewayId, (gw) => gw.previewSessions({ keys, limit, maxChars }));
+    },
+  );
+
+  ipcMain.handle(
     'ws:exec-approval-resolve',
     async (
       _event,

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -757,6 +757,14 @@ export class GatewayClient {
     return this.sendReq('sessions.usage', params as unknown as Record<string, unknown>);
   }
 
+  async previewSessions(params: {
+    keys: string[];
+    limit?: number;
+    maxChars?: number;
+  }): Promise<Record<string, unknown>> {
+    return this.sendReq('sessions.preview', params as unknown as Record<string, unknown>);
+  }
+
   async listCronJobs(params?: Record<string, unknown>): Promise<Record<string, unknown>> {
     return this.sendReq('cron.list', params ?? {});
   }

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -31,6 +31,7 @@ import type {
   ConfigSchemaLookupResult,
   ParsedTeam,
   AgentFileSet,
+  SessionsPreviewResult,
 } from '@clawwork/shared';
 
 type IpcResult<T = Record<string, unknown>> = SharedIpcResult<T>;
@@ -472,6 +473,11 @@ export interface ClawWorkAPI {
     params?: { startDate?: string; endDate?: string; days?: number },
   ) => Promise<IpcResult>;
   getSessionUsage: (gatewayId: string, sessionKey: string) => Promise<IpcResult>;
+  previewSessions: (
+    gatewayId: string,
+    keys: string[],
+    options?: { limit?: number; maxChars?: number },
+  ) => Promise<IpcResult<SessionsPreviewResult>>;
 
   resolveExecApproval: (gatewayId: string, id: string, decision: ApprovalDecision) => Promise<IpcResult>;
 

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -298,6 +298,8 @@ function buildApi(): ClawWorkAPI {
       ipcRenderer.invoke('ws:usage-cost', { gatewayId, ...params }),
     getSessionUsage: (gatewayId: string, sessionKey: string) =>
       ipcRenderer.invoke('ws:session-usage', { gatewayId, sessionKey }),
+    previewSessions: (gatewayId: string, keys: string[], options?: { limit?: number; maxChars?: number }) =>
+      ipcRenderer.invoke('ws:session-preview', { gatewayId, keys, ...options }),
 
     resolveExecApproval: (gatewayId: string, id: string, decision: ApprovalDecision) =>
       ipcRenderer.invoke('ws:exec-approval-resolve', { gatewayId, id, decision }),

--- a/packages/desktop/src/renderer/hooks/useSessionPreviews.ts
+++ b/packages/desktop/src/renderer/hooks/useSessionPreviews.ts
@@ -41,6 +41,7 @@ export function useSessionPreviews(tasks: Task[]): Record<string, TaskSessionPre
   const [previews, setPreviews] = useState<Record<string, TaskSessionPreview>>({});
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const inFlightRef = useRef(false);
+  const pendingRefreshRef = useRef(false);
 
   useEffect(() => {
     if (tasks.length === 0) {
@@ -48,10 +49,13 @@ export function useSessionPreviews(tasks: Task[]): Record<string, TaskSessionPre
       return;
     }
 
-    clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      if (inFlightRef.current) return;
+    const runFetch = () => {
+      if (inFlightRef.current) {
+        pendingRefreshRef.current = true;
+        return;
+      }
       inFlightRef.current = true;
+      pendingRefreshRef.current = false;
 
       const sessionKeyToTaskId = new Map<string, string>();
       const byGateway = new Map<string, string[]>();
@@ -103,8 +107,6 @@ export function useSessionPreviews(tasks: Task[]): Record<string, TaskSessionPre
           );
         } catch (err) {
           console.error('[session-preview] fetch failed:', err);
-        } finally {
-          inFlightRef.current = false;
         }
 
         for (const task of tasks) {
@@ -116,9 +118,19 @@ export function useSessionPreviews(tasks: Task[]): Record<string, TaskSessionPre
           }
         }
 
-        if (Object.keys(updates).length > 0) applyUpdates(updates);
+        const needsRefetch = pendingRefreshRef.current;
+        if (!needsRefetch && Object.keys(updates).length > 0) applyUpdates(updates);
+
+        inFlightRef.current = false;
+        if (needsRefetch) {
+          pendingRefreshRef.current = false;
+          runFetch();
+        }
       })();
-    }, 300);
+    };
+
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(runFetch, 300);
 
     return () => clearTimeout(timerRef.current);
   }, [taskFingerprint, connectedGateways, unreadRevision, messageRevision, tasks, gatewayStatusMap]);

--- a/packages/desktop/src/renderer/hooks/useSessionPreviews.ts
+++ b/packages/desktop/src/renderer/hooks/useSessionPreviews.ts
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Task, SessionsPreviewEntry, SessionsPreviewResult } from '@clawwork/shared';
+import { useUiStore } from '@/stores/uiStore';
+import { useMessageStore } from '@/stores/messageStore';
+
+export type SessionPreviewState = 'loading' | 'empty' | 'ready';
+
+export interface TaskSessionPreview {
+  text: string | null;
+  state: SessionPreviewState;
+}
+
+function extractSnippet(entry: SessionsPreviewEntry): string | null {
+  if (entry.status !== 'ok' || entry.items.length === 0) return null;
+  const last = entry.items[entry.items.length - 1];
+  const text = last?.text?.replace(/\s+/g, ' ').trim();
+  return text || null;
+}
+
+function connectedGatewayKey(statusMap: Record<string, string>): string {
+  return Object.entries(statusMap)
+    .filter(([, status]) => status === 'connected')
+    .map(([id]) => id)
+    .sort()
+    .join(',');
+}
+
+export function useSessionPreviews(tasks: Task[]): Record<string, TaskSessionPreview> {
+  const gatewayStatusMap = useUiStore((s) => s.gatewayStatusMap);
+  const unreadRevision = useUiStore((s) => Array.from(s.unreadTaskIds).sort().join(','));
+  const messageRevision = useMessageStore((s) =>
+    tasks.map((task) => `${task.id}:${s.messagesByTask[task.id]?.length ?? 0}`).join('|'),
+  );
+
+  const taskFingerprint = useMemo(
+    () => tasks.map((task) => `${task.id}:${task.sessionKey}:${task.gatewayId}`).join('|'),
+    [tasks],
+  );
+  const connectedGateways = useMemo(() => connectedGatewayKey(gatewayStatusMap), [gatewayStatusMap]);
+
+  const [previews, setPreviews] = useState<Record<string, TaskSessionPreview>>({});
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (tasks.length === 0) {
+      setPreviews({});
+      return;
+    }
+
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+
+      const sessionKeyToTaskId = new Map<string, string>();
+      const byGateway = new Map<string, string[]>();
+
+      for (const task of tasks) {
+        sessionKeyToTaskId.set(task.sessionKey, task.id);
+        if (gatewayStatusMap[task.gatewayId] !== 'connected') continue;
+        const keys = byGateway.get(task.gatewayId) ?? [];
+        keys.push(task.sessionKey);
+        byGateway.set(task.gatewayId, keys);
+      }
+
+      setPreviews((prev) => {
+        const next: Record<string, TaskSessionPreview> = { ...prev };
+        for (const task of tasks) {
+          if (gatewayStatusMap[task.gatewayId] !== 'connected') {
+            next[task.id] = { text: null, state: 'empty' };
+            continue;
+          }
+          const existing = prev[task.id];
+          next[task.id] = {
+            text: existing?.text ?? null,
+            state: existing?.state === 'ready' ? 'ready' : 'loading',
+          };
+        }
+        return next;
+      });
+
+      const applyUpdates = (updates: Record<string, TaskSessionPreview>) => {
+        setPreviews((prev) => ({ ...prev, ...updates }));
+      };
+
+      void (async () => {
+        const updates: Record<string, TaskSessionPreview> = {};
+
+        try {
+          await Promise.all(
+            Array.from(byGateway.entries()).map(async ([gatewayId, keys]) => {
+              const res = await window.clawwork.previewSessions(gatewayId, keys, { limit: 1, maxChars: 120 });
+              if (!res.ok || !res.result) return;
+              const result = res.result as SessionsPreviewResult;
+              for (const entry of result.previews ?? []) {
+                const taskId = sessionKeyToTaskId.get(entry.key);
+                if (!taskId) continue;
+                const snippet = extractSnippet(entry);
+                updates[taskId] = { text: snippet, state: snippet ? 'ready' : 'empty' };
+              }
+            }),
+          );
+        } catch (err) {
+          console.error('[session-preview] fetch failed:', err);
+        } finally {
+          inFlightRef.current = false;
+        }
+
+        for (const task of tasks) {
+          if (updates[task.id]) continue;
+          if (gatewayStatusMap[task.gatewayId] !== 'connected') {
+            updates[task.id] = { text: null, state: 'empty' };
+          } else if (byGateway.has(task.gatewayId)) {
+            updates[task.id] = { text: null, state: 'empty' };
+          }
+        }
+
+        if (Object.keys(updates).length > 0) applyUpdates(updates);
+      })();
+    }, 300);
+
+    return () => clearTimeout(timerRef.current);
+  }, [taskFingerprint, connectedGateways, unreadRevision, messageRevision, tasks, gatewayStatusMap]);
+
+  return previews;
+}

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -339,6 +339,7 @@
     "groupOlder": "Älter",
     "groupToday": "Heute",
     "groupYesterday": "Gestern",
+    "noPreview": "Noch keine Nachrichten",
     "scheduledTasks": "Geplant",
     "searchTasks": "Aufgaben suchen…",
     "updateAvailable": "Update verfuegbar"

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -339,6 +339,7 @@
     "groupOlder": "Older",
     "groupToday": "Today",
     "groupYesterday": "Yesterday",
+    "noPreview": "No messages yet",
     "scheduledTasks": "Scheduled",
     "searchTasks": "Search tasks…",
     "updateAvailable": "Update available"

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -339,6 +339,7 @@
     "groupOlder": "Anterior",
     "groupToday": "Hoy",
     "groupYesterday": "Ayer",
+    "noPreview": "Aún no hay mensajes",
     "scheduledTasks": "Programadas",
     "searchTasks": "Buscar tareas…",
     "updateAvailable": "Actualización disponible"

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -339,6 +339,7 @@
     "groupOlder": "以前",
     "groupToday": "今日",
     "groupYesterday": "昨日",
+    "noPreview": "メッセージはまだありません",
     "scheduledTasks": "スケジュール",
     "searchTasks": "タスクを検索…",
     "updateAvailable": "アップデートがあります"

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -339,6 +339,7 @@
     "groupOlder": "이전",
     "groupToday": "오늘",
     "groupYesterday": "어제",
+    "noPreview": "아직 메시지 없음",
     "scheduledTasks": "예약 작업",
     "searchTasks": "작업 검색…",
     "updateAvailable": "업데이트 가능"

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -339,6 +339,7 @@
     "groupOlder": "Anterior",
     "groupToday": "Hoje",
     "groupYesterday": "Ontem",
+    "noPreview": "Ainda sem mensagens",
     "scheduledTasks": "Agendadas",
     "searchTasks": "Buscar tarefas…",
     "updateAvailable": "Atualização disponível"

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -339,6 +339,7 @@
     "groupOlder": "更早",
     "groupToday": "今天",
     "groupYesterday": "昨天",
+    "noPreview": "尚無訊息",
     "scheduledTasks": "排程任務",
     "searchTasks": "搜尋任務…",
     "updateAvailable": "有可用更新"

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -339,6 +339,7 @@
     "groupOlder": "更早",
     "groupToday": "今天",
     "groupYesterday": "昨天",
+    "noPreview": "暂无消息",
     "scheduledTasks": "定时任务",
     "searchTasks": "搜索任务…",
     "updateAvailable": "有新版本可用"

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -85,8 +85,6 @@ export default function TaskItem({
       : preview?.state === 'empty'
         ? t('leftNav.noPreview')
         : null;
-  const tooltipLabel = previewText ? `${title}\n${previewText}` : title;
-
   if (collapsed) {
     return (
       <Tooltip>
@@ -118,7 +116,9 @@ export default function TaskItem({
             {hasUnread && <span className="absolute bottom-0.5 right-1 w-2 h-2 rounded-full bg-[var(--accent)]" />}
           </motion.button>
         </TooltipTrigger>
-        <TooltipContent side="right">{tooltipLabel}</TooltipContent>
+        <TooltipContent side="right" className={previewText ? 'whitespace-pre-line' : undefined}>
+          {previewText ? `${title}\n${previewText}` : title}
+        </TooltipContent>
       </Tooltip>
     );
   }

--- a/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/TaskItem.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { deriveSessionActivity, getTaskSessionKeys } from '@clawwork/core';
 import type { Task } from '@clawwork/shared';
 import ActivityBars from '@/components/ActivityBars';
+import type { TaskSessionPreview } from '@/hooks/useSessionPreviews';
 
 interface TaskItemProps {
   task: Task;
@@ -20,9 +21,18 @@ interface TaskItemProps {
   collapsed?: boolean;
   editing?: boolean;
   onEditDone?: () => void;
+  preview?: TaskSessionPreview;
 }
 
-export default function TaskItem({ task, active, onContextMenu, collapsed, editing, onEditDone }: TaskItemProps) {
+export default function TaskItem({
+  task,
+  active,
+  onContextMenu,
+  collapsed,
+  editing,
+  onEditDone,
+  preview,
+}: TaskItemProps) {
   const { t } = useTranslation();
   const reduced = useReducedMotion();
   const setActiveTask = useTaskStore((s) => s.setActiveTask);
@@ -68,6 +78,15 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
     setMainView('chat');
   };
 
+  const title = task.title || t('common.newTask');
+  const previewText =
+    preview?.state === 'ready' && preview.text
+      ? preview.text
+      : preview?.state === 'empty'
+        ? t('leftNav.noPreview')
+        : null;
+  const tooltipLabel = previewText ? `${title}\n${previewText}` : title;
+
   if (collapsed) {
     return (
       <Tooltip>
@@ -99,7 +118,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
             {hasUnread && <span className="absolute bottom-0.5 right-1 w-2 h-2 rounded-full bg-[var(--accent)]" />}
           </motion.button>
         </TooltipTrigger>
-        <TooltipContent side="right">{task.title || t('common.newTask')}</TooltipContent>
+        <TooltipContent side="right">{tooltipLabel}</TooltipContent>
       </Tooltip>
     );
   }
@@ -124,7 +143,7 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
               : 'hover:bg-[var(--bg-hover)]',
       )}
     >
-      <div className="flex items-center gap-2 px-3 h-9">
+      <div className={cn('flex items-center gap-2 px-3', editing ? 'h-9' : 'py-1.5 min-h-9')}>
         <div className="flex-1 min-w-0">
           {editing ? (
             <input
@@ -147,19 +166,22 @@ export default function TaskItem({ task, active, onContextMenu, collapsed, editi
               className="type-label w-full rounded border border-[var(--ring-accent)] bg-[var(--bg-primary)] px-1 py-0 text-[var(--text-primary)] outline-none"
             />
           ) : (
-            <span
-              className={cn(
-                'block truncate type-body',
-                hasUnread && 'font-medium',
-                active
-                  ? 'text-[var(--text-primary)]'
-                  : isCompleted
-                    ? 'text-[var(--text-muted)]'
-                    : 'text-[var(--text-secondary)]',
-              )}
-            >
-              {task.title || t('common.newTask')}
-            </span>
+            <>
+              <span
+                className={cn(
+                  'block truncate type-body',
+                  hasUnread && 'font-medium',
+                  active
+                    ? 'text-[var(--text-primary)]'
+                    : isCompleted
+                      ? 'text-[var(--text-muted)]'
+                      : 'text-[var(--text-secondary)]',
+                )}
+              >
+                {title}
+              </span>
+              {previewText && <span className="block truncate type-meta text-[var(--text-muted)]">{previewText}</span>}
+            </>
           )}
         </div>
 

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -45,6 +45,7 @@ import { exportToFiles, exportToLocal } from '@/lib/export-session';
 import TaskItem from './TaskItem';
 import type { Task, TaskStatus } from '@clawwork/shared';
 import EmptyState from '@/components/semantic/EmptyState';
+import { useSessionPreviews } from '@/hooks/useSessionPreviews';
 
 function groupTasksByTime(tasks: Task[]): {
   today: Task[];
@@ -293,6 +294,7 @@ export default function LeftNav() {
   const activeTasks = useMemo(() => visibleTasks.filter((t) => t.status === 'active'), [visibleTasks]);
   const completedTasks = useMemo(() => visibleTasks.filter((t) => t.status === 'completed'), [visibleTasks]);
   const activeGroups = useMemo(() => groupTasksByTime(activeTasks), [activeTasks]);
+  const sessionPreviews = useSessionPreviews(visibleTasks);
 
   const renderTaskGroup = (groupTasks: Task[], label: string) => {
     if (groupTasks.length === 0) return null;
@@ -307,6 +309,7 @@ export default function LeftNav() {
             onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
             editing={editingTaskId === task.id}
             onEditDone={() => setEditingTaskId(null)}
+            preview={sessionPreviews[task.id]}
           />
         ))}
       </>
@@ -416,6 +419,7 @@ export default function LeftNav() {
                 active={task.id === activeTaskId}
                 onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
                 collapsed
+                preview={sessionPreviews[task.id]}
               />
             ))}
             {completedTasks.length > 0 && activeTasks.length > 0 && (
@@ -428,6 +432,7 @@ export default function LeftNav() {
                 active={task.id === activeTaskId}
                 onContextMenu={(e) => handleContextMenu(e, task.id, task.status)}
                 collapsed
+                preview={sessionPreviews[task.id]}
               />
             ))}
           </motion.div>

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -754,6 +754,32 @@ export interface SessionsUsageResult {
   totals: CostUsageTotals;
 }
 
+export type SessionPreviewItemRole = 'user' | 'assistant' | 'tool' | 'system' | 'other';
+
+export interface SessionPreviewItem {
+  role: SessionPreviewItemRole;
+  text: string;
+}
+
+export type SessionPreviewStatus = 'ok' | 'empty' | 'missing' | 'error';
+
+export interface SessionsPreviewEntry {
+  key: string;
+  status: SessionPreviewStatus;
+  items: SessionPreviewItem[];
+}
+
+export interface SessionsPreviewResult {
+  ts: number;
+  previews: SessionsPreviewEntry[];
+}
+
+export interface SessionsPreviewParams {
+  keys: string[];
+  limit?: number;
+  maxChars?: number;
+}
+
 export interface DashboardBreakdownEntry {
   name: string;
   count: number;


### PR DESCRIPTION
## Summary

- Add Gateway `sessions.preview` IPC plumbing (main process, preload, shared types)
- Fetch batched session previews for visible LeftNav tasks via `useSessionPreviews`
- Show a one-line last-message snippet under each task title (and in collapsed tooltip)
- Show a localized placeholder for empty sessions; refresh when messages arrive

Closes #217

## Test plan

- [x] `pnpm check` passes
- [ ] With a connected gateway, visible tasks show a preview snippet under the title
- [ ] Empty sessions show "No messages yet" placeholder
- [ ] Sending a new message updates the preview for that task
- [ ] Collapsed sidebar tooltip includes title + preview
- [ ] No visible regression with many tasks (batched per gateway)

## release-note

Task list items now show a short preview of the last message so you can tell sessions apart at a glance.