### PR TITLE
[Docs] Add launch promotion materials and pre-launch checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to ClawWork are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - TBD
+
+First public launch release. Prior `0.0.x` builds were pre-release iterations.
+
+### Added
+
+- Three-column desktop workspace: task list, conversation, progress/artifacts panel
+- Parallel multi-task execution with per-task OpenClaw session isolation
+- Real-time tool call cards with expandable details and exec approval gates
+- Local artifact management — auto-extract code, images, and files to a Git-backed workspace
+- Full-text search across tasks, messages, and artifacts (SQLite FTS5)
+- Multi-gateway support with token, password, and pairing-code authentication
+- Per-task agent and model switching with thinking-level controls
+- Scheduled (cron) tasks with run history and manual trigger
+- Usage and cost dashboard across gateways and sessions
+- Teams and TeamsHub — multi-agent orchestration with coordinator/worker roles
+- Skills via ClawHub — discovery and install
+- AI Builder — LLM-assisted team creation
+- Progressive Web App with offline support and mobile UI
+- Cross-platform installers: macOS (DMG + Homebrew cask), Windows, Linux (AppImage + deb)
+- Background auto-update for packaged builds
+- System tray, global quick-launch shortcut, and desktop notifications
+- Light/dark themes with 8-language i18n support
+- Launch promotion materials in `docs/promotion/`
+- Agent guide (`AGENTS.md`) and contributing sign-off requirements (`CONTRIBUTING.md`)
+
+### Changed
+
+- README rewritten with OpenClaw positioning, channel comparison table, and architecture overview
+- Root `package.json` metadata: repository, homepage, and license fields
+
+[0.1.0]: https://github.com/clawwork-ai/ClawWork/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ Once you have multiple sessions, long-running jobs, approval stops, generated fi
 
 ClawWork fixes that. Every task becomes a durable workspace with its own session, artifacts, controls, and history — laid out in a three-panel UI: tasks on the left, active work in the center, artifacts and context on the right.
 
+### ClawWork vs messaging channels
+
+**The dedicated UI for OpenClaw — stop chatting with Agents in Feishu.**
+
+|                | Feishu / DingTalk / Slack  | ClawWork                                              |
+| -------------- | -------------------------- | ----------------------------------------------------- |
+| Layout         | Single chat thread         | Three-column: task list, conversation, progress panel |
+| Multi-task     | One conversation at a time | Parallel tasks in isolated sessions                   |
+| Tool calls     | Hidden or text-only        | Real-time visualization with expandable details       |
+| Artifacts      | Lost in chat history       | Auto-saved to local Git repo, searchable              |
+| Progress       | No structured tracking     | Step-by-step progress panel                           |
+| Data ownership | On third-party servers     | 100% local (SQLite + Git)                             |
+
+## Demo
+
+> **Launch prep:** Record a 60-second demo and save as `docs/demo.gif`. See [docs/promotion/demo-recording.md](./docs/promotion/demo-recording.md) for the checklist.
+
 ## Teams
 
 One agent is useful. A coordinated team of agents is a workforce.

--- a/docs/promotion/README.md
+++ b/docs/promotion/README.md
@@ -1,0 +1,44 @@
+# ClawWork Promotion Materials
+
+Draft copy and outlines for the launch promotion campaign tracked in [#11](https://github.com/clawwork-ai/ClawWork/issues/11).
+
+## Core positioning
+
+**The dedicated UI for OpenClaw — stop chatting with Agents in Feishu.**
+
+ClawWork is to OpenClaw what GitHub Desktop is to Git — a purpose-built native client that replaces generic messaging channels (Feishu, DingTalk, Slack).
+
+## Ready-to-post drafts
+
+| Platform              | File                                           | Language |
+| --------------------- | ---------------------------------------------- | -------- |
+| Hacker News (Show HN) | [hacker-news.md](./hacker-news.md)             | English  |
+| V2EX                  | [v2ex.md](./v2ex.md)                           | Chinese  |
+| Reddit r/selfhosted   | [reddit-selfhosted.md](./reddit-selfhosted.md) | English  |
+| Reddit r/opensource   | [reddit-opensource.md](./reddit-opensource.md) | English  |
+| Reddit r/LocalLLaMA   | [reddit-localllama.md](./reddit-localllama.md) | English  |
+| Twitter/X thread      | [twitter-thread.md](./twitter-thread.md)       | English  |
+| Jike                  | [jike.md](./jike.md)                           | Chinese  |
+
+## Article outlines
+
+| Platform                       | File                                                   | Language |
+| ------------------------------ | ------------------------------------------------------ | -------- |
+| Juejin technical article       | [juejin-outline.md](./juejin-outline.md)               | Chinese  |
+| Zhihu column                   | [zhihu-outline.md](./zhihu-outline.md)                 | Chinese  |
+| WeChat Official Account launch | [wechat-launch-article.md](./wechat-launch-article.md) | Chinese  |
+
+## Ecosystem integration
+
+| Target                      | File                                         |
+| --------------------------- | -------------------------------------------- |
+| OpenClaw docs PR content    | [openclaw-docs-pr.md](./openclaw-docs-pr.md) |
+| Demo recording checklist    | [demo-recording.md](./demo-recording.md)     |
+| GitHub repo topics (manual) | [github-topics.md](./github-topics.md)       |
+
+## Before posting
+
+1. Confirm launch prep ([#6](https://github.com/clawwork-ai/ClawWork/issues/6)) is complete.
+2. Record and embed the 60-second demo GIF in README (see [demo-recording.md](./demo-recording.md)).
+3. Verify the latest release DMG/installer is on GitHub Releases.
+4. Post on all high-leverage platforms on the **same day** for maximum impact.

--- a/docs/promotion/demo-recording.md
+++ b/docs/promotion/demo-recording.md
@@ -1,0 +1,41 @@
+# Demo Recording Checklist
+
+Steps to produce the 60-second demo GIF/video for README and launch posts. Tracked in [#6](https://github.com/clawwork-ai/ClawWork/issues/6) and [#11](https://github.com/clawwork-ai/ClawWork/issues/11).
+
+## Demo scenario
+
+Pick a visually compelling workflow that completes in ~30 seconds, e.g. **"Generate a Python CLI tool"**:
+
+1. Create a new task
+2. Send a user message
+3. Watch AI streaming reply
+4. Expand a tool call card
+5. Show artifact saved in the file browser
+
+## Recording
+
+- [ ] Record one continuous take (macOS: `Cmd+Shift+5`)
+- [ ] Crop to app window only — no desktop clutter
+- [ ] Dark theme — verify no layout glitches
+- [ ] Test with a real OpenClaw Gateway connection (not mocked)
+- [ ] Export as MP4, H.264, 60fps preferred
+- [ ] Compress to <15MB
+
+## GIF for README
+
+- [ ] Convert MP4 to GIF (≤60 seconds, optimized for GitHub rendering)
+- [ ] Save as `docs/demo.gif`
+- [ ] Embed in README:
+
+```markdown
+## Demo
+
+![ClawWork 60-second demo](./docs/demo.gif)
+```
+
+## Hero screenshot
+
+- [ ] Extract the best frame from the recording
+- [ ] Must show: three-column layout, active conversation, file browser with artifacts
+- [ ] PNG, at least 1920px wide
+- [ ] Save as `docs/screenshot.png` (or update existing)

--- a/docs/promotion/github-topics.md
+++ b/docs/promotion/github-topics.md
@@ -1,0 +1,21 @@
+# GitHub Repository Topics
+
+Apply these topics manually in the clawwork-ai/ClawWork repository settings (cannot be set via PR).
+
+## Required topics
+
+```
+openclaw
+desktop-client
+electron
+local-first
+ai-agent
+developer-tools
+```
+
+## How to apply
+
+1. Go to https://github.com/clawwork-ai/ClawWork
+2. Click the gear icon next to "About"
+3. Add each topic from the list above
+4. Set website URL to https://clawwork-ai.github.io/ClawWork/

--- a/docs/promotion/hacker-news.md
+++ b/docs/promotion/hacker-news.md
@@ -1,0 +1,35 @@
+# Hacker News — Show HN
+
+**Title:** Show HN: ClawWork – Open-source desktop client for OpenClaw (replaces Feishu/Slack channels)
+
+**Best time:** Tuesday–Thursday, 8–10 AM Pacific. Stay online for 2–3 hours after posting.
+
+---
+
+## Post body
+
+Hi HN — I built ClawWork, an open-source desktop client for [OpenClaw](https://github.com/openclaw/openclaw).
+
+If you run OpenClaw agents locally, you probably talk to them through Feishu, Slack, or a web chat UI. That works for one-off questions, but breaks down fast: multiple tasks bleed together, tool calls disappear in the message stream, and generated files vanish into chat history.
+
+ClawWork is a purpose-built workspace instead of a chat workaround:
+
+- **Three-column layout** — task list, conversation, progress/artifacts panel
+- **Parallel tasks** — each task gets its own isolated OpenClaw session
+- **Tool call visibility** — real-time cards with expandable details; risky exec actions require approval
+- **Local-first artifacts** — code, images, and files auto-saved to a local Git repo with full-text search
+- **100% local data** — SQLite + Git on your machine, no cloud sync
+
+Stack: Electron 34, React 19, TypeScript, SQLite (Drizzle + FTS5).
+
+Install:
+
+- macOS: `brew tap clawwork-ai/clawwork && brew install --cask clawwork`
+- All platforms: https://github.com/clawwork-ai/ClawWork/releases
+- Browser PWA: https://cpwa.pages.dev
+
+Apache 2.0, fully open source: https://github.com/clawwork-ai/ClawWork
+
+Happy to answer questions about the Gateway protocol, session isolation, or why chat UIs are a bad container for agent work.
+
+**Attach:** 60-second demo GIF from README.

--- a/docs/promotion/jike.md
+++ b/docs/promotion/jike.md
@@ -1,0 +1,27 @@
+# Jike — #indie-dev / #AI-products
+
+**配图：** 演示 GIF 或三栏布局截图
+
+---
+
+## Post body
+
+做了个开源项目：**ClawWork** — OpenClaw 专用桌面客户端。
+
+一句话定位：别再在飞书里和 Agent 聊天了。
+
+OpenClaw 很强，但用飞书/钉钉/Slack 当对话通道，多任务一多就乱套。ClawWork 给每个任务独立的工作区：
+
+- 三栏布局：任务列表 + 对话 + 进度/产物
+- 多任务并行，各自独立 Session
+- 工具调用实时可视化
+- 产物自动保存到本地 Git，可全文搜索
+- 数据 100% 本地
+
+技术栈：Electron + React 19 + SQLite
+
+macOS 可直接 `brew install --cask clawwork`
+
+GitHub：https://github.com/clawwork-ai/ClawWork
+
+欢迎试用反馈 🙌

--- a/docs/promotion/juejin-outline.md
+++ b/docs/promotion/juejin-outline.md
@@ -1,0 +1,58 @@
+# Juejin Technical Article Outline
+
+**Title:** 用 Electron + React 19 构建 OpenClaw 专用桌面客户端 — ClawWork 技术实践
+
+**Target:** Week 2–4, technical depth audience
+
+---
+
+## Outline
+
+### 1. 背景：为什么聊天界面承载不了 Agent 工作流
+
+- OpenClaw 的能力 vs 飞书/Slack 通道的结构性缺陷
+- 多任务并行、工具调用、产物管理的真实痛点
+- 产品定位：OpenClaw 的 GitHub Desktop
+
+### 2. 架构总览
+
+- Monorepo 分层：`shared` → `core` → `desktop` / `pwa`
+- 单 Gateway WebSocket，Session Key 隔离：`agent:main:clawwork:task:<taskId>`
+- 本地数据：SQLite (Drizzle ORM + FTS5) + Git 产物仓库
+- 配图：`docs/architecture.svg`
+
+### 3. Electron 主进程设计
+
+- Gateway WebSocket 连接管理与事件分发
+- IPC 通道设计（类型安全的 preload bridge）
+- 产物自动提取管线（代码块、远程图片 → 本地文件）
+- SQLite 消息持久化与去重
+
+### 4. React 19 渲染层
+
+- 三栏布局与 Zustand store 拆分
+- 工具调用卡片的流式渲染
+- Tailwind v4 踩坑记录（@theme、CSS 变量迁移）
+- Zustand 无限循环调试经验
+
+### 5. Gateway 协议逆向
+
+- OpenClaw Gateway 消息格式与事件类型
+- Session 生命周期：创建、重置、压缩、删除
+- 多 Gateway 认证（token / password / pairing code）
+- 参考：`docs/openclaw-gateway-source-guide.md`
+
+### 6. 关键工程决策
+
+- 为什么选 SQLite 而非云端同步
+- FTS5 全文搜索的实现与性能
+- 跨平台打包（electron-builder + Homebrew cask）
+- 自动更新策略
+
+### 7. 开源与贡献
+
+- Apache 2.0，欢迎 PR
+- `pnpm check` 验证门禁
+- GitHub: https://github.com/clawwork-ai/ClawWork
+
+**Estimated length:** 3000–5000 字

--- a/docs/promotion/openclaw-docs-pr.md
+++ b/docs/promotion/openclaw-docs-pr.md
@@ -1,0 +1,68 @@
+# OpenClaw Docs PR Content
+
+Submit to the OpenClaw documentation repository under **Desktop Clients** / **Community Tools** / **Getting Started**.
+
+---
+
+## Suggested page title
+
+ClawWork — Desktop Client
+
+## Summary paragraph
+
+[ClawWork](https://github.com/clawwork-ai/ClawWork) is an open-source, local-first desktop client for OpenClaw. It provides a three-panel workspace for parallel agent tasks, real-time tool call visualization, and Git-native artifact management. Available for macOS, Windows, and Linux, with a browser PWA option.
+
+## Installation
+
+### macOS (Homebrew)
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+### All platforms
+
+Download the latest installer from [GitHub Releases](https://github.com/clawwork-ai/ClawWork/releases/latest).
+
+### PWA (browser)
+
+Open [cpwa.pages.dev](https://cpwa.pages.dev) in any modern browser.
+
+## Quick start
+
+1. Start your OpenClaw Gateway (default: `ws://127.0.0.1:18789`).
+2. Open ClawWork → Settings → add your Gateway (token, password, or pairing code).
+3. Create a task, select an agent and model, and start working.
+
+## Key features
+
+- Parallel tasks with isolated OpenClaw sessions
+- Three-column UI: task list, conversation, progress/artifacts
+- Real-time tool call cards with exec approval gates
+- Auto-saved artifacts with local Git versioning and full-text search
+- Multi-gateway support with per-task model switching
+- Scheduled (cron) tasks with run history
+
+## Screenshots
+
+Include these assets in the PR:
+
+1. `docs/screenshot.png` — three-column desktop layout
+2. PWA screenshot from README (GitHub user-attachments URL)
+3. 60-second demo GIF (once recorded — see [demo-recording.md](./demo-recording.md))
+
+## Links
+
+- Repository: https://github.com/clawwork-ai/ClawWork
+- Website: https://clawwork-ai.github.io/ClawWork/
+- License: Apache 2.0
+- Discord: https://discord.gg/n9fCgBMgm
+
+## Awesome-list entry
+
+For `awesome-openclaw` or similar curated lists:
+
+```markdown
+- [ClawWork](https://github.com/clawwork-ai/ClawWork) — Local-first desktop client with parallel tasks, tool call visualization, and Git-native artifact management. (macOS/Windows/Linux/PWA)
+```

--- a/docs/promotion/reddit-localllama.md
+++ b/docs/promotion/reddit-localllama.md
@@ -1,0 +1,26 @@
+# Reddit r/LocalLLaMA
+
+**Title:** ClawWork — a dedicated desktop UI for self-hosted OpenClaw agents (parallel tasks, local artifacts)
+
+---
+
+## Post body
+
+If you run [OpenClaw](https://github.com/openclaw/openclaw) locally with your own models and gateways, you might be using Feishu/Slack/Telegram as the chat front-end. It works, but it's not built for agent workflows.
+
+**ClawWork** is an open-source desktop client designed specifically for OpenClaw:
+
+- Run **multiple agent tasks in parallel**, each with its own session and context
+- **Switch models and thinking levels per task** across multiple gateways
+- See **tool calls live** — no more black-box agent execution
+- **Artifacts stay local** — code, images, and files auto-saved with Git versioning and FTS search
+- **Approval gates** for sensitive shell commands
+
+It's local-first (SQLite + Git on disk), cross-platform (macOS/Windows/Linux), and Apache 2.0.
+
+- https://github.com/clawwork-ai/ClawWork
+- PWA (no install): https://cpwa.pages.dev
+
+Built for people who self-host agents and want a real workspace, not another chat window.
+
+**Attach:** demo GIF showing parallel tasks + tool call cards.

--- a/docs/promotion/reddit-opensource.md
+++ b/docs/promotion/reddit-opensource.md
@@ -1,0 +1,36 @@
+# Reddit r/opensource
+
+**Title:** [Project] ClawWork — open-source desktop client for OpenClaw with local Git artifact versioning
+
+---
+
+## Post body
+
+**ClawWork** is an open-source desktop client for [OpenClaw](https://github.com/openclaw/openclaw), the self-hosted AI agent runtime.
+
+### The problem
+
+OpenClaw is powerful, but most users interact through generic chat channels (Feishu, Slack, Telegram). Chat is a poor container for agent work: no parallel tasks, no structured progress, no durable artifact management.
+
+### What ClawWork does
+
+- **Three-panel workspace** — tasks, conversation, progress/artifacts
+- **Parallel multi-task** — each task maps to an isolated OpenClaw session
+- **Tool call transparency** — inline cards, expandable details, exec approval prompts
+- **Git-native artifacts** — auto-extract and version AI outputs locally
+- **Full-text search** — SQLite FTS5 across tasks, messages, and files
+
+### Tech stack
+
+Electron 34 · React 19 · TypeScript · Tailwind v4 · Zustand · SQLite (Drizzle ORM)
+
+### Get it
+
+- Repo: https://github.com/clawwork-ai/ClawWork
+- License: Apache 2.0
+- macOS: `brew tap clawwork-ai/clawwork && brew install --cask clawwork`
+- All installers: https://github.com/clawwork-ai/ClawWork/releases
+
+Contributions welcome — issues tagged `good first issue` for newcomers.
+
+**Attach:** screenshot or demo GIF.

--- a/docs/promotion/reddit-selfhosted.md
+++ b/docs/promotion/reddit-selfhosted.md
@@ -1,0 +1,33 @@
+# Reddit r/selfhosted
+
+**Title:** I built an open-source desktop client for OpenClaw that auto-versions all AI outputs to a local Git repo
+
+---
+
+## Post body
+
+I've been running [OpenClaw](https://github.com/openclaw/openclaw) on my homelab for agent workflows — code generation, file management, scheduled tasks. The default experience is chatting through messaging channels (Feishu, Slack, Telegram) or a basic web UI.
+
+For self-hosters who care about data ownership, that has real problems:
+
+- All conversation data lives on third-party IM servers (or gets lost in a single chat thread)
+- AI-generated files scroll away and aren't versioned
+- Running multiple agent tasks in parallel turns one chat into chaos
+
+So I built **ClawWork** — a local-first desktop client (Electron + React + SQLite) that:
+
+- Keeps **100% of data on your machine** (SQLite + local Git repo for artifacts)
+- Runs **parallel tasks** with isolated OpenClaw sessions
+- **Auto-saves** every code block, image, and file the agent produces
+- Shows **tool calls in real time** with approval gates for risky exec operations
+- Works with your existing OpenClaw Gateway (`ws://127.0.0.1:18789` by default)
+
+Cross-platform: macOS (Homebrew cask), Windows, Linux (AppImage/deb). There's also a PWA if you want browser access.
+
+- GitHub: https://github.com/clawwork-ai/ClawWork
+- Releases: https://github.com/clawwork-ai/ClawWork/releases
+- Apache 2.0
+
+Would love feedback from other self-hosters — especially around Gateway pairing, artifact storage, and what you'd want in a local-first agent workspace.
+
+**Attach:** demo GIF or screenshot gallery.

--- a/docs/promotion/twitter-thread.md
+++ b/docs/promotion/twitter-thread.md
@@ -1,0 +1,62 @@
+# Twitter/X Thread
+
+Tag @OpenClaw. Hashtags: #OpenClaw #LocalFirst #OpenSource #DevTools
+
+**Attach:** demo GIF on the first tweet.
+
+---
+
+## Tweet 1 (hook)
+
+Stop chatting with your OpenClaw agents in Feishu.
+
+ClawWork is the dedicated desktop client for OpenClaw — parallel tasks, real-time tool calls, local Git artifacts.
+
+Open source. Apache 2.0.
+
+https://github.com/clawwork-ai/ClawWork
+
+🧵
+
+## Tweet 2 (problem)
+
+OpenClaw is incredibly capable. But when you run 5 tasks at once through a chat channel:
+
+→ contexts bleed together
+→ tool calls vanish in the stream
+→ generated files are gone forever
+
+Chat is a workaround, not a workspace.
+
+## Tweet 3 (solution)
+
+ClawWork gives every task its own workspace:
+
+📋 Task list (left)
+💬 Conversation (center)
+📂 Progress + artifacts (right)
+
+Each task = isolated OpenClaw session. Switch freely, nothing collides.
+
+## Tweet 4 (features)
+
+What you get:
+
+✅ Real-time tool call cards (expandable)
+✅ Exec approval prompts
+✅ Auto-saved artifacts → local Git repo
+✅ Full-text search across everything
+✅ Multi-gateway, per-task model switching
+✅ Cron/scheduled tasks
+
+## Tweet 5 (install)
+
+Install today:
+
+🍺 macOS: brew install --cask clawwork
+📦 All platforms: github.com/clawwork-ai/ClawWork/releases
+🌐 PWA: cpwa.pages.dev
+
+Built with Electron 34 + React 19 + SQLite.
+
+Star ⭐ if a dedicated agent workspace sounds useful!

--- a/docs/promotion/v2ex.md
+++ b/docs/promotion/v2ex.md
@@ -1,0 +1,44 @@
+# V2EX — #share-creation
+
+**Title:** ClawWork — OpenClaw 专用桌面客户端，别再在飞书里和 Agent 聊天了
+
+---
+
+## Post body
+
+大家好，分享一个我最近一直在用的开源项目：**ClawWork**。
+
+如果你在用 [OpenClaw](https://github.com/openclaw/openclaw) 跑本地 Agent，大概率是通过飞书、钉钉或 Slack 当对话通道。单个任务还行，但多任务并行、长时运行、工具调用、生成文件一多，聊天记录就变成一团浆糊——状态看不清、文件找不到、上下文串台。
+
+ClawWork 的定位很简单：**OpenClaw 的专用 UI**，就像 GitHub Desktop 之于 Git。
+
+### 和飞书/钉钉/Slack 通道对比
+
+|          | 飞书 / 钉钉 / Slack | ClawWork                         |
+| -------- | ------------------- | -------------------------------- |
+| 布局     | 单聊线程            | 三栏：任务列表 + 对话 + 进度面板 |
+| 多任务   | 一次一个对话        | 并行任务，独立 Session           |
+| 工具调用 | 隐藏或纯文本        | 实时可视化，可展开详情           |
+| 产物文件 | 淹没在聊天记录里    | 自动保存到本地 Git 仓库，可搜索  |
+| 进度追踪 | 无结构化追踪        | 分步进度面板                     |
+| 数据归属 | 第三方服务器        | 100% 本地（SQLite + Git）        |
+
+### 核心能力
+
+- 多任务并行，每个任务独立 OpenClaw Session
+- 工具调用实时卡片 + 敏感操作审批
+- 产物自动提取保存，SQLite FTS5 全文搜索
+- 支持 macOS / Windows / Linux，也有 PWA 浏览器版
+
+### 安装
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+或直接下载：https://github.com/clawwork-ai/ClawWork/releases
+
+开源协议 Apache 2.0，欢迎 Star 和 Issue：https://github.com/clawwork-ai/ClawWork
+
+**配图：** README 截图或 60 秒演示 GIF。

--- a/docs/promotion/wechat-launch-article.md
+++ b/docs/promotion/wechat-launch-article.md
@@ -1,0 +1,67 @@
+# WeChat Official Account — Launch Article
+
+**Title:** 别再用飞书和 Agent 聊天了：ClawWork 是 OpenClaw 的专用桌面客户端
+
+**Target:** Launch day or Week 1
+
+---
+
+## Article body
+
+### 开篇
+
+如果你已经在本地或服务器上部署了 OpenClaw，大概率是通过飞书、钉钉或 Slack 跟 Agent 对话。
+
+单个问题还行。但当任务变多、变长、变复杂——多个 Agent 并行、工具调用频繁、生成大量文件——聊天记录就变成一团浆糊。
+
+**今天推荐一个开源项目：ClawWork。**
+
+### 一句话定位
+
+**OpenClaw 的专用 UI —— 就像 GitHub Desktop 之于 Git。**
+
+### 和飞书通道比，强在哪？
+
+|          | 飞书 / 钉钉 / Slack | ClawWork                 |
+| -------- | ------------------- | ------------------------ |
+| 布局     | 单聊线程            | 三栏：任务 + 对话 + 进度 |
+| 多任务   | 一次一个            | 并行隔离                 |
+| 工具调用 | 看不见              | 实时卡片                 |
+| 产物文件 | 淹没在聊天里        | 本地 Git 自动保存        |
+| 数据     | 第三方服务器        | 100% 本地                |
+
+### 核心功能
+
+1. **多任务并行** — 每个任务独立 Session，互不干扰
+2. **工具调用可视化** — 实时状态，敏感操作需审批
+3. **产物自动管理** — 代码、图片、文件自动提取保存
+4. **全文搜索** — 跨任务、跨消息、跨文件
+5. **定时任务** — cron 表达式，自动执行
+6. **全平台** — macOS / Windows / Linux + PWA 浏览器版
+
+### 怎么安装
+
+macOS 用户：
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+其他平台下载安装包：
+https://github.com/clawwork-ai/ClawWork/releases
+
+连接本地 Gateway（默认 `ws://127.0.0.1:18789`），创建任务即可开始。
+
+### 技术栈
+
+Electron 34 + React 19 + TypeScript + SQLite，Apache 2.0 开源。
+
+GitHub：https://github.com/clawwork-ai/ClawWork
+
+欢迎 Star、提 Issue、加入社区一起打磨 OpenClaw 生态最好的桌面工具。
+
+### 结尾 CTA
+
+- 扫码关注 / 加入用户群（维护者填写）
+- 回复「ClawWork」获取快速入门指南（维护者填写）

--- a/docs/promotion/zhihu-outline.md
+++ b/docs/promotion/zhihu-outline.md
@@ -1,0 +1,55 @@
+# Zhihu Column Article Outline
+
+**Title:** 为什么 OpenClaw 需要一个专用桌面客户端？
+
+**Target:** Week 2–4, product/thought leadership audience
+
+---
+
+## Outline
+
+### 1. 引子：Agent 时代的工作界面问题
+
+- 能力爆炸，界面停滞
+- 类比：IDE 之于代码，终端之于 Unix，Workspace 之于 Agent OS
+
+### 2. OpenClaw 改变了什么
+
+- 自托管 Agent 运行时
+- 邮件、日历、文件、工具调用——真正的数字同事
+- 但默认交互仍是「聊天」
+
+### 3. 聊天通道的结构性缺陷
+
+用对比表展开（飞书/钉钉/Slack vs ClawWork）：
+
+- 单线程 vs 三栏工作区
+- 单任务 vs 并行隔离
+- 工具调用不可见 vs 实时可视化
+- 产物丢失 vs Git 版本化
+- 数据在第三方 vs 100% 本地
+
+### 4. ClawWork 的产品哲学
+
+- Task-first，不是 Chat-first
+- 每个任务 = 持久工作区（Session + 产物 + 控制 + 历史）
+- Local-first：SQLite + Git，无云依赖
+
+### 5. 实际使用场景
+
+- 并行跑 5 个开发任务
+- 定时报告生成（cron）
+- 多 Gateway、多模型切换
+- Teams 多 Agent 编排
+
+### 6. 对 Agent OS 的展望
+
+- 从 OpenClaw 专用到多 Runtime 控制面
+- Workspace 层的长远价值
+
+### 7. 结语
+
+- 开源地址与安装方式
+- 邀请读者试用并反馈
+
+**Estimated length:** 2000–3000 字

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "clawwork",
   "private": true,
   "description": "OpenClaw desktop client with structured task management",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/clawwork-ai/ClawWork.git"
+  },
+  "homepage": "https://clawwork-ai.github.io/ClawWork/",
+  "license": "Apache-2.0",
   "scripts": {
     "postinstall": "node scripts/ensure-electron.mjs",
     "prepare": "husky",


### PR DESCRIPTION
## Summary

Implements the repository-side deliverables from the promotion plan (#11):

- **README** — adds the "ClawWork vs messaging channels" comparison table and a Demo section placeholder linked to the recording checklist
- **package.json** — adds `repository`, `homepage`, and `license` metadata fields
- **CHANGELOG.md** — initial v0.1.0 release notes
- **docs/promotion/** — ready-to-post drafts (HN, V2EX, Reddit ×3, Twitter, Jike), article outlines (Juejin, Zhihu, WeChat), OpenClaw docs PR content, demo recording checklist, and GitHub topics guide

Closes #11

## Remaining manual steps (not automatable via PR)

- Record and embed the 60-second demo GIF (`docs/demo.gif`)
- Apply GitHub repo topics per `docs/promotion/github-topics.md`
- Execute platform posts on launch day (blocked by #6)

## Test plan

- [x] `pnpm check` passes
- [x] Prettier formatting applied to all new markdown files
- [x] Architecture guardrails pass

## Release note

NONE