### PR TITLE
[Docs] Add pr-cleaner-master and pr-merge-runner skills

### DIFF
--- a/.claude/skills/pr-cleaner-master/SKILL.md
+++ b/.claude/skills/pr-cleaner-master/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: pr-cleaner-master
+description: >
+  Maintainer's daily PR sweep tool. Batch-review all open PRs in the current
+  repo, classify each into merge / fix-and-merge / request-changes / waiting /
+  cached, and present a three-section table. Incremental by default: unchanged
+  PRs since last sweep are folded away.
+  Use when: "review PRs", "pr cleaner", "pr sweep", "pr triage", "daily PR review",
+  "project maintainer PR management", sweeping open PRs as a project owner.
+  Passing a PR number narrows the sweep to that PR. Do not use for:
+  single-PR deep review or evaluating review comments on your own PR (use
+  pr-eval), issue management (use issue-cleaner-master), or automated merging.
+argument-hint: "[#PR|PR...] [--repo owner/repo] [--all] [--fresh]"
+---
+
+IRON LAW: NEVER POST A COMMENT, APPROVE, OR MERGE A PR WITHOUT SHOWING THE EXACT CONTENT TO THE USER AND GETTING EXPLICIT CONFIRMATION FIRST. NEVER PASTE CODE SNIPPETS TO CONTRIBUTORS — pasting code to a contributor is condescending. The only exception is a `fix-and-merge` row where the user has explicitly asked for a suggested fix in the current turn.
+
+# PR Cleaner Master
+
+Maintainer's daily sweep over open PRs. The goal is "inbox zero for PRs":
+scan all open PRs in seconds, classify each, and surface only the ones that
+need you today. Unchanged PRs since the last sweep are folded away.
+
+This skill does NOT do deep single-PR review — for that, use `pr-eval`.
+This skill does NOT merge PRs automatically — merge is a manual step you take
+after seeing the verdict, or invoke `pr-merge-runner` to land snapshot `merge`
+rows hands-off.
+
+Use the loaded skill base directory as `SKILL_DIR` when referencing bundled
+files (e.g. `references/reply-templates.md`).
+
+## Argument Parsing
+
+| Input                    | Behavior                                                  |
+|--------------------------|-----------------------------------------------------------|
+| no args                  | sweep all open PRs in current repo (incremental)          |
+| `123`                    | sweep only PR #123                                       |
+| `#123 #124`              | sweep only the listed PRs                                 |
+| `123 124`                | sweep only the listed PRs                                 |
+| `--repo owner/repo`      | sweep that repo instead of current git directory          |
+| `--all`                  | show Cached section in full instead of folded count       |
+| `--fresh`                | ignore snapshot, re-classify every PR from scratch        |
+
+Resolve target repo:
+
+1. If `--repo` given → use it.
+2. Else → `gh repo view --json nameWithOwner --jq .nameWithOwner`.
+3. If neither works → error: "Not in a GitHub repo. Pass --repo owner/repo."
+
+## Phase 0: Snapshot Load  ⛔ BLOCKING
+
+- [ ] Compute snapshot path: `~/.claude/projects/<project-dir-slug>/pr-cleaner-state.json`
+  - `<project-dir-slug>` is the same slug used by the memory system for the
+    current project root (e.g. `-Users-x-git-clawwork--bare`).
+- [ ] If the file exists, load it. If not, treat as `{}`.
+- [ ] Snapshot shape:
+  ```json
+  {
+    "repo": "owner/repo",
+    "lastSweep": "2026-04-13T14:32:00Z",
+    "prs": {
+      "123": {"headSha": "abc...", "comments": 2, "verdict": "merge", "at": "2026-04-13T14:32:00Z"}
+    }
+  }
+  ```
+- [ ] If snapshot `repo` differs from target repo, treat as empty. One
+      snapshot per repo — do not mix.
+- [ ] If `--fresh`, skip loading and treat as empty.
+
+## Phase 1: Batch Fetch  ⛔ BLOCKING
+
+One command gets the batch metadata for a full sweep. Do NOT loop per-PR in
+this phase unless the user explicitly passed PR numbers.
+Before selecting fields, verify `gh pr list --help` and request only fields
+listed under `JSON FIELDS`. If a field is not exposed by the installed `gh`,
+omit it and use the fallback behavior below; never pretend unsupported fields
+exist.
+
+```bash
+gh pr list --repo <repo> --state open --limit 100 --json \
+  number,title,author,headRefOid,mergeable,mergeStateStatus,\
+state,isDraft,reviewDecision,labels,updatedAt,additions,deletions,changedFiles,\
+statusCheckRollup,latestReviews,reviews,comments
+```
+
+If the user passed one or more PR numbers, fetch exactly those PRs instead of
+listing all open PRs. A bare number such as `123` is equivalent to `#123`.
+
+```bash
+gh pr view <number> --repo <repo> --json \
+  number,title,author,headRefOid,mergeable,mergeStateStatus,\
+state,isDraft,reviewDecision,labels,updatedAt,additions,deletions,changedFiles,\
+statusCheckRollup,latestReviews,reviews,comments
+```
+
+For multiple explicit PR numbers, repeat `gh pr view` only for those requested
+numbers and combine the results into the same in-memory list shape used by the
+full sweep.
+
+- [ ] If `gh` is not authenticated → error with `gh auth login` hint.
+- [ ] If a requested PR does not exist or is not open → report that PR and do
+      not fabricate a row for it.
+- [ ] If no open PRs in a full sweep → print
+      `No open PRs in <repo>. Nothing to sweep.` and exit.
+- [ ] `authorAssociation` is not available in all `gh pr list` versions. If it
+      is unavailable, do not display a `*first-time*` marker. Do not infer it
+      from author age, commit count, or prior local snapshots.
+- [ ] Also fetch the PR template once (best effort, non-blocking):
+  ```bash
+  gh api "repos/<repo>/contents/.github/pull_request_template.md" 2>/dev/null \
+    || gh api "repos/<repo>/contents/.github/PULL_REQUEST_TEMPLATE.md" 2>/dev/null \
+    || gh api "repos/<repo>/contents/PULL_REQUEST_TEMPLATE.md" 2>/dev/null
+  ```
+  Hold it in memory for this sweep only. If not found, no problem — PR
+  template compliance is informational.
+
+## Phase 2: Fast Classify  ⚠️ REQUIRED
+
+For each PR, apply the decision tree below. **First matching rule wins.**
+This phase uses metadata only — do NOT read diffs here.
+
+| # | Condition                                                                        | Bucket                     |
+|---|----------------------------------------------------------------------------------|----------------------------|
+| 1 | `isDraft == true`                                                                | `skip` (not shown)         |
+| 2 | `mergeable == "CONFLICTING"`                                                     | Waiting: `conflicts`       |
+| 3 | `statusCheckRollup` has any `PENDING` / `FAILURE` / `CANCELLED` / `ERROR`        | Waiting: `ci-not-passing`  |
+| 4 | `reviewDecision == "CHANGES_REQUESTED"` AND `headRefOid` unchanged from snapshot | Waiting: `awaiting-author` |
+| 5 | `headRefOid` AND `comments.length` both unchanged from snapshot                  | `cached` (prior verdict)   |
+| — | otherwise                                                                        | → Phase 3                  |
+
+CI is a hard gate. A PR with red or pending CI is the contributor's
+responsibility to fix before maintainer review. Do not comment, do not
+classify further — just list it under Waiting. A contributor with a failing
+CI does not need the maintainer pinging them; GitHub already notified them.
+
+## Phase 3: Deep Decide  ⚠️ REQUIRED (only for PRs that survive Phase 2)
+
+For each PR entering this phase, decide between `merge` / `fix-and-merge` /
+`request-changes`. This is where diffs and files get read — and only here.
+
+- [ ] Read existing review activity first using fields supported by the local
+      `gh` (`latestReviews`, `reviews`, `comments`). Do NOT re-raise points
+      another reviewer already made.
+- [ ] If exact unresolved review-thread state is needed and the local `gh`
+      does not expose `reviewThreads`, fetch it best-effort through the GitHub
+      API/GraphQL. If it still cannot be fetched, do not claim the PR has no
+      unresolved threads; classify conservatively and mention that thread state
+      was not locally exposed.
+- [ ] If existing threads are known to be unresolved and the author has not
+      responded, reclassify as Waiting: `awaiting-author`.
+- [ ] For small PRs (`additions + deletions <= 20` AND `changedFiles <= 3`):
+      read the full diff, lean toward `merge` or `fix-and-merge`.
+- [ ] For larger PRs: list changed files first, then read only the
+      load-bearing ones (entrypoints, shared types, files crossing layer
+      boundaries defined in project rules).
+
+### Decision rules
+
+| Signal                                                                                                       | Verdict            |
+|--------------------------------------------------------------------------------------------------------------|--------------------|
+| Code is clean, style matches project, tests present where expected, scope fits                              | `merge`            |
+| Only trivial blockers (missing DCO sign-off, typo, lint fix, one-char bug) — faster to fix than to request  | `fix-and-merge`    |
+| Low-risk project-convention issues caused by unfamiliarity with local workflow, formatting, naming, docs, or small tests | `fix-and-merge` |
+| Real questions about scope, approach, correctness, or API surface                                           | `request-changes`  |
+
+Scope rules of thumb:
+
+- Prefer `fix-and-merge` over `request-changes` when the issue is simple,
+  mechanical, low risk, and likely caused by the contributor not knowing local
+  project conventions. Do this to avoid needless review round-trips for small
+  PRs.
+- Do not use `fix-and-merge` to paper over real uncertainty. Correctness,
+  security, data behavior, public API, architecture direction, and cross-layer
+  ownership questions still require `request-changes`.
+- A PR that widens public API, touches shared types, or crosses package
+  boundaries without prior discussion → `request-changes` (flag the scope,
+  don't judge the code).
+- A PR that violates a project rule (e.g. comments in code, hardcoded
+  colors, content-based dedup, forbidden message persistence paths) →
+  `request-changes` with a one-line reference to the rule name. **Do not
+  paste the offending code back at the contributor.**
+- Uncertainty → `request-changes`. Never merge when in doubt.
+
+## Phase 4: Present Table  ⚠️ REQUIRED
+
+Output exactly this three-section structure. Only sections with content are
+shown. The Cached section is folded by default (summary line only) unless
+`--all` was passed.
+
+```markdown
+## PR Cleaner — <repo>  (sweep <UTC timestamp>, N open / M action / K waiting / C cached)
+
+### 🟢 Action needed (M)
+
+| PR | Author | Title | Action | Why | Draft Reply |
+|---|---|---|---|---|---|
+| #123 | @alice | feat: X | `merge` | Clean, 40 LOC, tests included | Thanks @alice, looks good to me! |
+| #124 | @bob | fix: Y | `fix-and-merge` | Missing DCO sign-off, otherwise LGTM | (locally add sign-off — no reply needed) |
+| #125 | @carol | refactor: Z | `request-changes` | Widens shared API without discussion | Thanks @carol! Could we align on the scope of the public surface change before landing? |
+
+### 🟡 Waiting (K) — no action from you
+
+| PR | Author | Reason | Since |
+|---|---|---|---|
+| #126 | @dave | CI not passing | 3h |
+| #127 | @eve | Conflicts | 1d |
+| #128 | @frank | Awaiting author response | 2d |
+
+### ⚪ Cached (C)
+
+2 PRs unchanged since last sweep: #101, #115. Run with `--all` to show.
+```
+
+Column notes:
+
+- **Author**: if an actually fetched `authorAssociation` is
+  `FIRST_TIME_CONTRIBUTOR` or `FIRST_TIMER`, append `*first-time*` after the
+  handle (display only — reply template is NOT auto-switched). If the field is
+  not available from local metadata, show only the handle.
+- **Action**: one of `merge` / `fix-and-merge` / `request-changes`.
+- **Why**: max ~10 words, factual, no hedging.
+- **Draft Reply**: the exact comment text that will be posted if confirmed.
+  If no reply is needed, write `(no reply)` or a short parenthetical note.
+
+## Phase 5: Confirmation Gate  ⛔ NEVER SKIP
+
+After the table, wait for the user. Common commands the user may type:
+
+| User says                         | Meaning                                                  |
+|-----------------------------------|----------------------------------------------------------|
+| `go` / `post` / `all`             | post every non-empty Draft Reply in the Action section   |
+| `post 123 125`                    | post only those rows' replies                            |
+| `skip 124`                        | drop that row's reply                                    |
+| `edit 125 "<new text>"`           | replace that row's draft with new text, then confirm     |
+| `abort` / `cancel`                | exit without posting anything                            |
+
+Never post without an explicit green light. No `--quick` flag bypasses this
+gate — if added later, it must still stop here.
+
+## Phase 6: Execute Approved Replies
+
+For each approved reply:
+
+```bash
+gh pr comment <N> --repo <repo> --body "<draft text>"
+```
+
+- Use `gh pr comment`, NOT `gh pr review --approve` or
+  `gh pr review --request-changes`. This skill keeps review state
+  lightweight and avoids tangling with project-specific approval settings.
+- For `fix-and-merge` rows, the skill does NOT fix code. It prints a
+  one-liner telling the user what needs fixing locally. The user then uses
+  `/commit` or `/ship` or manual git to handle it.
+- The skill NEVER runs `gh pr merge`. Merging is always a manual step taken
+  by the user after the sweep.
+
+After posting, report:
+
+```
+Posted: #123, #125
+Skipped: #124 (local fix), #127 (aborted)
+```
+
+## Phase 7: Write Snapshot
+
+Update `pr-cleaner-state.json`:
+
+- [ ] For every PR seen this sweep (action + waiting + cached), write
+      `{headSha, comments, verdict, at}`. Skipped drafts are NOT written.
+- [ ] Set `lastSweep` to now (UTC ISO8601).
+- [ ] Set `repo` to the target repo.
+- [ ] Atomic write: write to `<path>.tmp`, then rename over the target.
+- [ ] If the parent directory doesn't exist, create it. Do NOT create any
+      sibling memory files — this snapshot is the only file this skill
+      writes in that directory.
+
+## Reply Style  ⚠️ REQUIRED
+
+See `references/reply-templates.md` for the four canonical templates.
+
+Global rules (IRON LAW scope):
+
+- English only. No CJK in GitHub-facing text.
+- Open with `Thanks @<user>!` or `Thanks @<user>, ...`. No "We really
+  appreciate", no "Thank you so much for your contribution".
+- One or two short sentences. No walls of text.
+- **Never paste code blocks to contributors.** Reference files by
+  `path/to/file.ts:42` at most. Explaining how to fix something is the
+  contributor's job — the maintainer's job is to point at what.
+- PR template non-compliance: mention it as FYI in parentheses, never block
+  on it. Example:
+  `(FYI, we have a PR template at .github/PULL_REQUEST_TEMPLATE.md — no need to backfill)`.
+- Conflicts: one line. Never explain how to rebase.
+- Never apologize on behalf of the project for a contributor mistake.
+- Never promise a timeline ("I'll review this next week").
+
+## Do Not
+
+- Never post a comment without explicit user confirmation — **never**.
+- Never paste code snippets to contributors, even for "helpful" suggestions.
+- Never run `gh pr merge` automatically.
+- Never run `gh pr review --approve` or `--request-changes`. Use plain
+  `gh pr comment`.
+- Never close a PR, even if it looks like spam. Flag for user judgment.
+- Never modify PR labels — that is the triage skill's job.
+- Never re-raise a point another reviewer already made. Read existing review
+  activity first, and use `reviewThreads` only when it is actually exposed or
+  fetched.
+- Never classify a Draft PR.
+- Never skip the Phase 5 confirmation gate.
+- Never read PR diffs in Phase 2 — metadata only until Phase 3.
+- Never cache a verdict across repos — the snapshot is keyed to one repo.
+- Never fabricate PR data, author handles, or commit SHAs.
+- Never claim "CI is green" without verifying `statusCheckRollup`.
+- Never ping a contributor about a failing CI run — GitHub already did.

--- a/.claude/skills/pr-cleaner-master/references/reply-templates.md
+++ b/.claude/skills/pr-cleaner-master/references/reply-templates.md
@@ -1,0 +1,151 @@
+# Reply Templates
+
+Four canonical templates, one per verdict. All templates are English,
+GitHub-short, and never paste code. Fill in `<placeholders>` and adapt
+naturally — these are starting points, not rigid forms.
+
+Global rules (from `SKILL.md`):
+
+- Open with `Thanks @<user>!` or `Thanks @<user>, ...`.
+- One or two short sentences.
+- Never paste code blocks to contributors.
+- Never explain how to do something the contributor already knows (rebase,
+  fix a typo, add a sign-off).
+- Never apologize for the contributor's mistake.
+- Never promise a review timeline.
+
+---
+
+## Template: merge
+
+Used when a PR is clean and ready to merge. The skill does NOT auto-merge —
+this reply just signals approval in a lightweight way. The user will run
+`gh pr merge` manually afterward.
+
+Canonical:
+
+```
+Thanks @<user>, looks good to me!
+```
+
+Variants (pick one, don't chain):
+
+- `Thanks @<user>! This is a clean change, LGTM.`
+- `Thanks @<user>, this does exactly what it should. LGTM.`
+- `Thanks @<user>! Happy to land this.`
+
+Never say "I'll merge this now" unless the user is actually about to run
+`gh pr merge` in the same breath — dangling promises erode trust.
+
+---
+
+## Template: fix-and-merge
+
+Used when the maintainer plans to fix a small blocker locally and land it.
+In most cases **no reply is posted at all** — the user just fixes and
+merges. Only post a reply if the contributor explicitly asked what's
+missing, or if the blocker is non-obvious and silent merging would be
+confusing.
+
+```
+Thanks @<user>! Just needs <one-line blocker> — I'll handle it on merge.
+```
+
+Valid one-line blockers (examples):
+
+- `missing DCO sign-off`
+- `one typo in <file>`
+- `a lint fix`
+- `a missing import`
+
+Never describe the fix in detail. Never suggest how the contributor should
+apply it. The whole point of `fix-and-merge` is that the maintainer absorbs
+the cost so the contribution lands fast.
+
+---
+
+## Template: request-changes
+
+Used when there are real questions about scope, approach, or correctness.
+Ask, don't prescribe. The goal is to start a conversation, not dictate a
+solution.
+
+Shape: `Thanks @<user>! <one-sentence observation>. <one question>?`
+
+General examples:
+
+```
+Thanks @<user>! This touches <area>, which is load-bearing across the codebase. Could we align on the scope before landing?
+```
+
+```
+Thanks @<user>! I'm not sure the current approach handles <concern>. Could you walk me through how it behaves when <scenario>?
+```
+
+```
+Thanks @<user>! This looks like it might conflict with <rule/convention>. Is there a reason to diverge here, or should we match the existing pattern?
+```
+
+Scope call-outs (flag the scope, don't judge the code):
+
+```
+Thanks @<user>! This widens the public API surface. Could we discuss the design in an issue first before landing?
+```
+
+Rule violations — reference the rule by name, not by code example:
+
+```
+Thanks @<user>! This looks like it conflicts with the <rule name> rule. Could you take a look at the rule doc and adjust?
+```
+
+**Never** paste the offending code back at the contributor. **Never** paste
+a "suggested fix". Both read as condescending and push the contributor into
+a narrow compliance task rather than letting them own the solution.
+
+---
+
+## Template: conflicts
+
+Used when `mergeable == CONFLICTING`. This is Waiting, not Action — the
+comment just bounces the PR back to the author.
+
+Canonical:
+
+```
+Thanks @<user>! Could you rebase on main? Happy to re-review once it's clean.
+```
+
+Variants:
+
+- `Thanks @<user>! There are some conflicts with main now — could you resolve and push? I'll re-review right after.`
+- `Thanks @<user>! Looks like main has moved. Could you rebase when you get a chance?`
+
+Never explain how to rebase. Never link to a rebase tutorial. The
+contributor knows how their own git works.
+
+---
+
+## Non-templates: when NOT to post
+
+- **CI not passing**: do not comment. GitHub already notified the author.
+  A maintainer ping on top of the CI email is noise, not help.
+- **Awaiting author after a prior `request-changes`**: do not ping. The
+  ball is in their court; pinging is nagging.
+- **Cached PRs**: no new information, no comment.
+- **Draft PRs**: do not comment, do not classify.
+
+---
+
+## Anti-patterns (do not do these)
+
+- `Thank you so much for your contribution to our project! We really appreciate ...`
+- `Hi @<user>, hope you are doing well! ...`
+- `This is a great PR, I have just a few small suggestions: [wall of text]`
+- Pasting a "suggested fix" code block.
+- Asking the contributor to "please update the PR description to follow our template" — it is fine to mention as FYI, never block.
+- Promising a specific review timeline.
+- Apologizing on behalf of the project for a contributor mistake.
+- Multiple separate comments stacked on the same PR in one sweep —
+  consolidate into one.
+- Explaining obvious workflow steps (rebase, sign-off, squash) that any
+  active contributor already knows.

--- a/.claude/skills/pr-merge-runner/SKILL.md
+++ b/.claude/skills/pr-merge-runner/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: pr-merge-runner
+description: >
+  Auto-merge PRs after pr-cleaner-master. Processes only open PRs whose last
+  pr-cleaner verdict is merge, oldest first: post Thanks + /lgtm + /approve,
+  wait for ci-bot squash merge, git pull origin main, skip on any blocker.
+  Never rebase, retest, or fix CI. Always skip workflow-file PRs.
+  Use when: "merge safe PRs", "auto merge", "ship merge rows",
+  "pr-merge-runner", "/pr-merge-runner", after pr-cleaner when user wants
+  hands-off landing. Chains after pr-cleaner-master; does not replace review.
+argument-hint: "[#PR|PR...] [--repo owner/repo] [--dry-run] [--fresh]"
+---
+
+# PR Merge Runner
+
+Companion to `pr-cleaner-master`. That skill classifies; this skill **lands**
+only rows already marked `merge`. The user invoking this skill is the
+confirmation gate — no second approval step.
+
+This skill does **not** run deep review (use `pr-cleaner-master` or `pr-eval`).
+It does **not** fix code, rebase branches, retest CI, or call `gh pr merge`.
+
+Use the loaded skill base directory as `SKILL_DIR`.
+
+## Argument Parsing
+
+| Input | Behavior |
+|---|---|
+| no args | merge all eligible PRs from snapshot (`--from-snapshot`, default on) |
+| `517 521` | only those PR numbers |
+| `#517 #521` | same |
+| `--repo owner/repo` | target repo instead of current git directory |
+| `--dry-run` | preflight + plan only; no comments, no pull |
+| `--fresh` | ignore snapshot verdict filter; preflight all open PRs instead |
+| `--from-snapshot` | default **on**; only PRs with snapshot `verdict == "merge"` |
+
+Resolve target repo:
+
+1. If `--repo` given → use it.
+2. Else → `gh repo view --json nameWithOwner --jq .nameWithOwner`.
+3. If neither works → error: "Not in a GitHub repo. Pass --repo owner/repo."
+
+## Phase 0: Load Snapshot  ⛔ BLOCKING
+
+Same path as `pr-cleaner-master`:
+
+`~/.claude/projects/<project-dir-slug>/pr-cleaner-state.json`
+
+- `<project-dir-slug>` matches the memory-system slug for the current project root.
+- If missing or repo mismatch → treat as `{}`.
+- With default `--from-snapshot`: candidate PR numbers are keys in `snapshot.prs`
+  where `verdict == "merge"`. Still must pass live preflight (PR may have
+  closed, CI may have regressed).
+- With `--fresh`: candidate set = all open non-draft PRs from batch fetch.
+
+If `--from-snapshot` yields zero candidates → print
+`No merge-verdict PRs in snapshot. Run pr-cleaner-master first.` and exit.
+
+## Phase 1: Batch Fetch  ⛔ BLOCKING
+
+Fetch metadata for every candidate (and all open PRs when `--fresh`):
+
+```bash
+gh pr view <number> --repo <repo> --json \
+  number,title,author,createdAt,headRefOid,mergeable,mergeStateStatus,\
+state,isDraft,reviewDecision,labels,updatedAt,additions,deletions,changedFiles,\
+statusCheckRollup,comments
+```
+
+Or list all open when building `--fresh` set:
+
+```bash
+gh pr list --repo <repo> --state open --limit 100 --json \
+  number,title,author,createdAt,headRefOid,mergeable,mergeStateStatus,\
+state,isDraft,reviewDecision,labels,updatedAt,additions,deletions,changedFiles,\
+statusCheckRollup,comments
+```
+
+Sort candidates by `createdAt` ascending (oldest first).
+
+## Phase 2: Preflight  ⛔ BLOCKING
+
+For each candidate, **first failing rule → skip** (record reason, continue).
+Do **not** attempt any fix.
+
+| # | Condition | Skip reason |
+|---|---|---|
+| 1 | `state != "OPEN"` or `isDraft` | `not-open` |
+| 2 | `--from-snapshot` and snapshot verdict ≠ `merge` | `not-merge-verdict` |
+| 3 | `mergeable == "CONFLICTING"` | `conflicts` |
+| 4 | `mergeStateStatus == "BLOCKED"` | `blocked` |
+| 5 | `statusCheckRollup` has `PENDING` / `FAILURE` / `CANCELLED` / `ERROR` | `ci-fail` |
+| 6 | diff touches `.github/workflows/**` (see below) | `workflow-permission` |
+| — | all pass | → Phase 3 |
+
+### Workflow-file gate (always skip)
+
+Bot merge fails when the PR updates workflow files without `workflows`
+permission (e.g. `.github/workflows/ci-bot.yml`). Detect before commenting:
+
+```bash
+gh pr diff <number> --repo <repo> --name-only | rg '^\.github/workflows/'
+```
+
+Any match → skip with `workflow-permission`. **Never** add a bypass flag.
+
+### Hard prohibitions
+
+- Never `gh pr update-branch`, rebase, merge main into PR, or `/rebase`.
+- Never `/retest`, fix CI, or push commits to the PR branch.
+- Never `gh pr merge`, `gh pr review --approve`, or close PRs.
+- Never post `/merge` as a fallback (comment body is fixed; see Phase 3).
+
+## Phase 3: Execute Merge Loop  ⚠️ REQUIRED
+
+Process preflight-pass PRs **one at a time** (oldest first). Parallel batching
+is forbidden unless the user explicitly says several named PRs may run together
+in the same turn — default remains serial.
+
+For each PR:
+
+### Step A — Comment (exact three lines)
+
+```bash
+gh pr comment <N> --repo <repo> --body "$(cat <<'EOF'
+Thanks @<author>!
+/lgtm
+/approve
+EOF
+)"
+```
+
+Replace `<author>` with `author.login`. No other text. No code blocks.
+
+Skip Step A in `--dry-run` (log the would-be body instead).
+
+### Step B — Wait for merge
+
+Poll every **10 seconds**, up to **36** attempts (~6 minutes):
+
+```bash
+gh pr view <N> --repo <repo> --json state,mergedAt --jq '.state'
+```
+
+- `MERGED` → Step C.
+- Still `OPEN` after 36 polls → skip `timeout`, next PR.
+- `CLOSED` without merge → skip `not-open`, next PR.
+
+Do not post again on timeout.
+
+### Step C — Sync local main
+
+```bash
+git pull origin main
+```
+
+Run from the current git workspace root. Skip in `--dry-run`.
+
+### Step D — Record
+
+Append to in-memory results: `{ number, title, author, mergedAt }`.
+
+Then continue to the next PR.
+
+## Phase 4: Report  ⚠️ REQUIRED
+
+```markdown
+## PR Merge Runner — <repo>  (<UTC timestamp>)
+
+### Merged (N)
+
+| PR | Author | Title |
+|---|---|---|
+| #517 | @alice | fix: … |
+
+### Skipped (M)
+
+| PR | Reason | Note |
+|---|---|---|
+| #520 | workflow-permission | touches .github/workflows/ |
+| #516 | ci-fail | gateway / e2e failed |
+
+Local main: `<git rev-parse --short HEAD>` (after last pull)
+Dry run: yes/no
+```
+
+Skip reason codes (use exactly):
+
+| Code | Meaning |
+|---|---|
+| `ci-fail` | CI red or pending |
+| `conflicts` | mergeable CONFLICTING |
+| `blocked` | mergeStateStatus BLOCKED |
+| `workflow-permission` | diff touches `.github/workflows/**` |
+| `timeout` | labels posted but not merged in 6 min |
+| `not-open` | closed, merged already, or draft |
+| `not-merge-verdict` | snapshot verdict ≠ merge |
+
+## Phase 5: Update Snapshot
+
+After the run, update `pr-cleaner-state.json` for every candidate seen:
+
+```json
+"123": {
+  "headSha": "...",
+  "comments": 4,
+  "verdict": "merge",
+  "mergeResult": "merged",
+  "skipReason": null,
+  "at": "2026-06-10T18:00:00Z"
+}
+```
+
+- `mergeResult`: `"merged"` | `"skipped"` | `"dry-run"`
+- `skipReason`: null when merged; otherwise the code above.
+
+Atomic write: `<path>.tmp` then rename. Same repo key as pr-cleaner.
+
+## Chaining With pr-cleaner-master
+
+Typical maintainer flow:
+
+1. `/pr-cleaner-master` — classify, user reviews Action table.
+2. `/pr-merge-runner` — land every snapshot `merge` row that still passes
+   preflight.
+
+`pr-cleaner-master` never merges; this skill never re-classifies.
+
+## Do Not
+
+- Never fix, rebase, retest, or manually merge.
+- Never merge PRs not marked `merge` in snapshot (unless `--fresh`).
+- Never merge PRs that touch `.github/workflows/**`.
+- Never paste code to contributors.
+- Never parallelize by default.
+- Never skip the final Merged/Skipped report.
+- Never claim CI is green without checking `statusCheckRollup`.


### PR DESCRIPTION
## Summary

Add maintainer agent skills for PR sweep classification and hands-off merge execution. `pr-cleaner-master` classifies open PRs; `pr-merge-runner` chains after it to land snapshot `merge` rows via ci-bot comments.

## Type of change

- [ ] `[Feat]` new feature
- [ ] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [x] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

Maintainers need a repeatable two-step flow: sweep/classify PRs, then auto-merge rows already marked safe without manual rebase or CI fixes. These skills encode the workflow we validated on this repo (Thanks + /lgtm + /approve, poll for bot merge, git pull, skip blockers).

## What changed?

- Added `.claude/skills/pr-cleaner-master/` with sweep rules, reply templates, and snapshot state
- Added `.claude/skills/pr-merge-runner/` to merge snapshot `merge` PRs oldest-first with strict skip rules (no rebase, no CI fixes, always skip workflow-file PRs)
- Linked pr-cleaner to pr-merge-runner in the cleaner skill body

## Architecture impact

- Owning layer: N/A (agent skill docs only)
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: no runtime code changes

## Linked issues

N/A - maintainer workflow tooling

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [x] Not run

Commands, screenshots, or notes:

```text
Docs-only skill markdown. No application code changed.
Pre-ship: docs-only pass, 0 MUST-FIX.
CJK gate: removed Chinese trigger phrases from pr-cleaner description to satisfy ship validation.
```

## Screenshots or recordings

N/A - no UI changes

## Release note

- [x] No user-facing change. Release note is `NONE`.
- [ ] User-facing change. Release note is included below.

```release-note
NONE
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses at least one approved prefix: `[Feat]`, `[Fix]`, `[UI]`, `[Docs]`, `[Refactor]`, `[Build]`, or `[Chore]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate

Made with [Cursor](https://cursor.com)