### PR TITLE
[Fix] safeFetch streaming maxSize memory DoS regression test (#408)

### DIFF
--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -290,4 +290,35 @@ describe('safeFetch', () => {
     expect(cancel).toHaveBeenCalledOnce();
     expect(abortSignal?.aborted).toBe(true);
   });
+
+  it('does not read the entire oversized body before rejecting — bounded streaming (#408)', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(null);
+    const chunkSize = 256;
+    const maxSize = 1024;
+    const bodySize = 10 * 1024;
+    const cancel = vi.fn(async () => {});
+    const reader = streamReaderFrom(new ArrayBuffer(bodySize), chunkSize, cancel);
+    const read = vi.fn(reader.read.bind(reader));
+    netFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: {
+        getReader: () =>
+          ({
+            read,
+            cancel,
+            releaseLock: () => {},
+            closed: Promise.resolve(undefined),
+          }) as ReadableStreamDefaultReader<Uint8Array>,
+      },
+    } as unknown as Response);
+
+    await expect(safeFetch('https://cdn.example.com/huge-stream.bin', { maxSize })).rejects.toThrow('too large');
+
+    // 5 chunks (1280 bytes) exceed maxSize; must not drain the full 10 KiB body.
+    expect(read.mock.calls.length).toBeLessThan(bodySize / chunkSize);
+    expect(read.mock.calls.length).toBeLessThanOrEqual(Math.ceil(maxSize / chunkSize) + 1);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -298,27 +298,21 @@ describe('safeFetch', () => {
     const bodySize = 10 * 1024;
     const cancel = vi.fn(async () => {});
     const reader = streamReaderFrom(new ArrayBuffer(bodySize), chunkSize, cancel);
-    const read = vi.fn(reader.read.bind(reader));
+    const readSpy = vi.spyOn(reader, 'read');
     netFetchMock.mockResolvedValue({
       ok: true,
       status: 200,
       headers: new Headers(),
       body: {
-        getReader: () =>
-          ({
-            read,
-            cancel,
-            releaseLock: () => {},
-            closed: Promise.resolve(undefined),
-          }) as ReadableStreamDefaultReader<Uint8Array>,
+        getReader: () => reader,
       },
     } as unknown as Response);
 
     await expect(safeFetch('https://cdn.example.com/huge-stream.bin', { maxSize })).rejects.toThrow('too large');
 
     // 5 chunks (1280 bytes) exceed maxSize; must not drain the full 10 KiB body.
-    expect(read.mock.calls.length).toBeLessThan(bodySize / chunkSize);
-    expect(read.mock.calls.length).toBeLessThanOrEqual(Math.ceil(maxSize / chunkSize) + 1);
+    expect(readSpy.mock.calls.length).toBeLessThan(bodySize / chunkSize);
+    expect(readSpy.mock.calls.length).toBeLessThanOrEqual(Math.ceil(maxSize / chunkSize) + 1);
     expect(cancel).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- Issue #408 reported that `safeFetch` buffered the entire response via `res.arrayBuffer()` before enforcing `maxSize`, enabling a memory DoS. The streaming reader fix landed in #487 and reader cancellation in #523, but the issue remained open.
- Adds a regression test that verifies `safeFetch` stops reading an oversized streamed body before draining all chunks (bounded reads + reader cancel), matching the memory-DoS scenario in the issue.

Closes #408

## Test plan

- [x] `pnpm --filter @clawwork/desktop test -- safe-fetch.test.ts` — 25 tests passed
- [x] New test: `does not read the entire oversized body before rejecting — bounded streaming (#408)`

## release-note

NONE