### PR TITLE
[Fix] harden safeFetch DNS pinning against rebinding TOCTOU (#405)

### DIFF
--- a/packages/desktop/src/main/net/safe-fetch.ts
+++ b/packages/desktop/src/main/net/safe-fetch.ts
@@ -1,3 +1,4 @@
+import { isIP } from 'node:net';
 import { net } from 'electron';
 import { assertNotPrivateHost } from './ssrf-guard.js';
 
@@ -8,6 +9,10 @@ interface SafeFetchOptions {
   maxSize?: number;
   timeoutMs?: number;
   trustedOrigin?: string;
+}
+
+function formatPinnedHostname(ip: string): string {
+  return isIP(ip) === 6 ? `[${ip}]` : ip;
 }
 
 function isSameOrigin(parsed: URL, trustedOrigin?: string): boolean {
@@ -33,7 +38,7 @@ export async function safeFetch(url: string, opts: SafeFetchOptions = {}): Promi
       // Rewrite the URL with the pinned IP so net.fetch does NOT re-resolve DNS.
       // The original hostname is preserved via the Host header for SNI support.
       const rewritten = new URL(url);
-      rewritten.hostname = pinnedIP;
+      rewritten.hostname = formatPinnedHostname(pinnedIP);
       fetchUrl = rewritten.toString();
     }
   }

--- a/packages/desktop/src/main/net/ssrf-guard.ts
+++ b/packages/desktop/src/main/net/ssrf-guard.ts
@@ -112,7 +112,10 @@ export async function assertNotPrivateHost(hostname: string): Promise<string | n
   // actual fetch, closing the DNS rebinding TOCTOU window.  (#405)
   for (const r of results) {
     if (r.status !== 'fulfilled') continue;
-    return r.value[0]?.address ?? null;
+    const address = r.value[0]?.address;
+    if (address) return address;
   }
-  return null;
+  // Hostname lookups must pin an address; letting net.fetch re-resolve would
+  // reopen the DNS rebinding TOCTOU if the first lookup failed or was empty.
+  throw new Error('SSRF blocked: DNS resolution failed');
 }

--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -113,6 +113,12 @@ describe('safeFetch', () => {
     expect(netFetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects hostnames when DNS pinning fails', async () => {
+    assertNotPrivateHostMock.mockRejectedValue(new Error('SSRF blocked: DNS resolution failed'));
+    await expect(safeFetch('https://cdn.example.com/img.png')).rejects.toThrow('SSRF blocked');
+    expect(netFetchMock).not.toHaveBeenCalled();
+  });
+
   it('returns buffer on success', async () => {
     assertNotPrivateHostMock.mockResolvedValue(null);
     const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
@@ -132,6 +138,15 @@ describe('safeFetch', () => {
     expect(lastFetchUrl).toBe('https://93.184.216.34/img.png');
     // The original hostname must be preserved as the Host header
     expect(lastFetchOpts).toBeDefined();
+    expect((lastFetchOpts as Record<string, unknown>).headers).toEqual({ Host: 'cdn.example.com' });
+  });
+
+  it('rewrites URL with pinned IPv6 and preserves Host header', async () => {
+    assertNotPrivateHostMock.mockResolvedValue('2001:4860:4860::8888');
+    mockFetchWithTracking();
+
+    await safeFetch('https://cdn.example.com/img.png');
+    expect(lastFetchUrl).toBe('https://[2001:4860:4860::8888]/img.png');
     expect((lastFetchOpts as Record<string, unknown>).headers).toEqual({ Host: 'cdn.example.com' });
   });
 

--- a/packages/desktop/test/ssrf-guard.test.ts
+++ b/packages/desktop/test/ssrf-guard.test.ts
@@ -250,8 +250,13 @@ describe('assertNotPrivateHost', () => {
     await expect(assertNotPrivateHost('example.com')).resolves.toBe('93.184.216.34');
   });
 
-  it('returns null when DNS fails entirely', async () => {
+  it('rejects when DNS fails entirely', async () => {
     mockLookup.mockRejectedValue(new Error('ENOTFOUND'));
-    await expect(assertNotPrivateHost('broken-dns.example.com')).resolves.toBeNull();
+    await expect(assertNotPrivateHost('broken-dns.example.com')).rejects.toThrow('SSRF blocked');
+  });
+
+  it('rejects when DNS returns no addresses', async () => {
+    mockLookup.mockResolvedValue([]);
+    await expect(assertNotPrivateHost('empty-dns.example.com')).rejects.toThrow('SSRF blocked');
   });
 });


### PR DESCRIPTION
## Summary

Closes #405. Builds on the IP-pinning approach from #490 with two additional hardening fixes:

- **Reject unresolved hostnames** — `assertNotPrivateHost` now throws when DNS lookup fails or returns no addresses, instead of returning `null` and letting `net.fetch` perform an independent (rebindable) resolution.
- **Fix IPv6 pinning** — bracket IPv6 pinned addresses before rewriting the fetch URL; the URL API silently ignores unbracketed IPv6 hostnames, so pinning was a no-op for v6-only targets.

## Root cause

PR #490 closed the primary DNS rebinding TOCTOU by pinning the resolved IPv4 address into the fetch URL. Two gaps remained:

1. If the guard's DNS lookup failed, `safeFetch` fell through to `net.fetch` with the original hostname, reopening the TOCTOU window.
2. IPv6 pinned addresses were assigned to `URL.hostname` without brackets, which Node's URL parser rejects — the rewrite was skipped and the fetch used the original hostname.

## Changes

- `packages/desktop/src/main/net/ssrf-guard.ts` — throw `SSRF blocked: DNS resolution failed` when hostname lookup fails or is empty
- `packages/desktop/src/main/net/safe-fetch.ts` — add `formatPinnedHostname()` to bracket IPv6 before URL rewrite
- `packages/desktop/test/ssrf-guard.test.ts` — regression tests for DNS failure and empty results
- `packages/desktop/test/safe-fetch.test.ts` — regression tests for DNS pinning failure path and IPv6 rewrite

## Test plan

- [x] `npx vitest run test/safe-fetch.test.ts test/ssrf-guard.test.ts` — 92 tests pass
- [x] ESLint + Prettier on changed files
- [x] Pre-commit architecture guardrails pass

```release-note
NONE
```