### PR TITLE
[Fix] Add writeConfig failure-path regression tests

### DIFF
--- a/packages/desktop/test/workspace-config-persistence.test.ts
+++ b/packages/desktop/test/workspace-config-persistence.test.ts
@@ -89,6 +89,18 @@ describe('workspace config persistence', () => {
     expect(fsMock.unlinkSync).toHaveBeenCalledWith(tmpPath);
   });
 
+  it('does not rename when temp write fails', async () => {
+    const writeError = new Error('disk full');
+    fsMock.writeFileSync.mockImplementationOnce(() => {
+      throw writeError;
+    });
+    const { writeConfig } = await loadConfigModule();
+
+    expect(() => writeConfig({ workspacePath: '/workspace', gateways: [] })).toThrow(writeError);
+    expect(fsMock.renameSync).not.toHaveBeenCalled();
+    expect(fsMock.unlinkSync).toHaveBeenCalledWith(tmpPath);
+  });
+
   it('backs up malformed JSON config without running migration', async () => {
     fsMock.readFileSync.mockReturnValue('{bad json');
     const { readConfig } = await loadConfigModule();

--- a/packages/desktop/test/workspace-config.test.ts
+++ b/packages/desktop/test/workspace-config.test.ts
@@ -87,4 +87,36 @@ describe('workspace config', () => {
     expect(readConfig()).toEqual(second);
     expect(() => JSON.parse(readFileSync(configPath, 'utf8'))).not.toThrow();
   });
+
+  it('preserves existing config when rename fails', async () => {
+    const configPath = join(userDataDir, CONFIG_FILE_NAME);
+    const original: AppConfig = { workspacePath: '/original', gateways: [] };
+    writeConfig(original);
+    const snapshot = readFileSync(configPath, 'utf8');
+
+    const renameError = new Error('rename failed');
+    vi.resetModules();
+    vi.doMock('fs', async () => {
+      const actual = await vi.importActual<typeof import('fs')>('fs');
+      return {
+        ...actual,
+        renameSync: vi.fn((src: unknown, dest: unknown) => {
+          if (String(src).endsWith('.tmp')) throw renameError;
+          return actual.renameSync(src as string, dest as string);
+        }),
+      };
+    });
+
+    try {
+      const { writeConfig: writeWithFailingRename } = await import('../src/main/workspace/config.js');
+      expect(() => writeWithFailingRename({ workspacePath: '/new', gateways: [] })).toThrow(renameError);
+    } finally {
+      vi.resetModules();
+      vi.doUnmock('fs');
+    }
+    const { readConfig: readAfterFailure } = await import('../src/main/workspace/config.js');
+    expect(readFileSync(configPath, 'utf8')).toBe(snapshot);
+    expect(readAfterFailure()).toEqual(original);
+    expect(existsSync(`${configPath}.tmp`)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- The atomic `writeConfig` implementation (write-to-temp, `fsync`, `renameSync`) landed in #470; filesystem happy-path coverage landed in #527.
- Adds regression tests for the failure paths described in #385:
  - mock test: temp write failure must not call `renameSync` (original config path never touched)
  - integration test: existing on-disk config survives a failed atomic replace when `renameSync` throws

## Test plan

- [x] `pnpm test workspace-config` (9 tests across both config test files)
- [x] pre-commit hooks (eslint, prettier, architecture guardrails)

Closes #385

release-note: NONE