### PR TITLE
[Fix] Re-hydrate renderer stores after workspace change

### DIFF
--- a/packages/core/src/services/session-sync.ts
+++ b/packages/core/src/services/session-sync.ts
@@ -132,6 +132,7 @@ function normalizeLocalAssistantMessage(row: { role: string; content: string; at
 export function createSessionSync(deps: SessionSyncDeps) {
   let hydrationPromise: Promise<void> | null = null;
   const syncChains = new Map<string, Promise<void>>();
+  let syncEpoch = 0;
 
   function persistCanonicalMessage(message: Message): void {
     deps.persistence
@@ -189,14 +190,17 @@ export function createSessionSync(deps: SessionSyncDeps) {
 
   async function hydrateFromLocal(): Promise<void> {
     if (!hydrationPromise) {
+      const epoch = syncEpoch;
       hydrationPromise = (async () => {
         const taskStore = deps.getTaskStore();
         const messageStore = deps.getMessageStore();
         await taskStore.hydrate();
+        if (syncEpoch !== epoch) return;
         const tasks = deps.getTaskStore().tasks;
         for (const t of tasks) {
           try {
             const res = await deps.persistence.loadMessages(t.id);
+            if (syncEpoch !== epoch) return;
             if (res.ok && res.rows && res.rows.length > 0) {
               const msgs: Message[] = res.rows.map((r) => {
                 const normalized = normalizeLocalAssistantMessage(r);
@@ -228,13 +232,15 @@ export function createSessionSync(deps: SessionSyncDeps) {
     await hydrationPromise;
   }
 
-  async function doSyncSession(taskId: string, sessionKeyOverride?: string): Promise<void> {
+  async function doSyncSession(taskId: string, sessionKeyOverride: string | undefined, epoch: number): Promise<void> {
     const task = deps.getTaskStore().tasks.find((t) => t.id === taskId);
     const sessionKey = sessionKeyOverride ?? task?.sessionKey;
     if (!task?.gatewayId || !sessionKey) return;
 
     const httpBase = await deps.gateway.getHttpBase?.(task.gatewayId);
+    if (syncEpoch !== epoch) return;
     const res = await deps.gateway.chatHistory(task.gatewayId, sessionKey);
+    if (syncEpoch !== epoch) return;
     if (!res.ok || !res.result) return;
 
     const raw = res.result as { messages?: RawHistoryMessage[] };
@@ -265,6 +271,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
     }
 
     for (let i = 0; i < newest.length; i++) {
+      if (syncEpoch !== epoch) return;
       const gm = newest[i];
       const canonical: Message = {
         id: crypto.randomUUID(),
@@ -313,17 +320,22 @@ export function createSessionSync(deps: SessionSyncDeps) {
   }
 
   async function syncWithRetry(taskId: string, sessionKeyOverride?: string): Promise<void> {
+    const epoch = syncEpoch;
     for (let attempt = 0; attempt <= RETRY_DELAYS.length; attempt++) {
+      if (syncEpoch !== epoch) return;
       try {
-        await doSyncSession(taskId, sessionKeyOverride);
+        await doSyncSession(taskId, sessionKeyOverride, epoch);
         return;
       } catch {
         if (attempt < RETRY_DELAYS.length) {
           await new Promise((r) => setTimeout(r, RETRY_DELAYS[attempt]));
+          if (syncEpoch !== epoch) return;
         }
       }
     }
-    console.warn('[sync] syncSessionMessages exhausted retries for task', taskId);
+    if (syncEpoch === epoch) {
+      console.warn('[sync] syncSessionMessages exhausted retries for task', taskId);
+    }
   }
 
   function retrySyncPending(): void {
@@ -361,9 +373,12 @@ export function createSessionSync(deps: SessionSyncDeps) {
   }
 
   async function syncFromGateway(): Promise<void> {
+    const epoch = syncEpoch;
     try {
       await hydrateFromLocal();
+      if (syncEpoch !== epoch) return;
       const res = await deps.gateway.syncSessions();
+      if (syncEpoch !== epoch) return;
       if (!res.ok || !res.discovered) return;
       const taskStore = deps.getTaskStore();
       const messageStore = deps.getMessageStore();
@@ -371,6 +386,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
       taskStore.adoptTasks(discovered);
 
       for (const d of discovered) {
+        if (syncEpoch !== epoch) return;
         const collapsedMessages = collapseDiscoveredMessages(
           d.messages.map((message: DiscoveredSyncMessage) => ({
             role: message.role,
@@ -428,5 +444,11 @@ export function createSessionSync(deps: SessionSyncDeps) {
     }
   }
 
-  return { hydrateFromLocal, syncSessionMessages, syncFromGateway, retrySyncPending };
+  function resetHydration(): void {
+    hydrationPromise = null;
+    syncChains.clear();
+    syncEpoch++;
+  }
+
+  return { hydrateFromLocal, syncSessionMessages, syncFromGateway, retrySyncPending, resetHydration };
 }

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import { useTaskStore } from './stores/taskStore';
 import { useFileStore } from './stores/fileStore';
 import { composer } from './platform';
 import { useGatewayBootstrap } from './hooks/useGatewayBootstrap';
+import { useWorkspaceRefresh } from './hooks/useWorkspaceRefresh';
 import { useUpdateCheck } from './hooks/useUpdateCheck';
 import { useTraySync } from './hooks/useTraySync';
 import { cn } from '@/lib/utils';
@@ -63,6 +64,7 @@ export default function App() {
   const loadSettings = useSettingsStore((s) => s.load);
 
   useGatewayBootstrap();
+  useWorkspaceRefresh();
   useUpdateCheck();
   useTraySync();
 

--- a/packages/desktop/src/renderer/hooks/useGatewayDispatcherSetup.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewayDispatcherSetup.ts
@@ -141,3 +141,9 @@ export async function fetchAgentsForGateway(gatewayId: string): Promise<void> {
   const agentCatalog = useUiStore.getState().agentCatalogByGateway;
   return getDispatcher().fetchAgentsForGateway(gatewayId, agentCatalog);
 }
+
+export async function reinitializeGatewayBootstrap(): Promise<void> {
+  const d = getDispatcher();
+  d.reset();
+  await d.initialize();
+}

--- a/packages/desktop/src/renderer/hooks/useWorkspaceRefresh.ts
+++ b/packages/desktop/src/renderer/hooks/useWorkspaceRefresh.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { refreshRendererAfterWorkspaceChange } from '../lib/workspace-refresh';
+
+export function useWorkspaceRefresh(): void {
+  useEffect(() => {
+    return window.clawwork.onWorkspaceChanged(() => {
+      void refreshRendererAfterWorkspaceChange();
+    });
+  }, []);
+}

--- a/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
@@ -1,8 +1,4 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useTaskStore, useMessageStore } from '@/platform';
-import { useDashboardStore } from '@/stores/dashboardStore';
-import { useUsageStore } from '@/stores/usageStore';
-import { useApprovalStore } from '@/stores/approvalStore';
 import { MonitorDot, Zap, FolderOpen, Loader2, ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@/lib/toast';
@@ -23,7 +19,6 @@ export default function SystemSection() {
   const workspacePath = useSettingsStore((s) => s.settings?.workspacePath);
   const settingsLoaded = useSettingsStore((s) => s.loaded);
   const loadSettings = useSettingsStore((s) => s.load);
-  const refreshSettings = useSettingsStore((s) => s.refresh);
 
   useEffect(() => {
     window.clawwork
@@ -68,21 +63,6 @@ export default function SystemSection() {
     [quickLaunchShortcut, t],
   );
 
-  useEffect(() => {
-    return window.clawwork.onWorkspaceChanged(async () => {
-      useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
-      await useTaskStore.getState().hydrate();
-
-      useMessageStore.setState({ messagesByTask: {}, activeTurnBySession: {}, processingBySession: new Set() });
-
-      useDashboardStore.getState().clear();
-      useUsageStore.getState().clear();
-      useApprovalStore.getState().clear();
-
-      await refreshSettings().catch(() => {});
-    });
-  }, [refreshSettings]);
-
   const handleChangeWorkspace = useCallback(async () => {
     let selected: string | null = null;
     try {
@@ -98,7 +78,6 @@ export default function SystemSection() {
     try {
       const result = await window.clawwork.changeWorkspace(selected);
       if (result.ok) {
-        await refreshSettings().catch(() => {});
         toast.success(t('settings.workspaceChanged'), {
           description: t('settings.workspaceOldPathHint', { path: oldPath }),
           duration: 8000,
@@ -112,7 +91,7 @@ export default function SystemSection() {
     } finally {
       setChangingWorkspace(false);
     }
-  }, [refreshSettings, workspacePath, t]);
+  }, [workspacePath, t]);
 
   const handleShortcutRecord = useCallback(
     (e: React.KeyboardEvent) => {

--- a/packages/desktop/src/renderer/lib/session-sync.ts
+++ b/packages/desktop/src/renderer/lib/session-sync.ts
@@ -11,4 +11,4 @@ const sync = createSessionSync({
   }),
 });
 
-export const { hydrateFromLocal, syncSessionMessages, syncFromGateway, retrySyncPending } = sync;
+export const { hydrateFromLocal, syncSessionMessages, syncFromGateway, retrySyncPending, resetHydration } = sync;

--- a/packages/desktop/src/renderer/lib/workspace-refresh.ts
+++ b/packages/desktop/src/renderer/lib/workspace-refresh.ts
@@ -1,0 +1,79 @@
+import {
+  useTaskStore,
+  useMessageStore,
+  useUiStore,
+  useRoomStore,
+  useTeamStore,
+  systemSessionService,
+} from '../platform';
+import { useFileStore } from '../stores/fileStore';
+import { useDashboardStore } from '../stores/dashboardStore';
+import { useUsageStore } from '../stores/usageStore';
+import { useApprovalStore } from '../stores/approvalStore';
+import { useSettingsStore } from '../stores/settingsStore';
+import { hydrateFromLocal, resetHydration } from './session-sync';
+import { reinitializeGatewayBootstrap } from '../hooks/useGatewayDispatcherSetup';
+
+export async function refreshRendererAfterWorkspaceChange(): Promise<void> {
+  await systemSessionService.end().catch(() => {});
+
+  useTaskStore.setState({
+    tasks: [],
+    activeTaskId: null,
+    hydrated: false,
+    pendingNewTask: null,
+  });
+
+  useMessageStore.setState({
+    messagesByTask: {},
+    activeTurnBySession: {},
+    processingBySession: new Set(),
+    highlightedMessageId: null,
+  });
+
+  useRoomStore.setState({ rooms: {}, subagentKeyMap: {} });
+  useTeamStore.setState({ teams: {}, loading: false, loadedOnce: false });
+
+  useFileStore.setState({
+    artifacts: [],
+    selectedArtifactId: null,
+    searchQuery: '',
+    searchResults: null,
+    isSearching: false,
+    typeFilter: 'all',
+  });
+
+  useDashboardStore.getState().clear();
+  useUsageStore.getState().clear();
+  useApprovalStore.getState().clear();
+
+  useUiStore.setState({
+    gatewayStatusMap: {},
+    gatewayVersionMap: {},
+    gatewayReconnectInfo: {},
+    gatewaysLoaded: false,
+    defaultGatewayId: null,
+    gatewayInfoMap: {},
+    unreadTaskIds: new Set(),
+    modelCatalogByGateway: {},
+    agentCatalogByGateway: {},
+    toolsCatalogByGateway: {},
+    skillsStatusByGateway: {},
+    commandCatalogByGateway: {},
+  });
+
+  resetHydration();
+
+  await useSettingsStore
+    .getState()
+    .refresh()
+    .catch((err) => console.error('[workspace-refresh] Failed to refresh settings:', err));
+  await hydrateFromLocal().catch((err) => console.error('[workspace-refresh] Failed to hydrate from local:', err));
+  await reinitializeGatewayBootstrap().catch((err) =>
+    console.error('[workspace-refresh] Failed to reinitialize gateway bootstrap:', err),
+  );
+  await useTeamStore
+    .getState()
+    .loadTeams()
+    .catch((err) => console.error('[workspace-refresh] Failed to load teams:', err));
+}

--- a/packages/desktop/test/session-sync.test.ts
+++ b/packages/desktop/test/session-sync.test.ts
@@ -946,4 +946,134 @@ describe('session sync startup flow', () => {
       }),
     );
   });
+
+  it('aborts in-flight session sync after resetHydration to prevent cross-workspace writes', async () => {
+    const { sessionSync, taskStore, messageStore } = await loadModules();
+    const sessionKey = 'agent:main:clawwork:task:task-race';
+
+    taskStore.useTaskStore.setState({
+      tasks: [
+        {
+          id: 'task-race',
+          sessionKey,
+          sessionId: 'session-race',
+          title: 'Race test',
+          status: 'active',
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+          tags: [],
+          artifactDir: 'tasks/task-race',
+          gatewayId: 'gw-1',
+        },
+      ],
+      activeTaskId: 'task-race',
+      hydrated: true,
+    });
+    messageStore.useMessageStore.setState({
+      messagesByTask: {
+        'task-race': [
+          {
+            id: 'u1',
+            taskId: 'task-race',
+            role: 'user',
+            content: 'hello',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+        ],
+      },
+      activeTurnBySession: {},
+      processingBySession: new Set(),
+      highlightedMessageId: null,
+    });
+
+    const chatHistoryDeferred = createDeferred<{
+      ok: true;
+      result: {
+        messages: Array<{
+          role: string;
+          timestamp: number;
+          content: Array<{ type: string; text: string }>;
+        }>;
+      };
+    }>();
+
+    mockApi.chatHistory.mockReturnValue(chatHistoryDeferred.promise);
+
+    const syncPromise = sessionSync.syncSessionMessages('task-race');
+    await Promise.resolve();
+
+    sessionSync.resetHydration();
+
+    chatHistoryDeferred.resolve({
+      ok: true,
+      result: {
+        messages: [
+          {
+            role: 'assistant',
+            timestamp: Date.parse('2026-03-16T10:00:01.000Z'),
+            content: [{ type: 'text', text: 'stale write' }],
+          },
+        ],
+      },
+    });
+
+    await syncPromise;
+
+    expect(mockApi.persistMessage).not.toHaveBeenCalled();
+    expect(messageStore.useMessageStore.getState().messagesByTask['task-race']).toHaveLength(1);
+  });
+
+  it('resetHydration allows hydrateFromLocal to reload after workspace switch', async () => {
+    const { sessionSync, taskStore } = await loadModules();
+
+    mockApi.loadTasks.mockResolvedValue({
+      ok: true,
+      rows: [
+        {
+          id: 'task-old',
+          sessionKey: 'agent:main:clawwork:task:task-old',
+          sessionId: 'sess-old',
+          title: 'Old workspace task',
+          status: 'active',
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+          tags: [],
+          artifactDir: '/tmp/old',
+          gatewayId: 'gw-1',
+        },
+      ],
+    });
+
+    await sessionSync.hydrateFromLocal();
+    expect(taskStore.useTaskStore.getState().tasks).toHaveLength(1);
+    expect(taskStore.useTaskStore.getState().tasks[0].id).toBe('task-old');
+
+    taskStore.useTaskStore.setState({ tasks: [], activeTaskId: null, hydrated: false });
+    sessionSync.resetHydration();
+
+    mockApi.loadTasks.mockResolvedValue({
+      ok: true,
+      rows: [
+        {
+          id: 'task-new',
+          sessionKey: 'agent:main:clawwork:task:task-new',
+          sessionId: 'sess-new',
+          title: 'New workspace task',
+          status: 'active',
+          createdAt: '2026-03-17T00:00:00.000Z',
+          updatedAt: '2026-03-17T00:00:00.000Z',
+          tags: [],
+          artifactDir: '/tmp/new',
+          gatewayId: 'gw-1',
+        },
+      ],
+    });
+
+    await sessionSync.hydrateFromLocal();
+
+    expect(taskStore.useTaskStore.getState().tasks).toHaveLength(1);
+    expect(taskStore.useTaskStore.getState().tasks[0].id).toBe('task-new');
+  });
 });

--- a/packages/desktop/test/workspace-refresh.test.ts
+++ b/packages/desktop/test/workspace-refresh.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reinitializeGatewayBootstrapMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../src/renderer/hooks/useGatewayDispatcherSetup', () => ({
+  reinitializeGatewayBootstrap: reinitializeGatewayBootstrapMock,
+}));
+
+describe('refreshRendererAfterWorkspaceChange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reinitializeGatewayBootstrapMock.mockResolvedValue(undefined);
+
+    const clawwork = {
+      getSettings: vi.fn().mockResolvedValue({ workspacePath: '/tmp/new-workspace', gateways: [] }),
+      loadTasks: vi.fn().mockResolvedValue({ ok: true, rows: [] }),
+      getDeviceId: vi.fn().mockResolvedValue('device-1'),
+      listTeams: vi.fn().mockResolvedValue({ ok: true, result: [] }),
+      deleteSession: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    (globalThis.window ??= {} as typeof globalThis.window).clawwork =
+      clawwork as unknown as typeof globalThis.window.clawwork;
+  });
+
+  it('clears workspace-scoped renderer stores and re-bootstraps', async () => {
+    vi.resetModules();
+
+    const [
+      { refreshRendererAfterWorkspaceChange },
+      { useTaskStore },
+      { useMessageStore },
+      { useUiStore },
+      { useFileStore },
+      { useTeamStore },
+      { useRoomStore },
+    ] = await Promise.all([
+      import('../src/renderer/lib/workspace-refresh'),
+      import('../src/renderer/stores/taskStore'),
+      import('../src/renderer/stores/messageStore'),
+      import('../src/renderer/stores/uiStore'),
+      import('../src/renderer/stores/fileStore'),
+      import('../src/renderer/stores/teamStore'),
+      import('../src/renderer/stores/roomStore'),
+    ]);
+
+    useTaskStore.setState({
+      tasks: [
+        {
+          id: 'stale-task',
+          sessionKey: 'agent:main:clawwork:task:stale-task',
+          sessionId: 'sess-1',
+          title: 'Stale',
+          status: 'active',
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+          tags: [],
+          artifactDir: '/tmp/stale',
+          gatewayId: 'gw-1',
+        },
+      ],
+      activeTaskId: 'stale-task',
+      hydrated: true,
+      pendingNewTask: null,
+    });
+
+    useMessageStore.setState({
+      messagesByTask: {
+        'stale-task': [
+          {
+            id: 'msg-1',
+            taskId: 'stale-task',
+            role: 'user',
+            content: 'hello',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T00:00:00.000Z',
+          },
+        ],
+      },
+      activeTurnBySession: {},
+      processingBySession: new Set(['agent:main:clawwork:task:stale-task']),
+      highlightedMessageId: 'msg-1',
+    });
+
+    useUiStore.setState({
+      agentCatalogByGateway: {
+        'gw-1': { agents: [{ id: 'main', name: 'Main' }], defaultId: 'main' },
+      },
+      unreadTaskIds: new Set(['stale-task']),
+      gatewaysLoaded: true,
+      defaultGatewayId: 'gw-1',
+    });
+
+    useFileStore.setState({
+      artifacts: [
+        {
+          id: 'art-1',
+          taskId: 'stale-task',
+          messageId: 'msg-1',
+          name: 'stale.txt',
+          type: 'file',
+          filePath: '/tmp/stale.txt',
+          localPath: '/tmp/stale.txt',
+          mimeType: 'text/plain',
+          size: 1,
+          createdAt: '2026-03-16T00:00:00.000Z',
+        },
+      ],
+      selectedArtifactId: 'art-1',
+      searchQuery: 'stale',
+      searchResults: [],
+      isSearching: true,
+      typeFilter: 'file',
+    });
+
+    useTeamStore.setState({
+      teams: {
+        'team-1': {
+          id: 'team-1',
+          name: 'Stale team',
+          emoji: '🤖',
+          description: 'stale',
+          gatewayId: 'gw-1',
+          source: 'local',
+          version: '1',
+          agents: [],
+          createdAt: '2026-03-16T00:00:00.000Z',
+          updatedAt: '2026-03-16T00:00:00.000Z',
+        },
+      },
+      loading: false,
+      loadedOnce: true,
+    });
+
+    useRoomStore.setState({
+      rooms: {
+        'stale-task': {
+          taskId: 'stale-task',
+          conductorSessionKey: 'agent:main:clawwork:task:stale-task',
+          status: 'active',
+          conductorReady: true,
+          performers: [],
+        },
+      },
+      subagentKeyMap: { 'agent:sub:1': 'stale-task' },
+    });
+
+    await refreshRendererAfterWorkspaceChange();
+
+    expect(useTaskStore.getState().tasks).toEqual([]);
+    expect(useTaskStore.getState().activeTaskId).toBeNull();
+    expect(useMessageStore.getState().messagesByTask).toEqual({});
+    expect(useMessageStore.getState().processingBySession.size).toBe(0);
+    expect(useUiStore.getState().agentCatalogByGateway).toEqual({});
+    expect(useUiStore.getState().unreadTaskIds.size).toBe(0);
+    expect(useUiStore.getState().gatewaysLoaded).toBe(false);
+    expect(useFileStore.getState().artifacts).toEqual([]);
+    expect(useFileStore.getState().selectedArtifactId).toBeNull();
+    expect(useTeamStore.getState().teams).toEqual({});
+    expect(useRoomStore.getState().rooms).toEqual({});
+    expect(reinitializeGatewayBootstrapMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Move workspace-change store refresh from `SystemSection` to an app-level `useWorkspaceRefresh` hook so it always runs regardless of which view is open.
- Clear all workspace-scoped Zustand stores (tasks, messages, rooms, teams, artifacts, gateway catalogs, dashboard, usage, approvals) and reset the session-sync hydration cache.
- Re-run `hydrateFromLocal` and gateway bootstrap initialization so the UI loads data from the new SQLite workspace in place.

Closes #404

## Test plan
- [x] `pnpm check`
- [x] Added `workspace-refresh.test.ts` regression test for store clearing and bootstrap re-init
- [x] Added `session-sync.test.ts` regression test for `resetHydration` allowing re-hydration after workspace switch
- [ ] Manual: change workspace to a directory with a different task list; confirm task list and messages update without relaunch

## Release note
Fixed stale task lists and messages after switching workspaces — the app now refreshes in place instead of showing data from the previous workspace.