### PR TITLE
[Fix] Add regression tests for room-store persistence logging (#216)

### DIFF
--- a/packages/core/test/room-store.test.ts
+++ b/packages/core/test/room-store.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildSessionKey } from '@clawwork/shared';
+import { createRoomStore, type RoomStoreDeps } from '../src/stores/room-store';
+
+function createDeps(overrides: Partial<RoomStoreDeps> = {}): RoomStoreDeps {
+  return {
+    createSession: vi.fn(async () => ({ ok: true })),
+    abortChat: vi.fn(async () => ({})),
+    listSessionsBySpawner: vi.fn(async () => ({ ok: true, result: { sessions: [] } })),
+    persistRoom: vi.fn(async () => ({})),
+    persistPerformer: vi.fn(async () => ({})),
+    loadRoom: vi.fn(async () => ({ ok: true, room: null, performers: [] })),
+    ...overrides,
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('room-store persistence failures', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('logs when persistRoom fails in initConductor', async () => {
+    const err = new Error('db locked');
+    const deps = createDeps({
+      persistRoom: vi.fn(async () => {
+        throw err;
+      }),
+    });
+    const store = createRoomStore(deps);
+    const taskId = 'task-1';
+    const sessionKey = buildSessionKey(taskId);
+
+    const ok = await store.getState().initConductor(taskId, 'gw-1', sessionKey, '[]');
+    await flushMicrotasks();
+
+    expect(ok).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith('[room-store] persistRoom failed:', err);
+    expect(store.getState().getRoom(taskId)?.conductorReady).toBe(true);
+  });
+
+  it('logs when persistRoom fails in setRoomStatus', async () => {
+    const err = new Error('disk full');
+    const taskId = 'task-2';
+    const sessionKey = buildSessionKey(taskId);
+    const deps = createDeps({
+      loadRoom: vi.fn(async () => ({
+        ok: true,
+        room: { status: 'active', conductorReady: true },
+        performers: [],
+      })),
+      persistRoom: vi.fn(async () => {
+        throw err;
+      }),
+    });
+    const store = createRoomStore(deps);
+    await store.getState().hydrateRoom(taskId, sessionKey);
+
+    store.getState().setRoomStatus(taskId, 'stopping');
+    await flushMicrotasks();
+
+    expect(warnSpy).toHaveBeenCalledWith('[room-store] persistRoom failed:', err);
+    expect(store.getState().getRoom(taskId)?.status).toBe('stopping');
+  });
+
+  it('logs when persistPerformer fails in registerPerformerKey', async () => {
+    const err = new Error('write failed');
+    const taskId = 'task-3';
+    const sessionKey = buildSessionKey(taskId);
+    const subagentKey = 'agent:main:subagent:abc-123-def4-5678-90ab-cdef12345678';
+    const deps = createDeps({
+      loadRoom: vi.fn(async () => ({
+        ok: true,
+        room: { status: 'active', conductorReady: true },
+        performers: [],
+      })),
+      persistPerformer: vi.fn(async () => {
+        throw err;
+      }),
+    });
+    const store = createRoomStore(deps);
+    await store.getState().hydrateRoom(taskId, sessionKey);
+
+    store.getState().registerPerformerKey(taskId, subagentKey, 'performer-1', 'Performer');
+    await flushMicrotasks();
+
+    expect(warnSpy).toHaveBeenCalledWith('[room-store] persistPerformer failed:', err);
+    expect(store.getState().getRoom(taskId)?.performers).toHaveLength(1);
+    expect(store.getState().lookupTaskIdBySubagentKey(subagentKey)).toBe(taskId);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds regression tests for the room-store persistence error logging fix from #367
- Verifies `persistRoom` and `persistPerformer` failures emit `console.warn` instead of being silently swallowed
- Confirms in-memory room state still updates when persistence fails (documenting current behavior)

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Issue #216 reported that `room-store` used `.catch(() => {})` on all persistence calls, hiding DB/disk failures and allowing UI state to diverge from the database with no trace in logs. The logging fix landed in #367, but there were no tests to prevent a regression.

## What changed?

- Added `packages/core/test/room-store.test.ts` covering the three persistence paths: `initConductor`, `setRoomStatus`, and `registerPerformerKey`

## Architecture impact

- Owning layer: core
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: tests only; no production code paths changed

## Linked issues

Closes #216

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm check`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

```text
pnpm check
```

## Screenshots or recordings

N/A — no UI changes.

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate