### PR TITLE
[Docs] Add scheduled workflow recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ No install required — open **[cpwa.pages.dev](https://cpwa.pages.dev)** in any
 - Per-gateway session catalogs
 - Session controls that matter: stop, reset, compact, delete, and sync
 - Background work that stays readable instead of collapsing into one long thread
-- Set tasks on a schedule with `cron`, `every`, or `at` expressions — pick from presets or write your own, check run history, trigger manually anytime
+- Set tasks on a schedule with `cron`, `every`, or `at` expressions — pick from presets or write your own, check run history, trigger manually anytime ([recipe examples](./docs/scheduled-workflow-recipes.md))
 - Export any session as Markdown to keep a clean record outside the app
 
 ### 👁 Better visibility

--- a/docs/scheduled-workflow-recipes.md
+++ b/docs/scheduled-workflow-recipes.md
@@ -1,0 +1,96 @@
+# Scheduled Workflow Recipes
+
+ClawWork's Cron panel can run repeatable OpenClaw tasks against the same
+Gateway capabilities you use in chat. These recipes give operators a concrete
+starting point for plugin-backed work that should stay visible in task history,
+run history, artifacts, and approval prompts.
+
+Use them as templates, not hidden automation. Keep secrets in Gateway or plugin
+config, keep tool scopes narrow, and prefer a manual first run before enabling a
+schedule.
+
+## X/Twitter Monitor Digest With TweetClaw
+
+Use this when you want a scheduled task that searches tweets, checks monitored
+accounts, summarizes replies, or drafts a daily X/Twitter report inside
+ClawWork. TweetClaw is an optional OpenClaw plugin backed by Xquik. It exposes
+the free `explore` catalog tool and the optional `tweetclaw` API tool for
+account-backed X/Twitter automation or read-only MPP calls.
+
+### Install And Allow Tools
+
+Install the plugin from the OpenClaw Gateway environment, then allow only its 2
+tool names alongside your normal tool profile:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+openclaw plugins inspect tweetclaw --runtime
+openclaw skills info tweetclaw
+```
+
+Store credentials in Gateway config, not in ClawWork messages, task names, or
+cron prompts:
+
+```bash
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+```
+
+For accountless read-only usage, configure an MPP signing key instead:
+
+```bash
+openclaw config set plugins.entries.tweetclaw.config.tempoSigningKey "$MPP_SIGNING_KEY"
+```
+
+MPP mode is read-only. It cannot post tweets, post tweet replies, create
+monitors, send direct messages, upload media, create webhooks, run giveaway
+draws, or read account-backed private data.
+
+### Create The Cron Task
+
+In ClawWork:
+
+1. Open **Cron** from the sidebar.
+2. Create a job with an `every` or `cron` schedule.
+3. Use an isolated session target for clean recurring history.
+4. Put the task instructions in the agent message.
+5. Run once manually and inspect the tool calls before enabling the schedule.
+
+Example agent message:
+
+```text
+Use TweetClaw to search tweets and tweet replies about "openclaw agents" from
+the last day. Return the top source tweets, notable reply threads, repeated
+questions, and links worth reviewing. Do not post, reply, follow, DM, create
+monitors, upload media, or create webhooks. Ask before any write action or paid
+bulk extraction.
+```
+
+For a monitored-account digest:
+
+```text
+Use TweetClaw to check recent public tweets and replies from the approved
+account list in this task. Summarize new product feedback, bug reports, and
+integration requests. Include tweet URLs and a short action list. Do not create
+or modify monitors unless I explicitly approve the target, event types, stop
+condition, and delivery destination.
+```
+
+### Operator Checks
+
+- Start with `explore` so the agent selects the right endpoint before calling
+  `tweetclaw`.
+- Keep recurring prompts read-only unless the workflow explicitly needs writes.
+- Review OpenClaw approval prompts before post tweets, post tweet replies,
+  direct messages, follows, monitor changes, webhooks, media upload, media
+  download, or giveaway draws.
+- Use ClawWork run history to confirm each scheduled run produced a useful
+  summary, not just raw API output.
+- Disable or pause the job when the keyword, account list, or campaign window is
+  no longer current.
+
+Links:
+
+- [TweetClaw GitHub repo](https://github.com/Xquik-dev/tweetclaw)
+- [TweetClaw npm package](https://www.npmjs.com/package/@xquik/tweetclaw)
+- [TweetClaw ClawHub listing](https://clawhub.ai/plugins/@xquik/tweetclaw)

--- a/docs/scheduled-workflow-recipes.md
+++ b/docs/scheduled-workflow-recipes.md
@@ -52,7 +52,7 @@ In ClawWork:
 
 1. Open **Cron** from the sidebar.
 2. Create a job with an `every` or `cron` schedule.
-3. Use an isolated session target for clean recurring history.
+3. Use the task session target for clean recurring history.
 4. Put the task instructions in the agent message.
 5. Run once manually and inspect the tool calls before enabling the schedule.
 


### PR DESCRIPTION
## Summary

Adds a ClawWork docs recipe for scheduled plugin-backed workflows and links it from the README cron feature. The first recipe shows how to run an X/Twitter monitor digest through TweetClaw while keeping credentials in OpenClaw Gateway config and preserving ClawWork run history.

## Type of change

- [x] `[Docs]` documentation-only change

## Why is this needed?

ClawWork already exposes Cron jobs, tool catalog visibility, and ClawHub/plugin workflows, but the README does not point operators to concrete examples for recurring plugin-backed tasks. This gives users a safe template for a real scheduled workflow without turning the README into a plugin catalog.

## What changed?

- Added `docs/scheduled-workflow-recipes.md` with a TweetClaw X/Twitter digest recipe.
- Linked the recipe from the README cron feature bullet.
- Included install, tool allowlist, credential handling, read-only MPP limits, example prompts, and operator checks.

## Architecture impact

- Owning layer: docs
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: no runtime, IPC, Gateway, persistence, or renderer code changed.

## Linked issues

None.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
git diff --check
pnpm dlx prettier@3 --check README.md docs/scheduled-workflow-recipes.md
npm view @xquik/tweetclaw version
curl -I -L --max-time 20 https://github.com/Xquik-dev/tweetclaw
curl -I -L --max-time 20 https://clawhub.ai/plugins/@xquik/tweetclaw
```

Notes: `npm view @xquik/tweetclaw version` returned `1.6.31`. GitHub and ClawHub returned HTTP 200. The npm web package page returned a Cloudflare challenge over curl, so package existence was verified through npm registry metadata instead.

## Screenshots or recordings

Not applicable. Docs-only change.

## Release note

- [x] No user-facing change. Release note is `NONE`.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate
