### PR TITLE
[Fix] buffer pre-init debug events and flush to real logger on init

### DIFF
--- a/packages/desktop/src/main/debug/index.ts
+++ b/packages/desktop/src/main/debug/index.ts
@@ -5,7 +5,7 @@ import { createDebugLogger } from './logger.js';
 
 const PRE_INIT_BUFFER_LIMIT = 256;
 const preInitBuffer: DebugEvent[] = [];
-let preInitOverflowed = false;
+let isInitialized = false;
 
 function record(level: DebugEvent['level'], input: LogEventInput): DebugEvent {
   const event = sanitizeForLog({
@@ -14,15 +14,16 @@ function record(level: DebugEvent['level'], input: LogEventInput): DebugEvent {
     level,
   });
 
-  if (preInitBuffer.length < PRE_INIT_BUFFER_LIMIT) {
-    preInitBuffer.push(event);
-  } else if (!preInitOverflowed) {
-    preInitOverflowed = true;
-    console.warn(
-      `[debug] pre-init buffer cap (${PRE_INIT_BUFFER_LIMIT}) reached; ` +
-        'further events before initDebugLogger will be dropped.',
-    );
+  preInitBuffer.push(event);
+  if (preInitBuffer.length > PRE_INIT_BUFFER_LIMIT) {
+    preInitBuffer.shift();
   }
+
+  console.warn(
+    `[debug] Logger not initialized yet (pre-init event captured, buffer size: ${preInitBuffer.length}/${PRE_INIT_BUFFER_LIMIT}):`,
+    `[${level}] [${input.domain}] ${input.event}`,
+    input,
+  );
   return event;
 }
 
@@ -32,7 +33,7 @@ let debugLogger: DebugLogger = {
   warn: (input) => record('warn', input),
   error: (input) => record('error', input),
   log: (input) => record(input.level, input),
-  getRecentEvents: () => [],
+  getRecentEvents: () => [...preInitBuffer],
   currentFilePath: () => '',
   flush: () => Promise.resolve(),
 };
@@ -47,12 +48,16 @@ export function initDebugLogger(debugDir: string): DebugLogger {
     debugLogger.log(event);
   }
   preInitBuffer.length = 0;
-  preInitOverflowed = false;
+  isInitialized = true;
   return debugLogger;
 }
 
 export function getDebugLogger(): DebugLogger {
   return debugLogger;
+}
+
+export function isDebugLoggerInitialized(): boolean {
+  return isInitialized;
 }
 
 function broadcastDebugEvent(event: DebugEvent): void {

--- a/packages/desktop/src/main/debug/index.ts
+++ b/packages/desktop/src/main/debug/index.ts
@@ -44,7 +44,7 @@ export function initDebugLogger(debugDir: string): DebugLogger {
     onEvent: broadcastDebugEvent,
   });
   for (const event of preInitBuffer) {
-    debugLogger.log(event);
+    debugLogger.log(event, { silent: true });
   }
   preInitBuffer.length = 0;
   isInitialized = true;

--- a/packages/desktop/src/main/debug/index.ts
+++ b/packages/desktop/src/main/debug/index.ts
@@ -21,8 +21,7 @@ function record(level: DebugEvent['level'], input: LogEventInput): DebugEvent {
 
   console.warn(
     `[debug] Logger not initialized yet (pre-init event captured, buffer size: ${preInitBuffer.length}/${PRE_INIT_BUFFER_LIMIT}):`,
-    `[${level}] [${input.domain}] ${input.event}`,
-    input,
+    `[${event.level}] [${event.domain}] ${event.event}`,
   );
   return event;
 }

--- a/packages/desktop/src/main/debug/logger.ts
+++ b/packages/desktop/src/main/debug/logger.ts
@@ -33,12 +33,17 @@ export interface DebugLogFilter {
   limit?: number;
 }
 
+export interface LogEventOptions {
+  /** Skip console output (used when replaying pre-init buffered events). */
+  silent?: boolean;
+}
+
 export interface DebugLogger {
   debug: (input: LogEventInput) => DebugEvent;
   info: (input: LogEventInput) => DebugEvent;
   warn: (input: LogEventInput) => DebugEvent;
   error: (input: LogEventInput) => DebugEvent;
-  log: (input: LogEventInput & { level: DebugLevel }) => DebugEvent;
+  log: (input: LogEventInput & { level: DebugLevel }, options?: LogEventOptions) => DebugEvent;
   getRecentEvents: (filter?: DebugLogFilter) => DebugEvent[];
   currentFilePath: () => string;
   flush: () => Promise<void>;
@@ -137,7 +142,7 @@ export function createDebugLogger(options: CreateDebugLoggerOptions): DebugLogge
     }
   }
 
-  function log(input: LogEventInput & { level: DebugLevel }): DebugEvent {
+  function log(input: LogEventInput & { level: DebugLevel }, logOptions?: LogEventOptions): DebugEvent {
     const event: DebugEvent = sanitizeForLog({
       ts: new Date().toISOString(),
       ...input,
@@ -154,7 +159,7 @@ export function createDebugLogger(options: CreateDebugLoggerOptions): DebugLogge
     currentFileSize += Buffer.byteLength(jsonLine, 'utf8');
     writeStream!.write(jsonLine, 'utf8');
 
-    if (writeConsole) {
+    if (writeConsole && !logOptions?.silent) {
       const line = `[${event.level}] [${event.domain}] ${event.event}`;
       if (event.level === 'error') console.error(line, event);
       else if (event.level === 'warn') console.warn(line, event);

--- a/packages/desktop/test/debug-pre-init-buffer.test.ts
+++ b/packages/desktop/test/debug-pre-init-buffer.test.ts
@@ -58,23 +58,55 @@ describe('debug logger pre-init buffer (#412)', () => {
     expect(realLogger.getRecentEvents().some((e) => e.event === 'post-init-info')).toBe(true);
   });
 
-  it('stops buffering past PRE_INIT_BUFFER_LIMIT and warns once', async () => {
+  it('buffers events before initDebugLogger runs', async () => {
+    const { getDebugLogger, isDebugLoggerInitialized } = await loadDebugModule();
+
+    const logger = getDebugLogger();
+    const event1 = logger.info({ domain: 'app', event: 'test-event-1' });
+    const event2 = logger.error({ domain: 'gateway', event: 'test-event-2' });
+
+    expect(event1.level).toBe('info');
+    expect(event1.domain).toBe('app');
+    expect(event1.event).toBe('test-event-1');
+    expect(event2.level).toBe('error');
+    expect(event2.domain).toBe('gateway');
+
+    expect(getDebugLogger().getRecentEvents()).toHaveLength(2);
+    expect(isDebugLoggerInitialized()).toBe(false);
+  });
+
+  it('drops oldest events when buffer is full (keeps most recent 256)', async () => {
     const { getDebugLogger, initDebugLogger } = await loadDebugModule();
     const logger = getDebugLogger();
 
-    for (let i = 0; i < 300; i++) {
-      logger.debug({ domain: 'app', event: `evt-${i}` });
+    logger.info({ domain: 'app', event: 'oldest-event' });
+    for (let i = 1; i <= 256; i++) {
+      logger.debug({ domain: 'app', event: `buffer-overflow-test-${i}` });
     }
 
-    const warnCalls = consoleWarnSpy.mock.calls.filter((c) => String(c[0]).includes('pre-init buffer cap'));
-    expect(warnCalls).toHaveLength(1);
+    const events = getDebugLogger().getRecentEvents();
+    expect(events).toHaveLength(256);
+    expect(events.some((e) => e.event === 'oldest-event')).toBe(false);
+    expect(events[0].event).toBe('buffer-overflow-test-1');
+    expect(events[255].event).toBe('buffer-overflow-test-256');
 
     const os = await import('node:os');
     const fs = await import('node:fs');
     const path = await import('node:path');
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-debug-'));
     const realLogger = initDebugLogger(tmp);
-    const replayedBuffered = realLogger.getRecentEvents().filter((e) => /^evt-\d+$/.test(e.event));
-    expect(replayedBuffered.length).toBe(256);
+    const flushedEvents = realLogger.getRecentEvents();
+    expect(flushedEvents.some((e) => e.event === 'oldest-event')).toBe(false);
+  });
+
+  it('warns via console when logging before init', async () => {
+    const { getDebugLogger } = await loadDebugModule();
+
+    const logger = getDebugLogger();
+    logger.error({ domain: 'app', event: 'pre-init-warning-test' });
+
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    const warningCall = consoleWarnSpy.mock.calls[0][0] as string;
+    expect(warningCall).toContain('[debug] Logger not initialized yet');
   });
 });

--- a/packages/desktop/test/debug-pre-init-buffer.test.ts
+++ b/packages/desktop/test/debug-pre-init-buffer.test.ts
@@ -123,4 +123,32 @@ describe('debug logger pre-init buffer (#412)', () => {
     expect(warnPayload).not.toContain('secret-token');
     expect(warnPayload).toContain('pre-init-secret-test');
   });
+
+  it('does not re-print buffered events to console when flushing on init', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const { getDebugLogger, initDebugLogger } = await loadDebugModule();
+      getDebugLogger().error({ domain: 'app', event: 'pre-init-replay-test' });
+
+      const preInitWarnCount = consoleWarnSpy.mock.calls.length;
+      const preInitErrorCount = consoleErrorSpy.mock.calls.length;
+
+      const os = await import('node:os');
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'clawwork-debug-'));
+      initDebugLogger(tmp);
+
+      expect(consoleWarnSpy.mock.calls.length).toBe(preInitWarnCount);
+      expect(consoleErrorSpy.mock.calls.length).toBe(preInitErrorCount);
+      expect(consoleLogSpy.mock.calls.some((c) => String(c[0]).includes('pre-init-replay-test'))).toBe(
+        false,
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+    }
+  });
 });

--- a/packages/desktop/test/debug-pre-init-buffer.test.ts
+++ b/packages/desktop/test/debug-pre-init-buffer.test.ts
@@ -143,9 +143,7 @@ describe('debug logger pre-init buffer (#412)', () => {
 
       expect(consoleWarnSpy.mock.calls.length).toBe(preInitWarnCount);
       expect(consoleErrorSpy.mock.calls.length).toBe(preInitErrorCount);
-      expect(consoleLogSpy.mock.calls.some((c) => String(c[0]).includes('pre-init-replay-test'))).toBe(
-        false,
-      );
+      expect(consoleLogSpy.mock.calls.some((c) => String(c[0]).includes('pre-init-replay-test'))).toBe(false);
     } finally {
       consoleErrorSpy.mockRestore();
       consoleLogSpy.mockRestore();

--- a/packages/desktop/test/debug-pre-init-buffer.test.ts
+++ b/packages/desktop/test/debug-pre-init-buffer.test.ts
@@ -109,4 +109,18 @@ describe('debug logger pre-init buffer (#412)', () => {
     const warningCall = consoleWarnSpy.mock.calls[0][0] as string;
     expect(warningCall).toContain('[debug] Logger not initialized yet');
   });
+
+  it('redacts sensitive fields in pre-init console warnings', async () => {
+    const { getDebugLogger } = await loadDebugModule();
+
+    getDebugLogger().error({
+      domain: 'app',
+      event: 'pre-init-secret-test',
+      data: { token: 'secret-token' },
+    });
+
+    const warnPayload = consoleWarnSpy.mock.calls.flat().join(' ');
+    expect(warnPayload).not.toContain('secret-token');
+    expect(warnPayload).toContain('pre-init-secret-test');
+  });
 });


### PR DESCRIPTION
Supersedes #448 — rebased onto current `main` and fixes CI failures.

## Summary
- Rebases #448 onto latest `main` (which already had a partial pre-init buffer)
- Fixes type error: import `LogEventInput` from `./logger.js` instead of `@clawwork/shared`
- Drops oldest buffered events when the 256-event cap is reached (shift eviction)
- Exposes `isDebugLoggerInitialized()` for testing
- Returns buffered events from `getRecentEvents()` before init
- Emits per-event console warnings during pre-init logging
- Expands regression tests for buffering, eviction, and warnings

## CI fixes (from #448)
- **quality**: format check now passes
- **test**: desktop typecheck no longer fails on `LogEventInput` import

## Test plan
- [x] `pnpm --filter @clawwork/desktop test -- debug-pre-init-buffer`
- [x] `pnpm format:check`
- [x] Desktop typecheck passes for `debug/index.ts`

Fixes #412