### PR TITLE
[Fix] normalize workspace path in initDatabase guard

### DIFF
--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { mkdirSync } from 'fs';
 import { DB_FILE_NAME } from '@clawwork/shared';
 import * as schema from './schema.js';
@@ -9,6 +9,10 @@ import { initFTS } from './fts.js';
 let db: ReturnType<typeof drizzle> | null = null;
 let sqlite: Database.Database | null = null;
 let initializedWorkspacePath: string | null = null;
+
+function canonicalWorkspacePath(workspacePath: string): string {
+  return resolve(workspacePath);
+}
 
 function migrateAddColumn(database: Database.Database, sql: string): void {
   try {
@@ -188,20 +192,22 @@ function openDatabaseAt(workspacePath: string): void {
 }
 
 export function initDatabase(workspacePath: string): void {
+  const canonicalPath = canonicalWorkspacePath(workspacePath);
   if (db) {
-    if (initializedWorkspacePath !== workspacePath) {
+    if (initializedWorkspacePath !== canonicalPath) {
       throw new Error('initDatabase called with different workspace path; use reinitDatabase to switch');
     }
     return;
   }
-  initializedWorkspacePath = workspacePath;
-  openDatabaseAt(workspacePath);
+  initializedWorkspacePath = canonicalPath;
+  openDatabaseAt(canonicalPath);
 }
 
 export function reinitDatabase(workspacePath: string): void {
+  const canonicalPath = canonicalWorkspacePath(workspacePath);
   closeDatabase();
-  initializedWorkspacePath = workspacePath;
-  openDatabaseAt(workspacePath);
+  initializedWorkspacePath = canonicalPath;
+  openDatabaseAt(canonicalPath);
 }
 
 export function getDb(): ReturnType<typeof drizzle> {

--- a/packages/desktop/test/db.test.ts
+++ b/packages/desktop/test/db.test.ts
@@ -47,6 +47,13 @@ describe('initDatabase', () => {
     expect(Database).not.toHaveBeenCalled();
   });
 
+  it('returns early when called with an equivalent resolved path', () => {
+    initDatabase('/tmp/workspace-a');
+    vi.clearAllMocks();
+    expect(() => initDatabase('/tmp/workspace-a/')).not.toThrow();
+    expect(Database).not.toHaveBeenCalled();
+  });
+
   it('throws when called with different workspace path', () => {
     initDatabase('/tmp/workspace-a');
     expect(() => initDatabase('/tmp/workspace-b')).toThrow(


### PR DESCRIPTION
## Summary

- `initDatabase` and `reinitDatabase` now canonicalize workspace paths with `path.resolve()` before comparing or opening the database.
- Repeat calls with equivalent directory strings (for example `/tmp/workspace-a` vs `/tmp/workspace-a/`) are treated as the same workspace instead of incorrectly throwing or reopening SQLite.
- Adds a regression test for equivalent-path early return.

The core guard from #392 (throw on a genuinely different workspace path instead of silently ignoring it) landed in #446; this PR completes the behavior by normalizing paths before comparison.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Closes #392

After #446, `initDatabase` throws when called with a different workspace path instead of silently reusing the original database. Without path normalization, callers passing the same directory with different string forms (trailing slash, relative segments) could still hit false-positive errors.

## What changed?

- `packages/desktop/src/main/db/index.ts`: added `canonicalWorkspacePath()` using `resolve()`; store and compare canonical paths in `initDatabase` / `reinitDatabase`.
- `packages/desktop/test/db.test.ts`: added test for equivalent resolved path early return.

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched: none

## Validation

- [x] `pnpm --filter @clawwork/desktop test -- test/db.test.ts` — 7 passed

## Screenshots or recordings

No UI changes.

## Release note

```release-note
Fixed: initDatabase now treats equivalent workspace directory paths as the same workspace when checking for repeat initialization.
```

Made with [Cursor](https://cursor.com)