### PR TITLE
Fix desktop input, artifacts, and main agent session sync

### DIFF
--- a/packages/core/src/ports/gateway-transport.ts
+++ b/packages/core/src/ports/gateway-transport.ts
@@ -63,6 +63,12 @@ export interface SyncResult {
   error?: string;
 }
 
+export interface SessionSyncFilter {
+  gatewayId?: string;
+  agentId?: string;
+  workspace?: string;
+}
+
 export interface ChatAttachment {
   mimeType: string;
   fileName: string;
@@ -82,7 +88,7 @@ export interface GatewayTransportPort {
   patchSession: (gatewayId: string, sessionKey: string, patch: Record<string, unknown>) => Promise<IpcResult>;
   listSessionsBySpawner: (gatewayId: string, spawnedBy: string) => Promise<IpcResult>;
   gatewayStatus: () => Promise<GatewayStatusMap>;
-  syncSessions: () => Promise<SyncResult>;
+  syncSessions: (filter?: SessionSyncFilter) => Promise<SyncResult>;
   listGateways: () => Promise<GatewayListItem[]>;
   listModels: (gatewayId: string) => Promise<IpcResult>;
   listCommands: (gatewayId: string, params?: CommandsListParams) => Promise<IpcResult>;

--- a/packages/core/src/ports/persistence.ts
+++ b/packages/core/src/ports/persistence.ts
@@ -11,6 +11,7 @@ export interface PersistedTask {
   tags: string[];
   artifactDir: string;
   gatewayId: string;
+  agentId?: string | null;
   model?: string;
   modelProvider?: string;
   thinkingLevel?: string;
@@ -58,6 +59,7 @@ export interface PersistencePort {
     tags: string[];
     artifactDir: string;
     gatewayId: string;
+    agentId?: string | null;
   }) => Promise<IpcResult>;
   persistTaskUpdate: (params: {
     id: string;
@@ -69,6 +71,7 @@ export interface PersistencePort {
     inputTokens?: number;
     outputTokens?: number;
     contextTokens?: number;
+    agentId?: string | null;
     updatedAt: string;
   }) => Promise<IpcResult>;
   persistMessage: (msg: {

--- a/packages/core/src/protocol/normalize-history.ts
+++ b/packages/core/src/protocol/normalize-history.ts
@@ -16,7 +16,7 @@ export function isVisibleAssistantContent(content: string): boolean {
 }
 
 const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|avif)(?:[?#].*)?$/i;
-const DATA_IMAGE_RE = /^data:image\/(png|jpe?g|gif|webp|avif);base64,/i;
+const DATA_URL_RE = /^data:([^;]+);base64,/i;
 const GATEWAY_MEDIA_PATH_RE = /^\/(?:api\/chat\/media\/outgoing\/|media\/|__openclaw__\/media\/)/;
 
 function cleanMediaCandidate(raw: string): string {
@@ -126,18 +126,25 @@ function resolveGatewayMediaSource(candidate: string, httpBase?: string): string
 }
 
 function mimeTypeFromSource(source: string, fallback?: string): string | undefined {
-  if (fallback?.startsWith('image/')) return fallback;
+  if (fallback) return fallback;
   const lower = source.split(/[?#]/)[0]?.toLowerCase() ?? '';
   if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
   if (lower.endsWith('.png')) return 'image/png';
   if (lower.endsWith('.gif')) return 'image/gif';
   if (lower.endsWith('.webp')) return 'image/webp';
   if (lower.endsWith('.avif')) return 'image/avif';
-  const dataMatch = source.match(/^data:(image\/[^;]+);/i);
+  if (lower.endsWith('.pdf')) return 'application/pdf';
+  if (lower.endsWith('.md')) return 'text/markdown';
+  if (lower.endsWith('.txt')) return 'text/plain';
+  if (lower.endsWith('.json')) return 'application/json';
+  if (lower.endsWith('.csv')) return 'text/csv';
+  if (lower.endsWith('.html')) return 'text/html';
+  if (lower.endsWith('.zip')) return 'application/zip';
+  const dataMatch = source.match(/^data:([^;]+);/i);
   return dataMatch?.[1] ?? fallback;
 }
 
-function attachmentFromMediaSource(
+function attachmentFromSource(
   source: string,
   alt?: string,
   mimeType?: string,
@@ -147,27 +154,27 @@ function attachmentFromMediaSource(
   if (!candidate || candidate.length > 4096 || hasUnsafePathSegment(candidate) || candidate.startsWith('~'))
     return null;
 
-  if (DATA_IMAGE_RE.test(candidate)) {
+  if (DATA_URL_RE.test(candidate)) {
     return {
-      fileName: alt?.trim() || 'image.png',
+      fileName: alt?.trim() || fileNameFromSource(candidate, 'attachment'),
       dataUrl: candidate,
       mimeType: mimeTypeFromSource(candidate, mimeType),
     };
   }
 
   const gatewayMedia = resolveGatewayMediaSource(candidate, httpBase);
-  if (gatewayMedia && (IMAGE_EXT_RE.test(gatewayMedia) || mimeType?.startsWith('image/'))) {
+  if (gatewayMedia) {
     return {
-      fileName: alt?.trim() || fileNameFromSource(gatewayMedia, 'image.png'),
+      fileName: alt?.trim() || fileNameFromSource(gatewayMedia, 'attachment'),
       dataUrl: gatewayMedia,
       mimeType: mimeTypeFromSource(gatewayMedia, mimeType),
     };
   }
   if (candidate.startsWith('/') && GATEWAY_MEDIA_PATH_RE.test(candidate)) return null;
 
-  if (isAllowedRemoteMediaUrl(candidate) && (IMAGE_EXT_RE.test(candidate) || mimeType?.startsWith('image/'))) {
+  if (isAllowedRemoteMediaUrl(candidate)) {
     return {
-      fileName: alt?.trim() || fileNameFromSource(candidate, 'image.png'),
+      fileName: alt?.trim() || fileNameFromSource(candidate, 'attachment'),
       dataUrl: candidate,
       mimeType: mimeTypeFromSource(candidate, mimeType),
     };
@@ -175,9 +182,9 @@ function attachmentFromMediaSource(
 
   const filePath = filePathFromMediaCandidate(candidate);
   if (!filePath) return null;
-  if (filePath.startsWith('/') && IMAGE_EXT_RE.test(filePath)) {
+  if (filePath.startsWith('/')) {
     return {
-      fileName: alt?.trim() || fileNameFromSource(filePath, 'image.png'),
+      fileName: alt?.trim() || fileNameFromSource(filePath, 'attachment'),
       dataUrl: encodeFilePath(filePath),
       mimeType: mimeTypeFromSource(filePath, mimeType),
       sourcePath: filePath,
@@ -201,7 +208,7 @@ function splitTextMediaDirectives(text: string, httpBase?: string): { text: stri
     }
 
     if (!inFence && trimmed.toUpperCase().startsWith('MEDIA:')) {
-      const media = attachmentFromMediaSource(trimmed.slice('MEDIA:'.length), undefined, undefined, httpBase);
+      const media = attachmentFromSource(trimmed.slice('MEDIA:'.length), undefined, undefined, httpBase);
       if (media) {
         attachments.push(media);
         continue;
@@ -224,13 +231,33 @@ export function mergeMessageAttachments(
   incoming: MessageAttachment[] | undefined,
 ): MessageAttachment[] | undefined {
   const merged = [...(base ?? [])];
-  const seen = new Set(merged.map((attachment) => attachment.dataUrl));
+  const seen = new Set(merged.map((attachment) => attachment.sourcePath ?? attachment.dataUrl));
   for (const attachment of incoming ?? []) {
-    if (seen.has(attachment.dataUrl)) continue;
-    seen.add(attachment.dataUrl);
+    const key = attachment.sourcePath ?? attachment.dataUrl;
+    if (seen.has(key)) continue;
+    seen.add(key);
     merged.push(attachment);
   }
   return merged.length ? merged : undefined;
+}
+
+function attachmentFromFileBlock(block: RawContentBlock, httpBase?: string): MessageAttachment | null {
+  const fileName = block.fileName ?? block.name ?? block.alt;
+  if (block.dataUrl) return attachmentFromSource(block.dataUrl, fileName, block.mimeType, httpBase);
+  if (block.base64) {
+    const mimeType = block.mimeType ?? 'application/octet-stream';
+    return {
+      fileName: fileName?.trim() || 'attachment',
+      dataUrl: `data:${mimeType};base64,${block.base64}`,
+      mimeType,
+      size: block.size,
+    };
+  }
+  const source = block.url ?? block.openUrl ?? block.sourcePath ?? block.filePath ?? block.path;
+  if (!source) return null;
+  const attachment = attachmentFromSource(source, fileName, block.mimeType, httpBase);
+  if (!attachment) return null;
+  return { ...attachment, size: block.size ?? attachment.size };
 }
 
 export function normalizeContentBlocks(
@@ -254,9 +281,14 @@ export function normalizeContentBlocks(
     if (block.type === 'image') {
       const rawSource = block.url ?? block.openUrl;
       if (rawSource) {
-        const attachment = attachmentFromMediaSource(rawSource, block.alt, block.mimeType, httpBase);
+        const attachment = attachmentFromSource(rawSource, block.alt, block.mimeType, httpBase);
         attachments = mergeMessageAttachments(attachments, attachment ? [attachment] : undefined);
       }
+    }
+
+    if (block.type === 'file' || block.type === 'attachment') {
+      const attachment = attachmentFromFileBlock(block, httpBase);
+      attachments = mergeMessageAttachments(attachments, attachment ? [attachment] : undefined);
     }
   }
 

--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -25,6 +25,14 @@ export interface RawContentBlock {
   openUrl?: string;
   alt?: string;
   mimeType?: string;
+  dataUrl?: string;
+  sourcePath?: string;
+  path?: string;
+  filePath?: string;
+  fileName?: string;
+  size?: number;
+  base64?: string;
+  content?: string;
   id?: string;
   name?: string;
   arguments?: Record<string, unknown> | string;

--- a/packages/core/src/services/gateway-dispatcher.ts
+++ b/packages/core/src/services/gateway-dispatcher.ts
@@ -220,7 +220,9 @@ export function createGatewayDispatcher(deps: GatewayDispatcherDeps) {
     const direct = parseTaskIdFromSessionKey(sessionKey);
     if (direct) return direct;
     const mapped = deps.lookupTaskIdBySubagentKey?.(sessionKey);
-    return mapped ?? null;
+    if (mapped) return mapped;
+    const matched = deps.getTaskStore().tasks.find((task) => task.sessionKey === sessionKey);
+    return matched?.id ?? null;
   }
 
   function resolveTaskIdFromSpawnedBy(spawnedBy?: string): string | null {

--- a/packages/core/src/services/session-sync.ts
+++ b/packages/core/src/services/session-sync.ts
@@ -2,6 +2,7 @@ import { parseAgentIdFromSessionKey, parseTaskIdFromSessionKey } from '@clawwork
 import type { Message, MessageRole, ToolCall, IpcResult } from '@clawwork/shared';
 import type { RawHistoryMessage } from '../protocol/types.js';
 import type { ActiveTurn, MessageState } from '../stores/message-store.js';
+import type { SessionSyncFilter } from '../ports/gateway-transport.js';
 import { mergeCanonicalMessageWithActiveTurn } from '../stores/message-store.js';
 import {
   sanitizeModel,
@@ -52,7 +53,7 @@ export interface SessionSyncDeps {
   gateway: {
     getHttpBase?: (gatewayId: string) => string | undefined | Promise<string | undefined>;
     chatHistory: (gatewayId: string, sessionKey: string, limit?: number) => Promise<IpcResult>;
-    syncSessions: () => Promise<{
+    syncSessions: (filter?: SessionSyncFilter) => Promise<{
       ok: boolean;
       discovered?: {
         gatewayId: string;
@@ -360,10 +361,10 @@ export function createSessionSync(deps: SessionSyncDeps) {
     }
   }
 
-  async function syncFromGateway(): Promise<void> {
+  async function syncFromGateway(filter?: SessionSyncFilter): Promise<void> {
     try {
       await hydrateFromLocal();
-      const res = await deps.gateway.syncSessions();
+      const res = await deps.gateway.syncSessions(filter);
       if (!res.ok || !res.discovered) return;
       const taskStore = deps.getTaskStore();
       const messageStore = deps.getMessageStore();

--- a/packages/core/src/services/session-sync.ts
+++ b/packages/core/src/services/session-sync.ts
@@ -100,6 +100,7 @@ export interface SessionSyncDeps {
         inputTokens?: number;
         outputTokens?: number;
         contextTokens?: number;
+        agentId?: string;
       },
     ) => void;
   };
@@ -400,6 +401,7 @@ export function createSessionSync(deps: SessionSyncDeps) {
         );
 
         taskStore.updateTaskMetadata(d.taskId, {
+          agentId: d.agentId,
           model: d.model,
           modelProvider: d.modelProvider,
           thinkingLevel: d.thinkingLevel,

--- a/packages/core/src/stores/task-store.ts
+++ b/packages/core/src/stores/task-store.ts
@@ -1,5 +1,5 @@
 import { createStore } from 'zustand/vanilla';
-import { buildSessionKey } from '@clawwork/shared';
+import { buildSessionKey, parseAgentIdFromSessionKey } from '@clawwork/shared';
 import type { Task, TaskStatus, IpcResult } from '@clawwork/shared';
 
 export interface PendingNewTask {
@@ -278,6 +278,7 @@ export function createTaskStore(deps: TaskStoreDeps) {
               tags: r.tags,
               artifactDir: r.artifactDir,
               gatewayId: r.gatewayId,
+              agentId: parseAgentIdFromSessionKey(r.sessionKey),
             })),
             hydrated: true,
           });

--- a/packages/core/src/stores/task-store.ts
+++ b/packages/core/src/stores/task-store.ts
@@ -37,6 +37,7 @@ export interface TaskState {
       outputTokens?: number;
       contextTokens?: number;
       teamId?: string | null;
+      agentId?: string;
       updatedAt?: string;
     },
   ) => void;
@@ -74,6 +75,7 @@ export interface TaskStoreDeps {
     outputTokens?: number;
     contextTokens?: number;
     teamId?: string | null;
+    agentId?: string | null;
     updatedAt: string;
   }) => Promise<IpcResult>;
   deleteTask: (taskId: string) => Promise<IpcResult>;
@@ -98,6 +100,7 @@ export interface TaskStoreDeps {
       tags: string[];
       artifactDir: string;
       gatewayId: string;
+      agentId?: string | null;
     }[];
   }>;
   patchSession: (gatewayId: string, sessionKey: string, patch: Record<string, unknown>) => Promise<IpcResult>;
@@ -232,6 +235,7 @@ export function createTaskStore(deps: TaskStoreDeps) {
           outputTokens: meta.outputTokens,
           contextTokens: meta.contextTokens,
           teamId: meta.teamId,
+          agentId: meta.agentId,
           updatedAt,
         })
         .catch((err) => {
@@ -278,7 +282,7 @@ export function createTaskStore(deps: TaskStoreDeps) {
               tags: r.tags,
               artifactDir: r.artifactDir,
               gatewayId: r.gatewayId,
-              agentId: parseAgentIdFromSessionKey(r.sessionKey),
+              agentId: r.agentId ?? parseAgentIdFromSessionKey(r.sessionKey),
             })),
             hydrated: true,
           });
@@ -290,10 +294,19 @@ export function createTaskStore(deps: TaskStoreDeps) {
 
     adoptTasks: (discovered) => {
       const toPersist: Task[] = [];
+      const toUpdate: Array<{ id: string; agentId: string; updatedAt: string }> = [];
       set((s) => {
         const existing = new Set(s.tasks.map((t) => t.id));
+        const existingById = new Map(s.tasks.map((t) => [t.id, t]));
         const newTasks: Task[] = [];
         for (const d of discovered) {
+          const existingTask = existingById.get(d.taskId);
+          if (existingTask) {
+            if (d.agentId && existingTask.agentId !== d.agentId) {
+              toUpdate.push({ id: d.taskId, agentId: d.agentId, updatedAt: d.updatedAt });
+            }
+            continue;
+          }
           if (existing.has(d.taskId)) continue;
           const task: Task = {
             id: d.taskId,
@@ -316,12 +329,25 @@ export function createTaskStore(deps: TaskStoreDeps) {
           };
           newTasks.push(task);
         }
-        if (newTasks.length === 0) return s;
+        if (newTasks.length === 0 && toUpdate.length === 0) return s;
         toPersist.push(...newTasks);
-        return { tasks: [...newTasks, ...s.tasks] };
+        return {
+          tasks: [
+            ...newTasks,
+            ...s.tasks.map((task) => {
+              const update = toUpdate.find((item) => item.id === task.id);
+              return update ? { ...task, agentId: update.agentId } : task;
+            }),
+          ],
+        };
       });
       for (const task of toPersist) {
         deps.persistTask(task).catch((err) => {
+          console.error('[persist:task]', err);
+        });
+      }
+      for (const update of toUpdate) {
+        deps.persistTaskUpdate(update).catch((err) => {
           console.error('[persist:task]', err);
         });
       }

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -287,7 +287,7 @@ export function createUiStore(deps: UiStoreDeps) {
       const selected = state.selectedMainAgentByGateway[gatewayId];
       const catalog = state.agentCatalogByGateway[gatewayId];
       if (selected && catalog?.agents.some((agent) => agent.id === selected)) return selected;
-      return catalog?.defaultId ?? catalog?.agents[0]?.id ?? null;
+      return null;
     },
 
     toolsCatalogByGateway: {},

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -80,6 +80,10 @@ export interface UiState {
   agentCatalogByGateway: Record<string, { agents: AgentInfo[]; defaultId: string }>;
   setAgentCatalogForGateway: (gatewayId: string, agents: AgentInfo[], defaultId: string) => void;
 
+  selectedMainAgentByGateway: Record<string, string>;
+  setSelectedMainAgentForGateway: (gatewayId: string, agentId: string | null) => void;
+  getSelectedMainAgentId: (gatewayId: string) => string | null;
+
   toolsCatalogByGateway: Record<string, ToolsCatalog>;
   setToolsCatalogForGateway: (gatewayId: string, catalog: ToolsCatalog) => void;
 
@@ -259,6 +263,32 @@ export function createUiStore(deps: UiStoreDeps) {
           [gatewayId]: { agents, defaultId },
         },
       })),
+
+    selectedMainAgentByGateway: (() => {
+      const raw = deps.storage.get('cw:selectedMainAgentByGateway');
+      if (!raw) return {};
+      try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
+      } catch {
+        return {};
+      }
+    })(),
+    setSelectedMainAgentForGateway: (gatewayId, agentId) =>
+      set((s) => {
+        const next = { ...s.selectedMainAgentByGateway };
+        if (agentId) next[gatewayId] = agentId;
+        else delete next[gatewayId];
+        deps.storage.set('cw:selectedMainAgentByGateway', JSON.stringify(next));
+        return { selectedMainAgentByGateway: next };
+      }),
+    getSelectedMainAgentId: (gatewayId) => {
+      const state = get();
+      const selected = state.selectedMainAgentByGateway[gatewayId];
+      const catalog = state.agentCatalogByGateway[gatewayId];
+      if (selected && catalog?.agents.some((agent) => agent.id === selected)) return selected;
+      return catalog?.defaultId ?? catalog?.agents[0]?.id ?? null;
+    },
 
     toolsCatalogByGateway: {},
     setToolsCatalogForGateway: (gatewayId, catalog) =>

--- a/packages/desktop/src/main/artifact/auto-extract.ts
+++ b/packages/desktop/src/main/artifact/auto-extract.ts
@@ -20,7 +20,7 @@ interface AutoExtractParams {
   gatewayHttpBase?: string;
 }
 
-const DATA_IMAGE_RE = /^data:(image\/(?:png|jpe?g|gif|webp|avif));base64,(.+)$/i;
+const DATA_URL_RE = /^data:([^;]+);base64,(.+)$/i;
 const extractionByMessage = new Map<string, Promise<void>>();
 
 type ExistingArtifact = Pick<Artifact, 'name' | 'type' | 'size' | 'contentText' | 'sourceKey'>;
@@ -44,6 +44,13 @@ function isUniqueArtifactError(err: unknown): boolean {
 }
 
 function extFromMime(mimeType: string | undefined): string {
+  if (mimeType === 'application/pdf') return 'pdf';
+  if (mimeType === 'application/json') return 'json';
+  if (mimeType === 'application/zip') return 'zip';
+  if (mimeType === 'text/csv') return 'csv';
+  if (mimeType === 'text/html') return 'html';
+  if (mimeType === 'text/markdown') return 'md';
+  if (mimeType?.startsWith('text/')) return 'txt';
   if (mimeType === 'image/jpeg') return 'jpg';
   if (mimeType === 'image/gif') return 'gif';
   if (mimeType === 'image/webp') return 'webp';
@@ -59,13 +66,19 @@ function safeImageFileName(fileName: string | undefined, mimeType: string | unde
   return `${clean || 'image'}.${ext}`;
 }
 
-async function readAttachmentImage(attachment: MessageAttachment, trustedOrigin?: string): Promise<Buffer | null> {
+function safeAttachmentFileName(fileName: string | undefined, mimeType: string | undefined): string {
+  const raw = fileName?.trim() || `attachment.${extFromMime(mimeType)}`;
+  const clean = raw.replace(/[/\\]/g, '_').replace(/[^a-zA-Z0-9._-]/g, '_');
+  return clean || `attachment.${extFromMime(mimeType)}`;
+}
+
+async function readAttachmentBuffer(attachment: MessageAttachment, trustedOrigin?: string): Promise<Buffer | null> {
   if (attachment.sourcePath) {
     const base64 = await readOpenClawMediaFile(attachment.sourcePath);
     return base64 ? Buffer.from(base64, 'base64') : null;
   }
 
-  const dataMatch = attachment.dataUrl.match(DATA_IMAGE_RE);
+  const dataMatch = attachment.dataUrl.match(DATA_URL_RE);
   if (dataMatch) return Buffer.from(dataMatch[2], 'base64');
 
   if (/^https?:\/\//i.test(attachment.dataUrl)) {
@@ -73,6 +86,38 @@ async function readAttachmentImage(attachment: MessageAttachment, trustedOrigin?
   }
 
   return null;
+}
+
+export async function saveAttachmentArtifact(params: {
+  workspacePath: string;
+  taskId: string;
+  messageId: string;
+  attachment: MessageAttachment;
+  gatewayHttpBase?: string;
+}): Promise<Artifact | null> {
+  const key = sourceKey('attachment', params.attachment.sourcePath ?? params.attachment.dataUrl);
+  const existing = getDb()
+    .select()
+    .from(artifacts)
+    .where(eq(artifacts.messageId, params.messageId))
+    .all()
+    .find((artifact) => artifact.sourceKey === key) as Artifact | undefined;
+  if (existing) return existing;
+
+  const buffer = await readAttachmentBuffer(params.attachment, params.gatewayHttpBase);
+  if (!buffer) return null;
+  const isImage = params.attachment.mimeType?.startsWith('image/') ?? false;
+  return saveArtifactFromBuffer({
+    workspacePath: params.workspacePath,
+    taskId: params.taskId,
+    messageId: params.messageId,
+    fileName: isImage
+      ? safeImageFileName(params.attachment.fileName, params.attachment.mimeType)
+      : safeAttachmentFileName(params.attachment.fileName, params.attachment.mimeType),
+    buffer,
+    artifactType: isImage ? 'image' : 'file',
+    sourceKey: key,
+  });
 }
 
 async function doAutoExtractArtifacts(params: AutoExtractParams): Promise<void> {
@@ -91,7 +136,7 @@ async function doAutoExtractArtifacts(params: AutoExtractParams): Promise<void> 
   async function saveExtracted(input: {
     fileName: string;
     buffer: Buffer;
-    artifactType: 'image' | 'code';
+    artifactType: 'image' | 'code' | 'file';
     sourceKey: string;
     contentText?: string;
   }): Promise<void> {
@@ -169,20 +214,20 @@ async function doAutoExtractArtifacts(params: AutoExtractParams): Promise<void> 
   for (const attachment of attachments) {
     try {
       if (!attachment.dataUrl && !attachment.sourcePath) continue;
-      if (attachment.mimeType && !attachment.mimeType.startsWith('image/')) continue;
       const key = sourceKey('attachment', attachment.sourcePath ?? attachment.dataUrl);
       if (existingSourceKeys.has(key)) continue;
-      const buffer = await readAttachmentImage(attachment, gatewayHttpBase);
-      if (!buffer) continue;
-      const fileName = safeImageFileName(attachment.fileName, attachment.mimeType);
-      await saveExtracted({
-        fileName,
-        buffer,
-        artifactType: 'image',
-        sourceKey: key,
-      });
+      const artifact = await saveAttachmentArtifact({ workspacePath, taskId, messageId, attachment, gatewayHttpBase });
+      if (artifact) {
+        existingSourceKeys.add(key);
+        existing.push(artifact);
+        saved.push(artifact);
+      }
     } catch (err) {
-      console.error('[auto-extract] attachment image save failed:', err);
+      if (isUniqueArtifactError(err)) {
+        existingSourceKeys.add(sourceKey('attachment', attachment.sourcePath ?? attachment.dataUrl));
+        continue;
+      }
+      console.error('[auto-extract] attachment save failed:', err);
     }
   }
 

--- a/packages/desktop/src/main/db/index.ts
+++ b/packages/desktop/src/main/db/index.ts
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   updated_at TEXT NOT NULL,
   tags TEXT NOT NULL DEFAULT '[]',
   artifact_dir TEXT NOT NULL DEFAULT '',
-  gateway_id TEXT NOT NULL DEFAULT ''
+  gateway_id TEXT NOT NULL DEFAULT '',
+  agent_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS messages (
@@ -81,6 +82,7 @@ function openDatabaseAt(workspacePath: string): void {
   sqlite.exec(CREATE_TABLES_SQL);
 
   migrateAddColumn(sqlite, "ALTER TABLE tasks ADD COLUMN gateway_id TEXT NOT NULL DEFAULT ''");
+  migrateAddColumn(sqlite, 'ALTER TABLE tasks ADD COLUMN agent_id TEXT');
 
   for (const sql of [
     'ALTER TABLE tasks ADD COLUMN model TEXT',

--- a/packages/desktop/src/main/db/schema.ts
+++ b/packages/desktop/src/main/db/schema.ts
@@ -19,6 +19,7 @@ export const tasks = sqliteTable('tasks', {
   tags: text('tags').notNull().default('[]'),
   artifactDir: text('artifact_dir').notNull().default(''),
   gatewayId: text('gateway_id').notNull().default(''),
+  agentId: text('agent_id'),
 });
 
 export const messages = sqliteTable('messages', {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -155,6 +155,22 @@ function createWindow(): BrowserWindow {
     if (isReload) event.preventDefault();
   });
 
+  win.webContents.on('context-menu', (_event, params) => {
+    if (!params.isEditable) return;
+    const template: Electron.MenuItemConstructorOptions[] = [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut', enabled: params.editFlags.canCut },
+      { role: 'copy', enabled: params.editFlags.canCopy },
+      { role: 'paste', enabled: params.editFlags.canPaste },
+      { role: 'delete', enabled: params.editFlags.canDelete },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: params.editFlags.canSelectAll },
+    ];
+    Menu.buildFromTemplate(template).popup({ window: win });
+  });
+
   win.on('blur', () => {
     if (win.isDestroyed()) return;
     const level = win.webContents.getZoomLevel();

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -156,18 +156,22 @@ function createWindow(): BrowserWindow {
   });
 
   win.webContents.on('context-menu', (_event, params) => {
-    if (!params.isEditable) return;
-    const template: Electron.MenuItemConstructorOptions[] = [
-      { role: 'undo', label: '撤销' },
-      { role: 'redo', label: '重做' },
-      { type: 'separator' },
-      { role: 'cut', label: '剪切', enabled: params.editFlags.canCut },
-      { role: 'copy', label: '复制', enabled: params.editFlags.canCopy },
-      { role: 'paste', label: '粘贴', enabled: params.editFlags.canPaste },
-      { role: 'delete', label: '删除', enabled: params.editFlags.canDelete },
-      { type: 'separator' },
-      { role: 'selectAll', label: '全选', enabled: params.editFlags.canSelectAll },
-    ];
+    const template: Electron.MenuItemConstructorOptions[] = params.isEditable
+      ? [
+          { role: 'undo', label: '撤销' },
+          { role: 'redo', label: '重做' },
+          { type: 'separator' },
+          { role: 'cut', label: '剪切', enabled: params.editFlags.canCut },
+          { role: 'copy', label: '复制', enabled: params.editFlags.canCopy },
+          { role: 'paste', label: '粘贴', enabled: params.editFlags.canPaste },
+          { role: 'delete', label: '删除', enabled: params.editFlags.canDelete },
+          { type: 'separator' },
+          { role: 'selectAll', label: '全选', enabled: params.editFlags.canSelectAll },
+        ]
+      : params.selectionText.trim()
+        ? [{ role: 'copy', label: '复制', enabled: params.editFlags.canCopy }]
+        : [];
+    if (template.length === 0) return;
     Menu.buildFromTemplate(template).popup({ window: win });
   });
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -158,15 +158,15 @@ function createWindow(): BrowserWindow {
   win.webContents.on('context-menu', (_event, params) => {
     if (!params.isEditable) return;
     const template: Electron.MenuItemConstructorOptions[] = [
-      { role: 'undo' },
-      { role: 'redo' },
+      { role: 'undo', label: '撤销' },
+      { role: 'redo', label: '重做' },
       { type: 'separator' },
-      { role: 'cut', enabled: params.editFlags.canCut },
-      { role: 'copy', enabled: params.editFlags.canCopy },
-      { role: 'paste', enabled: params.editFlags.canPaste },
-      { role: 'delete', enabled: params.editFlags.canDelete },
+      { role: 'cut', label: '剪切', enabled: params.editFlags.canCut },
+      { role: 'copy', label: '复制', enabled: params.editFlags.canCopy },
+      { role: 'paste', label: '粘贴', enabled: params.editFlags.canPaste },
+      { role: 'delete', label: '删除', enabled: params.editFlags.canDelete },
       { type: 'separator' },
-      { role: 'selectAll', enabled: params.editFlags.canSelectAll },
+      { role: 'selectAll', label: '全选', enabled: params.editFlags.canSelectAll },
     ];
     Menu.buildFromTemplate(template).popup({ window: win });
   });

--- a/packages/desktop/src/main/ipc/artifact-handlers.ts
+++ b/packages/desktop/src/main/ipc/artifact-handlers.ts
@@ -8,9 +8,12 @@ import { eq } from 'drizzle-orm';
 import { getDb, getSqlite } from '../db/index.js';
 import { artifacts, tasks, messages } from '../db/schema.js';
 import { saveArtifact, saveArtifactFromBuffer } from '../artifact/save.js';
+import { saveAttachmentArtifact } from '../artifact/auto-extract.js';
 import { getWorkspacePath } from '../workspace/config.js';
 import { searchArtifacts } from '../db/search.js';
 import { safeFetch } from '../net/safe-fetch.js';
+import { getGatewayClient } from '../ws/index.js';
+import type { MessageAttachment } from '@clawwork/shared';
 
 interface SaveParams {
   taskId: string;
@@ -89,6 +92,39 @@ export function registerArtifactHandlers(): void {
       return { ok: false, error: msg };
     }
   });
+
+  ipcMain.handle(
+    'artifact:save-attachment',
+    async (
+      _event,
+      params: {
+        taskId: string;
+        messageId: string;
+        attachment: MessageAttachment;
+      },
+    ) => {
+      const workspacePath = getWorkspacePath();
+      if (!workspacePath) return { ok: false, error: 'workspace not configured' };
+      try {
+        const db = getDb();
+        const task = db.select({ gatewayId: tasks.gatewayId }).from(tasks).where(eq(tasks.id, params.taskId)).get();
+        const gatewayHttpBase = task ? getGatewayClient(task.gatewayId)?.httpBase : undefined;
+        const artifact = await saveAttachmentArtifact({
+          workspacePath,
+          taskId: params.taskId,
+          messageId: params.messageId,
+          attachment: params.attachment,
+          gatewayHttpBase,
+        });
+        if (!artifact) return { ok: false, error: 'attachment unavailable' };
+        const win = BrowserWindow.getAllWindows()[0];
+        if (win) win.webContents.send('artifact:saved', artifact);
+        return { ok: true, result: artifact };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };
+      }
+    },
+  );
 
   ipcMain.handle('artifact:read-file', async (_event, params: { localPath: string }) => {
     const workspacePath = getWorkspacePath();

--- a/packages/desktop/src/main/ipc/data-handlers.ts
+++ b/packages/desktop/src/main/ipc/data-handlers.ts
@@ -47,6 +47,7 @@ export function registerDataHandlers(): void {
         tags: string[];
         artifactDir: string;
         gatewayId: string;
+        agentId?: string;
       },
     ) => {
       if (!isDbReady()) return ipcError(new Error('database not ready'));
@@ -72,6 +73,7 @@ export function registerDataHandlers(): void {
             tags: JSON.stringify(task.tags),
             artifactDir: task.artifactDir,
             gatewayId: task.gatewayId,
+            agentId: task.agentId ?? null,
           })
           .run();
         return { ok: true };
@@ -98,6 +100,7 @@ export function registerDataHandlers(): void {
         outputTokens?: number;
         contextTokens?: number;
         teamId?: string | null;
+        agentId?: string | null;
         updatedAt: string;
       },
     ) => {
@@ -115,6 +118,7 @@ export function registerDataHandlers(): void {
         if (params.outputTokens !== undefined) updates.outputTokens = params.outputTokens;
         if (params.contextTokens !== undefined) updates.contextTokens = params.contextTokens;
         if (params.teamId !== undefined) updates.teamId = params.teamId;
+        if (params.agentId !== undefined) updates.agentId = params.agentId;
         db.update(tasks).set(updates).where(eq(tasks.id, params.id)).run();
         return { ok: true };
       } catch (err) {

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -310,6 +310,10 @@ function sessionTitle(session: GatewaySessionRow, titleFromMsg: string): string 
   return session.derivedTitle ?? session.label ?? session.title ?? session.displayName ?? session.name ?? titleFromMsg;
 }
 
+function isCronSessionTitle(title: string | undefined): boolean {
+  return /^\s*cron\s*[:：]/i.test(title ?? '');
+}
+
 interface SyncSessionFilter {
   gatewayId?: string;
   agentId?: string;
@@ -564,8 +568,20 @@ export function registerWsHandlers(): void {
           const taskId = nativeTaskIdForSessionKey(s.key);
           if (!taskId) continue;
 
-          const historyRaw = (await gw.getChatHistory(s.key, 200)) as unknown as ChatHistoryPayload;
-          const rawMsgs = historyRaw.messages ?? [];
+          let rawMsgs: ChatHistoryMessage[] = [];
+          try {
+            const historyRaw = (await gw.getChatHistory(s.key, 200)) as unknown as ChatHistoryPayload;
+            rawMsgs = Array.isArray(historyRaw.messages) ? historyRaw.messages : [];
+          } catch (err) {
+            getDebugLogger().warn({
+              domain: 'ipc',
+              event: 'ipc.ws.sync-sessions.history-failed',
+              gatewayId,
+              sessionKey: s.key,
+              data: { agentId: filter?.agentId },
+              error: { message: err instanceof Error ? err.message : 'unknown error' },
+            });
+          }
 
           const toolResultMap = new Map<string, string>();
           for (const m of rawMsgs) {
@@ -633,12 +649,14 @@ export function registerWsHandlers(): void {
 
           const firstUserMsg = msgs.find((m) => m.role === 'user' && m.content);
           const titleFromMsg = firstUserMsg ? firstUserMsg.content.slice(0, 30) : '';
+          const title = sessionTitle(s, titleFromMsg);
+          if (isCronSessionTitle(title)) continue;
 
           discovered.push({
             gatewayId,
             taskId,
             sessionKey: s.key,
-            title: sessionTitle(s, titleFromMsg),
+            title,
             updatedAt: toIsoTimestamp(s.updatedAt),
             agentId: sessionAgentId(s, filter?.agentId),
             model: s.model,

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -53,8 +53,17 @@ async function gatewayRpc(
 interface GatewaySessionRow {
   key: string;
   agentId?: string;
+  agent?: {
+    id?: string;
+    workspace?: string;
+  };
   sessionId?: string;
   workspace?: string;
+  workspacePath?: string;
+  cwd?: string;
+  workingDir?: string;
+  workingDirectory?: string;
+  spawnedBy?: string;
   updatedAt: number | null;
   derivedTitle?: string;
   label?: string;
@@ -106,8 +115,23 @@ function nativeTaskIdForSessionKey(sessionKey: string): string {
   return `native-${createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)}`;
 }
 
-function sessionAgentId(session: GatewaySessionRow): string {
-  return session.agentId || parseAgentIdFromSessionKey(session.key);
+function explicitSessionAgentId(session: GatewaySessionRow): string | undefined {
+  return session.agentId || session.agent?.id;
+}
+
+function sessionAgentId(session: GatewaySessionRow, fallbackAgentId?: string): string {
+  return explicitSessionAgentId(session) || fallbackAgentId || parseAgentIdFromSessionKey(session.key);
+}
+
+function sessionWorkspace(session: GatewaySessionRow): string | undefined {
+  return (
+    session.workspace ||
+    session.workspacePath ||
+    session.cwd ||
+    session.workingDir ||
+    session.workingDirectory ||
+    session.agent?.workspace
+  );
 }
 
 function normalizePathForCompare(path: string | undefined): string {
@@ -115,12 +139,15 @@ function normalizePathForCompare(path: string | undefined): string {
 }
 
 function shouldSyncSession(session: GatewaySessionRow, deviceId: string, filter?: SyncSessionFilter): boolean {
-  if (!session.key || isSystemSession(session.key) || isSubagentSession(session.key)) return false;
+  if (!session.key || session.spawnedBy || isSystemSession(session.key) || isSubagentSession(session.key)) return false;
   if (!filter?.agentId && !filter?.workspace) return isClawWorkSession(session.key, deviceId);
 
-  if (filter.agentId && sessionAgentId(session) !== filter.agentId) return false;
-  if (filter.workspace && session.workspace) {
-    return normalizePathForCompare(session.workspace) === normalizePathForCompare(filter.workspace);
+  const agentId = explicitSessionAgentId(session);
+  if (filter.agentId && agentId && agentId !== filter.agentId) return false;
+
+  const workspace = sessionWorkspace(session);
+  if (filter.workspace && workspace) {
+    return normalizePathForCompare(workspace) === normalizePathForCompare(filter.workspace);
   }
   return true;
 }
@@ -442,7 +469,7 @@ export function registerWsHandlers(): void {
             sessionKey: s.key,
             title: s.derivedTitle ?? s.label ?? titleFromMsg,
             updatedAt: s.updatedAt ? new Date(s.updatedAt).toISOString() : new Date().toISOString(),
-            agentId: sessionAgentId(s),
+            agentId: sessionAgentId(s, filter?.agentId),
             model: s.model,
             modelProvider: s.modelProvider,
             thinkingLevel: s.thinkingLevel,

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -64,12 +64,22 @@ interface GatewaySessionRow {
   workingDir?: string;
   workingDirectory?: string;
   spawnedBy?: string;
-  updatedAt: number | null;
+  parentSessionKey?: string;
+  parentKey?: string;
+  spawnerKey?: string;
+  isSubagent?: boolean;
+  type?: string;
+  role?: string;
+  updatedAt: number | string | null;
+  startedAt?: number | string;
   derivedTitle?: string;
+  title?: string;
+  name?: string;
   label?: string;
   displayName?: string;
   model?: string;
   modelProvider?: string;
+  provider?: string;
   thinkingLevel?: string;
   reasoningLevel?: string;
   fastMode?: boolean;
@@ -79,26 +89,25 @@ interface GatewaySessionRow {
   contextTokens?: number;
 }
 
-interface SessionsListPayload {
-  sessions?: GatewaySessionRow[];
-}
-
 interface ChatHistoryMessage {
   role: string;
-  content: {
-    type: string;
-    text?: string;
-    thinking?: string;
-    url?: string;
-    openUrl?: string;
-    alt?: string;
-    mimeType?: string;
-    id?: string;
-    name?: string;
-    arguments?: Record<string, unknown> | string;
-    result?: unknown;
-  }[];
+  content:
+    | string
+    | {
+        type: string;
+        text?: string;
+        thinking?: string;
+        url?: string;
+        openUrl?: string;
+        alt?: string;
+        mimeType?: string;
+        id?: string;
+        name?: string;
+        arguments?: Record<string, unknown> | string;
+        result?: unknown;
+      }[];
   timestamp?: number;
+  ts?: number;
 }
 
 interface ChatHistoryPayload {
@@ -108,11 +117,98 @@ interface ChatHistoryPayload {
 
 const INTERNAL_ASSISTANT_MARKERS = new Set(['NO_REPLY']);
 const RELATIVE_GATEWAY_MEDIA_PATH_RE = /^\/(?:api\/chat\/media\/outgoing\/|media\/|__openclaw__\/media\/)/;
+const SESSION_METADATA_KEYS = new Set([
+  'recent',
+  'count',
+  'path',
+  'defaults',
+  'ts',
+  'timestamp',
+  'updatedAt',
+  'sessions',
+  'items',
+  'rows',
+  'data',
+  'result',
+]);
 
 function nativeTaskIdForSessionKey(sessionKey: string): string {
   const parsed = parseTaskIdFromSessionKey(sessionKey);
   if (parsed) return parsed;
   return `native-${createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function stringField(source: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = nonEmptyString(source[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function isSessionMetadataKey(key: string): boolean {
+  return SESSION_METADATA_KEYS.has(key);
+}
+
+function normalizeGatewaySessionRow(value: unknown, mapKey?: string): GatewaySessionRow | null {
+  if (!isRecord(value)) {
+    const key = nonEmptyString(mapKey);
+    return key && !isSessionMetadataKey(key) ? ({ key, updatedAt: null } as GatewaySessionRow) : null;
+  }
+
+  const agent = isRecord(value.agent) ? (value.agent as GatewaySessionRow['agent']) : undefined;
+  const key = stringField(value, ['key', 'sessionKey', 'sessionId', 'id']) ?? nonEmptyString(mapKey);
+  if (!key || isSessionMetadataKey(key)) return null;
+
+  return {
+    ...(value as Record<string, unknown>),
+    key,
+    agent,
+    agentId: stringField(value, ['agentId', 'agentID', 'agent_id']) ?? agent?.id,
+    sessionId: stringField(value, ['sessionId', 'sessionID']) ?? stringField(value, ['id']),
+    spawnedBy: stringField(value, ['spawnedBy', 'spawnedBySessionKey']),
+    parentSessionKey: stringField(value, ['parentSessionKey', 'parentSessionId']),
+    parentKey: stringField(value, ['parentKey']),
+    spawnerKey: stringField(value, ['spawnerKey']),
+    workspace: stringField(value, ['workspace', 'workspaceRoot']),
+    workspacePath: stringField(value, ['workspacePath', 'worktreePath']),
+    cwd: stringField(value, ['cwd']),
+    workingDir: stringField(value, ['workingDir']),
+    workingDirectory: stringField(value, ['workingDirectory']),
+    updatedAt: typeof value.updatedAt === 'number' || typeof value.updatedAt === 'string' ? value.updatedAt : null,
+  } as GatewaySessionRow;
+}
+
+function collectSessionRows(value: unknown): GatewaySessionRow[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeGatewaySessionRow(item)).filter((item): item is GatewaySessionRow => !!item);
+  }
+
+  if (!isRecord(value)) return [];
+
+  const nestedKeys = ['sessions', 'items', 'rows', 'data', 'result'];
+  for (const key of nestedKeys) {
+    if (key in value) {
+      const nested = collectSessionRows(value[key]);
+      if (nested.length > 0) return nested;
+    }
+  }
+
+  const single = normalizeGatewaySessionRow(value);
+  if (single) return [single];
+
+  return Object.entries(value)
+    .filter(([key]) => !isSessionMetadataKey(key))
+    .map(([key, row]) => normalizeGatewaySessionRow(row, key))
+    .filter((item): item is GatewaySessionRow => !!item);
 }
 
 function explicitSessionAgentId(session: GatewaySessionRow): string | undefined {
@@ -138,8 +234,28 @@ function normalizePathForCompare(path: string | undefined): string {
   return (path ?? '').trim().replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
 }
 
+function isDerivedSession(session: GatewaySessionRow): boolean {
+  return Boolean(
+    session.spawnedBy ||
+      session.parentSessionKey ||
+      session.parentKey ||
+      session.spawnerKey ||
+      session.isSubagent ||
+      session.type === 'subagent' ||
+      session.role === 'subagent',
+  );
+}
+
 function shouldSyncSession(session: GatewaySessionRow, deviceId: string, filter?: SyncSessionFilter): boolean {
-  if (!session.key || session.spawnedBy || isSystemSession(session.key) || isSubagentSession(session.key)) return false;
+  if (
+    !session.key ||
+    isDerivedSession(session) ||
+    session.type === 'system' ||
+    session.role === 'system' ||
+    isSystemSession(session.key) ||
+    isSubagentSession(session.key)
+  )
+    return false;
   if (!filter?.agentId && !filter?.workspace) return isClawWorkSession(session.key, deviceId);
 
   const agentId = explicitSessionAgentId(session);
@@ -162,6 +278,36 @@ function sessionListParamsForFilter(filter?: SyncSessionFilter): Record<string, 
     includeDerivedTitles: true,
     includeLastMessage: true,
   };
+}
+
+function messageContentBlocks(message: ChatHistoryMessage): Exclude<ChatHistoryMessage['content'], string> {
+  if (Array.isArray(message.content)) return message.content;
+  if (typeof message.content === 'string' && message.content.length > 0) {
+    return [{ type: 'text', text: message.content }];
+  }
+  return [];
+}
+
+function messageTimestamp(message: ChatHistoryMessage): number | undefined {
+  return typeof message.timestamp === 'number'
+    ? message.timestamp
+    : typeof message.ts === 'number'
+      ? message.ts
+      : undefined;
+}
+
+function toIsoTimestamp(value: number | string | null | undefined): string {
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return new Date().toISOString();
+  const millis = value < 10_000_000_000 ? value * 1000 : value;
+  return new Date(millis).toISOString();
+}
+
+function sessionTitle(session: GatewaySessionRow, titleFromMsg: string): string {
+  return session.derivedTitle ?? session.label ?? session.title ?? session.displayName ?? session.name ?? titleFromMsg;
 }
 
 interface SyncSessionFilter {
@@ -397,9 +543,22 @@ export function registerWsHandlers(): void {
       if (!gw.isConnected) continue;
       try {
         const deviceId = ensureDeviceId();
-        const raw = (await gw.listSessions(sessionListParamsForFilter(filter))) as unknown as SessionsListPayload;
-        const allSessions = raw.sessions ?? [];
+        const params = sessionListParamsForFilter(filter);
+        const raw = await gw.listSessions(params);
+        const allSessions = collectSessionRows(raw);
         const ours = allSessions.filter((s) => shouldSyncSession(s, deviceId, filter));
+        getDebugLogger().info({
+          domain: 'ipc',
+          event: 'ipc.ws.sync-sessions.listed',
+          gatewayId,
+          data: {
+            requestedAgentId: filter?.agentId,
+            requestedWorkspace: filter?.workspace,
+            paramKeys: Object.keys(params),
+            sessionCount: allSessions.length,
+            importableCount: ours.length,
+          },
+        });
 
         for (const s of ours) {
           const taskId = nativeTaskIdForSessionKey(s.key);
@@ -411,7 +570,7 @@ export function registerWsHandlers(): void {
           const toolResultMap = new Map<string, string>();
           for (const m of rawMsgs) {
             if (m.role === 'toolResult') {
-              for (const b of m.content ?? []) {
+              for (const b of messageContentBlocks(m)) {
                 if (b.type === 'toolResult' && b.id && b.result !== undefined) {
                   toolResultMap.set(b.id, typeof b.result === 'string' ? b.result : JSON.stringify(b.result));
                 }
@@ -422,17 +581,19 @@ export function registerWsHandlers(): void {
           const msgs = rawMsgs
             .filter((m) => m.role === 'user' || m.role === 'assistant')
             .map((m) => {
+              const blocks = messageContentBlocks(m);
+              const timestamp = messageTimestamp(m);
               const normalizedContent =
                 m.role === 'assistant'
-                  ? normalizeContentBlocks(m.content ?? [], gw.httpBase)
+                  ? normalizeContentBlocks(blocks, gw.httpBase)
                   : {
-                      content: (m.content ?? [])
+                      content: blocks
                         .filter((b) => b.type === 'text' && b.text)
                         .map((b) => b.text!)
                         .join(''),
                     };
 
-              const toolCalls: ParsedToolCall[] = (m.content ?? [])
+              const toolCalls: ParsedToolCall[] = blocks
                 .filter((b) => b.type === 'toolCall' && b.id && b.name)
                 .map((b) => {
                   const tcId = b.id!;
@@ -448,12 +609,10 @@ export function registerWsHandlers(): void {
                           ? parseToolArgs(b.arguments)
                           : undefined,
                     result: resultText,
-                    startedAt: m.timestamp ? new Date(m.timestamp).toISOString() : new Date().toISOString(),
+                    startedAt: toIsoTimestamp(timestamp),
                     completedAt:
                       resultText !== undefined
-                        ? m.timestamp
-                          ? new Date(m.timestamp).toISOString()
-                          : new Date().toISOString()
+                        ? toIsoTimestamp(timestamp)
                         : undefined,
                   };
                 });
@@ -462,7 +621,7 @@ export function registerWsHandlers(): void {
                 role: m.role,
                 content: normalizedContent.content,
                 attachments: normalizedContent.attachments,
-                timestamp: m.timestamp ? new Date(m.timestamp).toISOString() : new Date().toISOString(),
+                timestamp: toIsoTimestamp(timestamp),
                 toolCalls,
               };
             })
@@ -479,11 +638,11 @@ export function registerWsHandlers(): void {
             gatewayId,
             taskId,
             sessionKey: s.key,
-            title: s.derivedTitle ?? s.label ?? titleFromMsg,
-            updatedAt: s.updatedAt ? new Date(s.updatedAt).toISOString() : new Date().toISOString(),
+            title: sessionTitle(s, titleFromMsg),
+            updatedAt: toIsoTimestamp(s.updatedAt),
             agentId: sessionAgentId(s, filter?.agentId),
             model: s.model,
-            modelProvider: s.modelProvider,
+            modelProvider: s.modelProvider ?? s.provider,
             thinkingLevel: s.thinkingLevel,
             inputTokens: s.inputTokens,
             outputTokens: s.outputTokens,

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -1,7 +1,14 @@
 import { ipcMain } from 'electron';
+import { createHash } from 'crypto';
 import { getGatewayClient, getAllGatewayClients, reconnectGateway } from '../ws/index.js';
 import { readConfig, ensureDeviceId } from '../workspace/config.js';
-import { isClawWorkSession, parseTaskIdFromSessionKey, parseAgentIdFromSessionKey } from '@clawwork/shared';
+import {
+  isClawWorkSession,
+  isSubagentSession,
+  isSystemSession,
+  parseTaskIdFromSessionKey,
+  parseAgentIdFromSessionKey,
+} from '@clawwork/shared';
 import { normalizeContentBlocks, parseToolArgs } from '@clawwork/core';
 import type {
   ApprovalDecision,
@@ -45,7 +52,9 @@ async function gatewayRpc(
 
 interface GatewaySessionRow {
   key: string;
+  agentId?: string;
   sessionId?: string;
+  workspace?: string;
   updatedAt: number | null;
   derivedTitle?: string;
   label?: string;
@@ -90,6 +99,37 @@ interface ChatHistoryPayload {
 
 const INTERNAL_ASSISTANT_MARKERS = new Set(['NO_REPLY']);
 const RELATIVE_GATEWAY_MEDIA_PATH_RE = /^\/(?:api\/chat\/media\/outgoing\/|media\/|__openclaw__\/media\/)/;
+
+function nativeTaskIdForSessionKey(sessionKey: string): string {
+  const parsed = parseTaskIdFromSessionKey(sessionKey);
+  if (parsed) return parsed;
+  return `native-${createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)}`;
+}
+
+function sessionAgentId(session: GatewaySessionRow): string {
+  return session.agentId || parseAgentIdFromSessionKey(session.key);
+}
+
+function normalizePathForCompare(path: string | undefined): string {
+  return (path ?? '').trim().replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+}
+
+function shouldSyncSession(session: GatewaySessionRow, deviceId: string, filter?: SyncSessionFilter): boolean {
+  if (!session.key || isSystemSession(session.key) || isSubagentSession(session.key)) return false;
+  if (!filter?.agentId && !filter?.workspace) return isClawWorkSession(session.key, deviceId);
+
+  if (filter.agentId && sessionAgentId(session) !== filter.agentId) return false;
+  if (filter.workspace && session.workspace) {
+    return normalizePathForCompare(session.workspace) === normalizePathForCompare(filter.workspace);
+  }
+  return true;
+}
+
+interface SyncSessionFilter {
+  gatewayId?: string;
+  agentId?: string;
+  workspace?: string;
+}
 
 /** Parsed tool call for transport to renderer */
 interface ParsedToolCall {
@@ -283,7 +323,7 @@ export function registerWsHandlers(): void {
     return statusMap;
   });
 
-  ipcMain.handle('ws:sync-sessions', async () => {
+  ipcMain.handle('ws:sync-sessions', async (_event, filter?: SyncSessionFilter) => {
     const clients = getAllGatewayClients();
     getDebugLogger().info({
       domain: 'ipc',
@@ -314,15 +354,16 @@ export function registerWsHandlers(): void {
     }[] = [];
 
     for (const [gatewayId, gw] of clients) {
+      if (filter?.gatewayId && filter.gatewayId !== gatewayId) continue;
       if (!gw.isConnected) continue;
       try {
         const deviceId = ensureDeviceId();
         const raw = (await gw.listSessions()) as unknown as SessionsListPayload;
         const allSessions = raw.sessions ?? [];
-        const ours = allSessions.filter((s) => isClawWorkSession(s.key, deviceId));
+        const ours = allSessions.filter((s) => shouldSyncSession(s, deviceId, filter));
 
         for (const s of ours) {
-          const taskId = parseTaskIdFromSessionKey(s.key);
+          const taskId = nativeTaskIdForSessionKey(s.key);
           if (!taskId) continue;
 
           const historyRaw = (await gw.getChatHistory(s.key, 200)) as unknown as ChatHistoryPayload;
@@ -401,7 +442,7 @@ export function registerWsHandlers(): void {
             sessionKey: s.key,
             title: s.derivedTitle ?? s.label ?? titleFromMsg,
             updatedAt: s.updatedAt ? new Date(s.updatedAt).toISOString() : new Date().toISOString(),
-            agentId: parseAgentIdFromSessionKey(s.key),
+            agentId: sessionAgentId(s),
             model: s.model,
             modelProvider: s.modelProvider,
             thinkingLevel: s.thinkingLevel,

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -122,6 +122,7 @@ const SESSION_METADATA_KEYS = new Set([
   'count',
   'path',
   'defaults',
+  'sessionDefaults',
   'ts',
   'timestamp',
   'updatedAt',
@@ -130,6 +131,13 @@ const SESSION_METADATA_KEYS = new Set([
   'rows',
   'data',
   'result',
+  'global',
+  'main',
+  'default',
+  'current',
+  'active',
+  'latest',
+  'unknown',
 ]);
 
 function nativeTaskIdForSessionKey(sessionKey: string): string {
@@ -158,14 +166,26 @@ function isSessionMetadataKey(key: string): boolean {
   return SESSION_METADATA_KEYS.has(key);
 }
 
+function isLikelySessionKey(key: string | undefined): key is string {
+  if (!key || isSessionMetadataKey(key)) return false;
+  return /^(agent|openclaw|dashboard)[:\uFF1A]/i.test(key) || (key.includes(':') && /session/i.test(key));
+}
+
+function hasSessionTitlePrefix(value: Record<string, unknown>): boolean {
+  const title = stringField(value, ['derivedTitle', 'label', 'title', 'displayName', 'name']);
+  return /^\s*(dashboard|cron)\s*[:\uFF1A]/i.test(title ?? '');
+}
+
 function normalizeGatewaySessionRow(value: unknown, mapKey?: string): GatewaySessionRow | null {
   if (!isRecord(value)) {
     const key = nonEmptyString(mapKey);
-    return key && !isSessionMetadataKey(key) ? ({ key, updatedAt: null } as GatewaySessionRow) : null;
+    return isLikelySessionKey(key) ? ({ key, updatedAt: null } as GatewaySessionRow) : null;
   }
 
   const agent = isRecord(value.agent) ? (value.agent as GatewaySessionRow['agent']) : undefined;
-  const key = stringField(value, ['key', 'sessionKey', 'sessionId', 'id']) ?? nonEmptyString(mapKey);
+  const explicitKey = stringField(value, ['key', 'sessionKey', 'sessionId', 'id']);
+  const mapSessionKey = nonEmptyString(mapKey);
+  const key = explicitKey ?? (isLikelySessionKey(mapSessionKey) || hasSessionTitlePrefix(value) ? mapSessionKey : undefined);
   if (!key || isSessionMetadataKey(key)) return null;
 
   return {
@@ -197,8 +217,7 @@ function collectSessionRows(value: unknown): GatewaySessionRow[] {
   const nestedKeys = ['sessions', 'items', 'rows', 'data', 'result'];
   for (const key of nestedKeys) {
     if (key in value) {
-      const nested = collectSessionRows(value[key]);
-      if (nested.length > 0) return nested;
+      return collectSessionRows(value[key]);
     }
   }
 
@@ -215,8 +234,16 @@ function explicitSessionAgentId(session: GatewaySessionRow): string | undefined 
   return session.agentId || session.agent?.id;
 }
 
+function dashboardSessionAgentId(sessionKey: string): string | undefined {
+  return sessionKey.match(/^dashboard[:\uFF1A]([^:\uFF1A]+)(?:[:\uFF1A]|$)/i)?.[1];
+}
+
+function inferredSessionAgentId(session: GatewaySessionRow): string | undefined {
+  return explicitSessionAgentId(session) || dashboardSessionAgentId(session.key);
+}
+
 function sessionAgentId(session: GatewaySessionRow, fallbackAgentId?: string): string {
-  return explicitSessionAgentId(session) || fallbackAgentId || parseAgentIdFromSessionKey(session.key);
+  return inferredSessionAgentId(session) || fallbackAgentId || parseAgentIdFromSessionKey(session.key);
 }
 
 function sessionWorkspace(session: GatewaySessionRow): string | undefined {
@@ -258,7 +285,7 @@ function shouldSyncSession(session: GatewaySessionRow, deviceId: string, filter?
     return false;
   if (!filter?.agentId && !filter?.workspace) return isClawWorkSession(session.key, deviceId);
 
-  const agentId = explicitSessionAgentId(session);
+  const agentId = inferredSessionAgentId(session);
   if (filter.agentId && agentId && agentId !== filter.agentId) return false;
 
   const workspace = sessionWorkspace(session);
@@ -307,11 +334,18 @@ function toIsoTimestamp(value: number | string | null | undefined): string {
 }
 
 function sessionTitle(session: GatewaySessionRow, titleFromMsg: string): string {
-  return session.derivedTitle ?? session.label ?? session.title ?? session.displayName ?? session.name ?? titleFromMsg;
+  const explicitTitle = session.derivedTitle ?? session.label ?? session.title ?? session.displayName ?? session.name;
+  if (explicitTitle) return explicitTitle;
+  if (/^dashboard[:\uFF1A]/i.test(session.key)) return session.key.replace(/^dashboard[:\uFF1A]?/i, 'dashboard: ');
+  return titleFromMsg;
 }
 
 function isCronSessionTitle(title: string | undefined): boolean {
-  return /^\s*cron\s*[:：]/i.test(title ?? '');
+  return /^\s*cron\s*[:\uFF1A]/i.test(title ?? '');
+}
+
+function isDashboardSession(session: GatewaySessionRow, title: string | undefined): boolean {
+  return /^dashboard[:\uFF1A]/i.test(session.key) || /^\s*dashboard\s*[:\uFF1A]/i.test(title ?? '');
 }
 
 interface SyncSessionFilter {
@@ -651,6 +685,7 @@ export function registerWsHandlers(): void {
           const titleFromMsg = firstUserMsg ? firstUserMsg.content.slice(0, 30) : '';
           const title = sessionTitle(s, titleFromMsg);
           if (isCronSessionTitle(title)) continue;
+          if (!title.trim() && msgs.length === 0 && !isDashboardSession(s, title)) continue;
 
           discovered.push({
             gatewayId,

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -146,7 +146,7 @@ function shouldSyncSession(session: GatewaySessionRow, deviceId: string, filter?
   if (filter.agentId && agentId && agentId !== filter.agentId) return false;
 
   const workspace = sessionWorkspace(session);
-  if (filter.workspace && workspace) {
+  if (!filter.agentId && filter.workspace && workspace) {
     return normalizePathForCompare(workspace) === normalizePathForCompare(filter.workspace);
   }
   return true;
@@ -154,9 +154,9 @@ function shouldSyncSession(session: GatewaySessionRow, deviceId: string, filter?
 
 function sessionListParamsForFilter(filter?: SyncSessionFilter): Record<string, unknown> {
   if (!filter?.agentId && !filter?.workspace) return {};
+  if (filter.agentId) return { agentId: filter.agentId };
 
   return {
-    ...(filter.agentId ? { agentId: filter.agentId } : {}),
     includeGlobal: true,
     includeUnknown: true,
     includeDerivedTitles: true,

--- a/packages/desktop/src/main/ipc/ws-handlers.ts
+++ b/packages/desktop/src/main/ipc/ws-handlers.ts
@@ -152,6 +152,18 @@ function shouldSyncSession(session: GatewaySessionRow, deviceId: string, filter?
   return true;
 }
 
+function sessionListParamsForFilter(filter?: SyncSessionFilter): Record<string, unknown> {
+  if (!filter?.agentId && !filter?.workspace) return {};
+
+  return {
+    ...(filter.agentId ? { agentId: filter.agentId } : {}),
+    includeGlobal: true,
+    includeUnknown: true,
+    includeDerivedTitles: true,
+    includeLastMessage: true,
+  };
+}
+
 interface SyncSessionFilter {
   gatewayId?: string;
   agentId?: string;
@@ -385,7 +397,7 @@ export function registerWsHandlers(): void {
       if (!gw.isConnected) continue;
       try {
         const deviceId = ensureDeviceId();
-        const raw = (await gw.listSessions()) as unknown as SessionsListPayload;
+        const raw = (await gw.listSessions(sessionListParamsForFilter(filter))) as unknown as SessionsListPayload;
         const allSessions = raw.sessions ?? [];
         const ours = allSessions.filter((s) => shouldSyncSession(s, deviceId, filter));
 

--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -591,8 +591,8 @@ export class GatewayClient {
     return this.sendReq('chat.history', { sessionKey, limit }, this.sessionMeta(sessionKey));
   }
 
-  async listSessions(): Promise<Record<string, unknown>> {
-    return this.sendReq('sessions.list', {}, { requestId: randomUUID() });
+  async listSessions(params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.sendReq('sessions.list', params, { requestId: randomUUID() });
   }
 
   async listSessionsBySpawner(spawnedBy: string): Promise<Record<string, unknown>> {

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -228,6 +228,12 @@ interface SyncResult {
   error?: string;
 }
 
+interface SessionSyncFilter {
+  gatewayId?: string;
+  agentId?: string;
+  workspace?: string;
+}
+
 interface ListResult<T> {
   ok: boolean;
   rows?: T[];
@@ -284,7 +290,7 @@ export interface ClawWorkAPI {
   lookupConfigSchema: (gatewayId: string, path: string) => Promise<IpcResult<ConfigSchemaLookupResult>>;
 
   gatewayStatus: () => Promise<GatewayStatusMap>;
-  syncSessions: () => Promise<SyncResult>;
+  syncSessions: (filter?: SessionSyncFilter) => Promise<SyncResult>;
   listGateways: () => Promise<GatewayListItem[]>;
 
   onGatewayEvent: (callback: (data: GatewayEvent) => void) => () => void;

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -192,6 +192,7 @@ interface PersistedTask {
   tags: string[];
   artifactDir: string;
   gatewayId: string;
+  agentId?: string | null;
 }
 
 interface PersistedMessage {
@@ -421,6 +422,7 @@ export interface ClawWorkAPI {
     tags: string[];
     artifactDir: string;
     gatewayId: string;
+    agentId?: string | null;
   }) => Promise<IpcResult>;
 
   persistTaskUpdate: (params: {
@@ -435,6 +437,7 @@ export interface ClawWorkAPI {
     outputTokens?: number;
     contextTokens?: number;
     teamId?: string | null;
+    agentId?: string | null;
     updatedAt: string;
   }) => Promise<IpcResult>;
 

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -31,6 +31,8 @@ import type {
   ConfigSchemaLookupResult,
   ParsedTeam,
   AgentFileSet,
+  Artifact,
+  MessageAttachment,
 } from '@clawwork/shared';
 
 type IpcResult<T = Record<string, unknown>> = SharedIpcResult<T>;
@@ -217,7 +219,7 @@ interface DiscoveredSession {
   inputTokens?: number;
   outputTokens?: number;
   contextTokens?: number;
-  messages: { role: string; content: string; timestamp: string }[];
+  messages: { role: string; content: string; timestamp: string; attachments?: MessageAttachment[]; toolCalls?: unknown[] }[];
 }
 
 interface SyncResult {
@@ -325,6 +327,11 @@ export interface ClawWorkAPI {
     language?: string;
     fileName?: string;
   }) => Promise<IpcResult>;
+  saveMessageAttachment: (params: {
+    taskId: string;
+    messageId: string;
+    attachment: MessageAttachment;
+  }) => Promise<IpcResult<Artifact>>;
   saveImageFromUrl: (params: { taskId: string; messageId: string; url: string; alt?: string }) => Promise<IpcResult>;
   searchArtifacts: (
     query: string,

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -143,6 +143,7 @@ function buildApi(): ClawWorkAPI {
       };
     },
     saveCodeBlock: (params) => ipcRenderer.invoke('artifact:save-content', params),
+    saveMessageAttachment: (params) => ipcRenderer.invoke('artifact:save-attachment', params),
     saveImageFromUrl: (params) => ipcRenderer.invoke('artifact:save-image-url', params),
     searchArtifacts: (query: string, options) => ipcRenderer.invoke('artifact:search', { query, ...(options ?? {}) }),
     openArtifactFile: (localPath: string) => ipcRenderer.invoke('artifact:open-file', { localPath }),

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -245,6 +245,7 @@ function buildApi(): ClawWorkAPI {
       tags: string[];
       artifactDir: string;
       gatewayId: string;
+      agentId?: string | null;
     }) => ipcRenderer.invoke('data:create-task', task),
 
     persistTaskUpdate: (params: {
@@ -259,6 +260,7 @@ function buildApi(): ClawWorkAPI {
       outputTokens?: number;
       contextTokens?: number;
       teamId?: string | null;
+      agentId?: string | null;
       updatedAt: string;
     }) => ipcRenderer.invoke('data:update-task', params),
 

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -28,7 +28,8 @@ function buildApi(): ClawWorkAPI {
       ipcRenderer.invoke('ws:chat-history', { gatewayId, sessionKey, limit }),
     listSessions: (gatewayId: string) => ipcRenderer.invoke('ws:list-sessions', { gatewayId }),
     gatewayStatus: () => ipcRenderer.invoke('ws:gateway-status'),
-    syncSessions: () => ipcRenderer.invoke('ws:sync-sessions'),
+    syncSessions: (filter?: { gatewayId?: string; agentId?: string; workspace?: string }) =>
+      ipcRenderer.invoke('ws:sync-sessions', filter),
     abortChat: (gatewayId: string, sessionKey: string) =>
       ipcRenderer.invoke('ws:abort-chat', { gatewayId, sessionKey }),
     listGateways: () => ipcRenderer.invoke('ws:list-gateways'),

--- a/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
+++ b/packages/desktop/src/renderer/components/ChatInput/useChatSend.ts
@@ -74,7 +74,6 @@ export function useChatSend(opts: UseChatSendOpts) {
 
   const activeTask = useTaskStore((s) => s.tasks.find((tt) => tt.id === s.activeTaskId));
   const commitPendingTask = useTaskStore((s) => s.commitPendingTask);
-  const updateTaskMetadata = useTaskStore((s) => s.updateTaskMetadata);
   const pendingNewTask = useTaskStore((s) => s.pendingNewTask);
   const addMessage = useMessageStore((s) => s.addMessage);
   const setProcessing = useMessageStore((s) => s.setProcessing);
@@ -460,18 +459,11 @@ export function useChatSend(opts: UseChatSendOpts) {
         useTaskStore.getState().updatePending({ model: modelId });
         return;
       }
-      const ta = textareaRef.current;
-      if (!ta) return;
-      updateTaskMetadata(activeTask.id, {
-        model: modelId,
-        modelProvider: modelCatalog.find((m) => m.id === modelId)?.provider,
+      void composer.applySlashCommand(activeTask.id, 'model', modelId).then((result) => {
+        if (!result.ok) toast.error(t('errors.sendFailed'));
       });
-      ta.value = `/model ${modelId}`;
-      ta.style.height = 'auto';
-      ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
-      void handleSend();
     },
-    [activeTask, handleSend, modelCatalog, updateTaskMetadata, textareaRef],
+    [activeTask, t],
   );
 
   const handleThinkingQuickSend = useCallback(
@@ -480,14 +472,11 @@ export function useChatSend(opts: UseChatSendOpts) {
         useTaskStore.getState().updatePending({ thinkingLevel: level });
         return;
       }
-      const ta = textareaRef.current;
-      if (!ta) return;
-      ta.value = `/think ${level}`;
-      ta.style.height = 'auto';
-      ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
-      void handleSend();
+      void composer.applySlashCommand(activeTask.id, 'think', level).then((result) => {
+        if (!result.ok) toast.error(t('errors.sendFailed'));
+      });
     },
-    [activeTask, handleSend, textareaRef],
+    [activeTask, t],
   );
 
   const [aborting, setAborting] = useState(false);

--- a/packages/desktop/src/renderer/components/ChatMessage.tsx
+++ b/packages/desktop/src/renderer/components/ChatMessage.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { motion } from 'framer-motion';
-import type { Message } from '@clawwork/shared';
+import type { Artifact, Message, MessageAttachment } from '@clawwork/shared';
 import { Check, Copy, File, FileCode, Loader2, Save } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@/lib/toast';
@@ -104,28 +104,68 @@ function MessageActionButton({
   );
 }
 
-function AttachmentFileCard({ attachment }: { attachment: { fileName: string; localPath?: string } }) {
+function AttachmentFileCard({
+  attachment,
+  taskId,
+  messageId,
+}: {
+  attachment: MessageAttachment;
+  taskId: string;
+  messageId: string;
+}) {
   const { t } = useTranslation();
-  const canOpen = Boolean(attachment.localPath);
+  const [artifactLocalPath, setArtifactLocalPath] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const canOpen = Boolean(attachment.localPath || artifactLocalPath);
+  const canSave = Boolean(taskId && messageId && (attachment.dataUrl || attachment.sourcePath));
+
+  const handleClick = async () => {
+    if (attachment.localPath) {
+      const res = await window.clawwork.openInboxFile(attachment.localPath);
+      if (!res.ok) toast.error(t('chatInput.openFailed', { fileName: attachment.fileName }));
+      return;
+    }
+    if (artifactLocalPath) {
+      const res = await window.clawwork.openArtifactFile(artifactLocalPath);
+      if (!res.ok) toast.error(t('chatInput.openFailed', { fileName: attachment.fileName }));
+      return;
+    }
+    if (!canSave || saving) return;
+    setSaving(true);
+    try {
+      const res = await window.clawwork.saveMessageAttachment({ taskId, messageId, attachment });
+      if (!res.ok || !res.result) throw new Error(res.error);
+      const artifact = res.result as Artifact;
+      setArtifactLocalPath(artifact.localPath);
+      await window.clawwork.openArtifactFile(artifact.localPath);
+    } catch {
+      toast.error(t('chatInput.attachmentSaveFailed', { fileName: attachment.fileName }));
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <button
       type="button"
-      disabled={!canOpen}
-      onClick={async () => {
-        if (!attachment.localPath) return;
-        const res = await window.clawwork.openInboxFile(attachment.localPath);
-        if (!res.ok) toast.error(t('chatInput.openFailed', { fileName: attachment.fileName }));
-      }}
+      disabled={!canOpen && !canSave}
+      onClick={handleClick}
       className={cn(
         'inline-flex items-center gap-2 rounded-xl px-3 py-2 max-w-xs',
         'border border-[var(--border-subtle)] bg-[var(--bg-tertiary)] text-[var(--text-secondary)]',
-        canOpen
+        canOpen || canSave
           ? 'cursor-pointer hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors'
           : 'opacity-70 cursor-default',
       )}
-      title={attachment.fileName}
+      title={canOpen ? attachment.fileName : t('common.save')}
     >
-      <File size={16} className="flex-shrink-0" />
+      {saving ? (
+        <Loader2 size={16} className="flex-shrink-0 animate-spin" />
+      ) : canOpen ? (
+        <File size={16} className="flex-shrink-0" />
+      ) : (
+        <Save size={16} className="flex-shrink-0" />
+      )}
       <span className="type-body truncate">{attachment.fileName}</span>
     </button>
   );
@@ -338,7 +378,12 @@ const ChatMessage = memo(function ChatMessage({
                   onOpen={onImageClick}
                 />
               ) : (
-                <AttachmentFileCard key={`${attachment.fileName}-${i}`} attachment={attachment} />
+                <AttachmentFileCard
+                  key={`${attachment.fileName}-${i}`}
+                  attachment={attachment}
+                  taskId={message.taskId}
+                  messageId={message.id}
+                />
               );
             })}
           </div>

--- a/packages/desktop/src/renderer/hooks/useGatewaySelector.ts
+++ b/packages/desktop/src/renderer/hooks/useGatewaySelector.ts
@@ -24,6 +24,8 @@ export function useGatewaySelector(options: UseGatewaySelectorOptions = {}): Use
   const gatewayInfoMap = useUiStore((s) => s.gatewayInfoMap);
   const defaultGatewayId = useUiStore((s) => s.defaultGatewayId);
   const agentCatalogByGateway = useUiStore((s) => s.agentCatalogByGateway);
+  const selectedMainAgentByGateway = useUiStore((s) => s.selectedMainAgentByGateway);
+  const setSelectedMainAgentForGateway = useUiStore((s) => s.setSelectedMainAgentForGateway);
 
   const gateways = useMemo(() => Object.values(gatewayInfoMap), [gatewayInfoMap]);
   const [selectedGwId, setSelectedGwId] = useState(
@@ -32,17 +34,19 @@ export function useGatewaySelector(options: UseGatewaySelectorOptions = {}): Use
 
   const gwAgents = agentCatalogByGateway[selectedGwId];
   const agentCatalog = useMemo(() => gwAgents?.agents ?? [], [gwAgents]);
-  const [selectedAgentId, setSelectedAgentId] = useState(
-    options.initialAgentId ??
-      agentCatalogByGateway[options.initialGatewayId ?? defaultGatewayId ?? '']?.defaultId ??
-      '',
-  );
+  const [localSelectedAgentId, setLocalSelectedAgentId] = useState(options.initialAgentId ?? '');
 
   const defaultAgentId = gwAgents?.defaultId ?? agentCatalog[0]?.id ?? '';
+  const selectedAgentId = localSelectedAgentId || selectedMainAgentByGateway[selectedGwId] || '';
   const effectiveAgentId = useMemo(
     () => (agentCatalog.some((agent) => agent.id === selectedAgentId) ? selectedAgentId : defaultAgentId),
     [agentCatalog, defaultAgentId, selectedAgentId],
   );
+
+  const setSelectedAgentId = (id: string): void => {
+    setLocalSelectedAgentId(id);
+    if (selectedGwId) setSelectedMainAgentForGateway(selectedGwId, id || null);
+  };
 
   useEffect(() => {
     if (!gateways.length) return;

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -173,7 +173,11 @@ function agentLabel(agent: AgentInfo | undefined, fallbackId: string): string {
 }
 
 function isCronTaskTitle(title: string | undefined): boolean {
-  return /^\s*cron\s*[:：]/i.test(title ?? '');
+  return /^\s*cron\s*[:\uFF1A]/i.test(title ?? '');
+}
+
+function isEmptyImportedPlaceholder(task: Task): boolean {
+  return task.id.startsWith('native-') && !task.title.trim();
 }
 
 function matchesSelectedMainAgent(task: Task, gatewayId: string | undefined, agentId: string | undefined): boolean {
@@ -467,6 +471,7 @@ export default function LeftNav() {
         (t) =>
           t.status !== 'archived' &&
           !isCronTaskTitle(t.title) &&
+          !isEmptyImportedPlaceholder(t) &&
           matchesSelectedMainAgent(t, defaultGatewayId ?? undefined, selectedMainAgentId),
       ),
     [defaultGatewayId, selectedMainAgentId, tasks],

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -172,6 +172,15 @@ function agentLabel(agent: AgentInfo | undefined, fallbackId: string): string {
   return basename(agent.workspace) || agent.name || fallbackId;
 }
 
+function isCronTaskTitle(title: string | undefined): boolean {
+  return /^\s*cron\s*[:：]/i.test(title ?? '');
+}
+
+function matchesSelectedMainAgent(task: Task, gatewayId: string | undefined, agentId: string | undefined): boolean {
+  if (!gatewayId || !agentId) return true;
+  return task.gatewayId === gatewayId && task.agentId === agentId;
+}
+
 const startupSyncedMainAgentKeys = new Set<string>();
 
 function mainAgentSyncKey(gatewayId: string, agent: AgentInfo): string {
@@ -332,6 +341,9 @@ export default function LeftNav() {
   const toggleLeftNavCollapsed = useUiStore((s) => s.toggleLeftNavCollapsed);
   const focusSearch = useUiStore((s) => s.focusSearch);
   const searchFocusTrigger = useUiStore((s) => s.searchFocusTrigger);
+  const defaultGatewayId = useUiStore((s) => s.defaultGatewayId);
+  const selectedMainAgentByGateway = useUiStore((s) => s.selectedMainAgentByGateway);
+  const selectedMainAgentId = defaultGatewayId ? selectedMainAgentByGateway[defaultGatewayId] : undefined;
 
   const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null);
   const [confirmTaskId, setConfirmTaskId] = useState('');
@@ -449,7 +461,16 @@ export default function LeftNav() {
     openMenu(e, taskId, status);
   };
 
-  const visibleTasks = useMemo(() => tasks.filter((t) => t.status !== 'archived'), [tasks]);
+  const visibleTasks = useMemo(
+    () =>
+      tasks.filter(
+        (t) =>
+          t.status !== 'archived' &&
+          !isCronTaskTitle(t.title) &&
+          matchesSelectedMainAgent(t, defaultGatewayId ?? undefined, selectedMainAgentId),
+      ),
+    [defaultGatewayId, selectedMainAgentId, tasks],
+  );
   const activeTasks = useMemo(() => visibleTasks.filter((t) => t.status === 'active'), [visibleTasks]);
   const completedTasks = useMemo(() => visibleTasks.filter((t) => t.status === 'completed'), [visibleTasks]);
   const activeGroups = useMemo(() => groupTasksByTime(activeTasks), [activeTasks]);

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -12,6 +12,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import {
   Plus,
   Search,
+  Check,
+  ChevronDown,
   FolderOpen,
   Settings,
   Archive,
@@ -34,6 +36,12 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -42,8 +50,10 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { exportToFiles, exportToLocal } from '@/lib/export-session';
+import { syncFromGateway } from '@/lib/session-sync';
+import AgentIcon from '@/components/AgentIcon';
 import TaskItem from './TaskItem';
-import type { Task, TaskStatus } from '@clawwork/shared';
+import type { AgentInfo, Task, TaskStatus } from '@clawwork/shared';
 import EmptyState from '@/components/semantic/EmptyState';
 
 function groupTasksByTime(tasks: Task[]): {
@@ -149,6 +159,112 @@ const navActiveClass = (active: boolean) =>
   active
     ? 'bg-[var(--accent-dim)] text-[var(--text-primary)]'
     : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]';
+
+function basename(path: string | undefined): string {
+  if (!path) return '';
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
+  return normalized.split('/').pop() || normalized;
+}
+
+function agentLabel(agent: AgentInfo | undefined, fallbackId: string): string {
+  if (!agent) return fallbackId;
+  return basename(agent.workspace) || agent.name || fallbackId;
+}
+
+function MainAgentWorkspaceSelector({ collapsed }: { collapsed?: boolean }) {
+  const { t } = useTranslation();
+  const defaultGatewayId = useUiStore((s) => s.defaultGatewayId);
+  const catalog = useUiStore((s) => (defaultGatewayId ? s.agentCatalogByGateway[defaultGatewayId] : undefined));
+  const selectedMainAgentByGateway = useUiStore((s) => s.selectedMainAgentByGateway);
+  const setSelectedMainAgentForGateway = useUiStore((s) => s.setSelectedMainAgentForGateway);
+  const updatePending = useTaskStore((s) => s.updatePending);
+
+  if (!defaultGatewayId || !catalog?.agents.length) return null;
+
+  const selectedId = selectedMainAgentByGateway[defaultGatewayId] || catalog.defaultId || catalog.agents[0]?.id || '';
+  const selected = catalog.agents.find((agent) => agent.id === selectedId) ?? catalog.agents[0];
+  if (!selected) return null;
+
+  const handleSelect = (agent: AgentInfo): void => {
+    setSelectedMainAgentForGateway(defaultGatewayId, agent.id);
+    const pending = useTaskStore.getState().pendingNewTask;
+    if (pending?.gatewayId === defaultGatewayId && !pending.ensemble && !pending.teamId) {
+      updatePending({ agentId: agent.id });
+    }
+    void syncFromGateway({ gatewayId: defaultGatewayId, agentId: agent.id, workspace: agent.workspace }).catch((err) =>
+      console.warn('[left-nav] sync selected main agent sessions failed:', err),
+    );
+  };
+
+  const label = agentLabel(selected, selected.id);
+  const secondaryLabel = selected.workspace ? (selected.name ?? selected.id) : selected.id;
+  const triggerClass = collapsed
+    ? 'titlebar-no-drag flex h-8 w-8 items-center justify-center rounded-md text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] focus-visible:outline-none glow-focus'
+    : 'titlebar-no-drag flex min-w-0 w-full items-center gap-2 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-2.5 py-2 text-left transition-colors hover:border-[var(--text-muted)] focus-visible:outline-none glow-focus';
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button className={triggerClass} aria-label={t('leftNav.mainWorkspace', { defaultValue: 'Main workspace' })}>
+              <AgentIcon
+                gatewayId={defaultGatewayId}
+                agentId={selected.id}
+                gatewayAvatarUrl={selected.identity?.avatarUrl}
+                emoji={selected.identity?.emoji}
+                imgClass="h-4 w-4 rounded-full object-cover"
+                emojiClass="emoji-sm"
+                iconSize={collapsed ? 16 : 14}
+              />
+              {!collapsed && (
+                <>
+                  <span className="min-w-0 flex-1">
+                    <span className="type-label block truncate text-[var(--text-primary)]">{label}</span>
+                    <span className="type-support block truncate text-[var(--text-muted)]">{secondaryLabel}</span>
+                  </span>
+                  <ChevronDown size={13} className="flex-shrink-0 text-[var(--text-muted)]" />
+                </>
+              )}
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side={collapsed ? 'right' : 'top'}>
+          {t('leftNav.mainWorkspace', { defaultValue: 'Main workspace' })}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align={collapsed ? 'start' : 'end'} side={collapsed ? 'right' : 'top'} className="w-72">
+        {catalog.agents.map((agent) => {
+          const selectedAgent = agent.id === selected.id;
+          return (
+            <DropdownMenuItem
+              key={agent.id}
+              onClick={() => handleSelect(agent)}
+              className={cn(selectedAgent && 'text-[var(--accent)]')}
+            >
+              <AgentIcon
+                gatewayId={defaultGatewayId}
+                agentId={agent.id}
+                gatewayAvatarUrl={agent.identity?.avatarUrl}
+                emoji={agent.identity?.emoji}
+                imgClass="h-4 w-4 rounded-full object-cover"
+                emojiClass="emoji-sm"
+                iconSize={14}
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate">{agentLabel(agent, agent.id)}</span>
+                <span className="type-support block truncate text-[var(--text-muted)]">
+                  {agent.workspace ? (agent.name ?? agent.id) : agent.id}
+                </span>
+              </span>
+              {selectedAgent && <Check size={13} className="ml-auto flex-shrink-0" />}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
 export default function LeftNav() {
   const { t } = useTranslation();
@@ -435,6 +551,8 @@ export default function LeftNav() {
 
         <div className="w-6 h-px bg-[var(--border)]" />
 
+        <MainAgentWorkspaceSelector collapsed />
+
         <div className="flex flex-col items-center gap-0.5">
           <IconButton
             icon={Clock}
@@ -563,6 +681,9 @@ export default function LeftNav() {
       </div>
 
       <div className="flex-shrink-0 px-3" style={{ paddingBottom: 'calc(var(--density-panel-gap) / 4)' }}>
+        <div className="mb-2">
+          <MainAgentWorkspaceSelector />
+        </div>
         <NavButton
           icon={Clock}
           label={t('leftNav.scheduledTasks')}

--- a/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
+++ b/packages/desktop/src/renderer/layouts/LeftNav/index.tsx
@@ -171,6 +171,41 @@ function agentLabel(agent: AgentInfo | undefined, fallbackId: string): string {
   return basename(agent.workspace) || agent.name || fallbackId;
 }
 
+const startupSyncedMainAgentKeys = new Set<string>();
+
+function mainAgentSyncKey(gatewayId: string, agent: AgentInfo): string {
+  return `${gatewayId}:${agent.id}:${agent.workspace ?? ''}`;
+}
+
+function syncMainAgentSessions(gatewayId: string, agent: AgentInfo): void {
+  void syncFromGateway({ gatewayId, agentId: agent.id, workspace: agent.workspace }).catch((err) =>
+    console.warn('[left-nav] sync selected main agent sessions failed:', err),
+  );
+}
+
+function useStartupMainAgentSessionSync(): void {
+  const defaultGatewayId = useUiStore((s) => s.defaultGatewayId);
+  const catalog = useUiStore((s) => (defaultGatewayId ? s.agentCatalogByGateway[defaultGatewayId] : undefined));
+  const selectedMainAgentByGateway = useUiStore((s) => s.selectedMainAgentByGateway);
+  const gwStatusMap = useUiStore((s) => s.gatewayStatusMap);
+
+  useEffect(() => {
+    if (!defaultGatewayId || gwStatusMap[defaultGatewayId] !== 'connected') return;
+
+    const selectedId = selectedMainAgentByGateway[defaultGatewayId];
+    if (!selectedId || !catalog?.agents.length) return;
+
+    const selected = catalog.agents.find((agent) => agent.id === selectedId);
+    if (!selected) return;
+
+    const syncKey = mainAgentSyncKey(defaultGatewayId, selected);
+    if (startupSyncedMainAgentKeys.has(syncKey)) return;
+
+    startupSyncedMainAgentKeys.add(syncKey);
+    syncMainAgentSessions(defaultGatewayId, selected);
+  }, [catalog, defaultGatewayId, gwStatusMap, selectedMainAgentByGateway]);
+}
+
 function MainAgentWorkspaceSelector({ collapsed }: { collapsed?: boolean }) {
   const { t } = useTranslation();
   const defaultGatewayId = useUiStore((s) => s.defaultGatewayId);
@@ -181,9 +216,8 @@ function MainAgentWorkspaceSelector({ collapsed }: { collapsed?: boolean }) {
 
   if (!defaultGatewayId || !catalog?.agents.length) return null;
 
-  const selectedId = selectedMainAgentByGateway[defaultGatewayId] || catalog.defaultId || catalog.agents[0]?.id || '';
-  const selected = catalog.agents.find((agent) => agent.id === selectedId) ?? catalog.agents[0];
-  if (!selected) return null;
+  const selectedId = selectedMainAgentByGateway[defaultGatewayId] || '';
+  const selected = selectedId ? catalog.agents.find((agent) => agent.id === selectedId) : undefined;
 
   const handleSelect = (agent: AgentInfo): void => {
     setSelectedMainAgentForGateway(defaultGatewayId, agent.id);
@@ -191,13 +225,17 @@ function MainAgentWorkspaceSelector({ collapsed }: { collapsed?: boolean }) {
     if (pending?.gatewayId === defaultGatewayId && !pending.ensemble && !pending.teamId) {
       updatePending({ agentId: agent.id });
     }
-    void syncFromGateway({ gatewayId: defaultGatewayId, agentId: agent.id, workspace: agent.workspace }).catch((err) =>
-      console.warn('[left-nav] sync selected main agent sessions failed:', err),
-    );
+    syncMainAgentSessions(defaultGatewayId, agent);
   };
 
-  const label = agentLabel(selected, selected.id);
-  const secondaryLabel = selected.workspace ? (selected.name ?? selected.id) : selected.id;
+  const label = selected
+    ? agentLabel(selected, selected.id)
+    : t('leftNav.selectMainWorkspace', { defaultValue: 'Select workspace' });
+  const secondaryLabel = selected
+    ? selected.workspace
+      ? (selected.name ?? selected.id)
+      : selected.id
+    : t('leftNav.noMainWorkspaceSelected', { defaultValue: 'No main workspace selected' });
   const triggerClass = collapsed
     ? 'titlebar-no-drag flex h-8 w-8 items-center justify-center rounded-md text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] focus-visible:outline-none glow-focus'
     : 'titlebar-no-drag flex min-w-0 w-full items-center gap-2 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-2.5 py-2 text-left transition-colors hover:border-[var(--text-muted)] focus-visible:outline-none glow-focus';
@@ -208,15 +246,19 @@ function MainAgentWorkspaceSelector({ collapsed }: { collapsed?: boolean }) {
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <button className={triggerClass} aria-label={t('leftNav.mainWorkspace', { defaultValue: 'Main workspace' })}>
-              <AgentIcon
-                gatewayId={defaultGatewayId}
-                agentId={selected.id}
-                gatewayAvatarUrl={selected.identity?.avatarUrl}
-                emoji={selected.identity?.emoji}
-                imgClass="h-4 w-4 rounded-full object-cover"
-                emojiClass="emoji-sm"
-                iconSize={collapsed ? 16 : 14}
-              />
+              {selected ? (
+                <AgentIcon
+                  gatewayId={defaultGatewayId}
+                  agentId={selected.id}
+                  gatewayAvatarUrl={selected.identity?.avatarUrl}
+                  emoji={selected.identity?.emoji}
+                  imgClass="h-4 w-4 rounded-full object-cover"
+                  emojiClass="emoji-sm"
+                  iconSize={collapsed ? 16 : 14}
+                />
+              ) : (
+                <FolderOpen size={collapsed ? 16 : 14} className="flex-shrink-0 text-[var(--text-muted)]" />
+              )}
               {!collapsed && (
                 <>
                   <span className="min-w-0 flex-1">
@@ -235,7 +277,7 @@ function MainAgentWorkspaceSelector({ collapsed }: { collapsed?: boolean }) {
       </Tooltip>
       <DropdownMenuContent align={collapsed ? 'start' : 'end'} side={collapsed ? 'right' : 'top'} className="w-72">
         {catalog.agents.map((agent) => {
-          const selectedAgent = agent.id === selected.id;
+          const selectedAgent = agent.id === selected?.id;
           return (
             <DropdownMenuItem
               key={agent.id}
@@ -268,6 +310,7 @@ function MainAgentWorkspaceSelector({ collapsed }: { collapsed?: boolean }) {
 
 export default function LeftNav() {
   const { t } = useTranslation();
+  useStartupMainAgentSessionSync();
   const tasks = useTaskStore((s) => s.tasks);
   const activeTaskId = useTaskStore((s) => s.activeTaskId);
   const startNewTask = useTaskStore((s) => s.startNewTask);

--- a/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Bot, Sparkles, Users, Compass } from 'lucide-react';
+import { Sparkles, Users, Compass, type LucideIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Team } from '@clawwork/shared';
 import { useTaskStore } from '@/stores/taskStore';
@@ -199,8 +199,7 @@ export default function WelcomeScreen() {
   }, [setMainView]);
 
   const visibleTabs = useMemo(() => {
-    const all: { id: WelcomeTab; label: string; icon: typeof Bot; visible: boolean }[] = [
-      { id: 'agent', label: t('mainArea.tabAgent'), icon: Bot, visible: true },
+    const all: { id: WelcomeTab; label: string; icon: LucideIcon; visible: boolean }[] = [
       { id: 'team', label: t('mainArea.tabTeam'), icon: Users, visible: true },
       {
         id: 'orchestrate',
@@ -277,7 +276,7 @@ function TabButton({
   onSelectTab,
 }: {
   active: boolean;
-  icon: typeof Bot;
+  icon: LucideIcon;
   label: string;
   onSelectTab: () => void;
 }) {

--- a/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
@@ -8,7 +8,7 @@ import { useTeamStore } from '@/stores/teamStore';
 import { cn } from '@/lib/utils';
 import { motion as animationPresets } from '@/styles/design-tokens';
 import { motion } from 'framer-motion';
-import { useGatewaySelector } from '@/hooks/useGatewaySelector';
+import { fetchAgentsForGateway } from '@/hooks/useGatewayBootstrap';
 import GatewayInstanceSelector from '@/components/GatewayInstanceSelector';
 import logo from '@/assets/logo.png';
 
@@ -17,6 +17,10 @@ type WelcomeTab = 'agent' | 'team' | 'orchestrate';
 export default function WelcomeScreen() {
   const { t } = useTranslation();
   const setMainView = useUiStore((s) => s.setMainView);
+  const gatewayInfoMap = useUiStore((s) => s.gatewayInfoMap);
+  const defaultGatewayId = useUiStore((s) => s.defaultGatewayId);
+  const agentCatalogByGateway = useUiStore((s) => s.agentCatalogByGateway);
+  const selectedMainAgentByGateway = useUiStore((s) => s.selectedMainAgentByGateway);
   const pendingNewTask = useTaskStore((s) => s.pendingNewTask);
   const activeTaskId = useTaskStore((s) => s.activeTaskId);
   const activeTaskEnsemble = useTaskStore((s) => {
@@ -35,18 +39,19 @@ export default function WelcomeScreen() {
   const loadTeams = useTeamStore((s) => s.loadTeams);
 
   const teams = useMemo(() => Object.values(teamsMap), [teamsMap]);
-  const {
-    gateways,
-    selectedGwId,
-    setSelectedGwId,
-    agentCatalog,
-    defaultAgentId,
-    effectiveAgentId,
-    hasMultipleAgents,
-  } = useGatewaySelector({
-    initialGatewayId: pendingNewTask?.gatewayId,
-    initialAgentId: pendingNewTask?.agentId,
-  });
+  const gateways = useMemo(() => Object.values(gatewayInfoMap), [gatewayInfoMap]);
+  const [selectedGwId, setSelectedGwId] = useState(
+    pendingNewTask?.gatewayId ?? defaultGatewayId ?? gateways[0]?.id ?? '',
+  );
+  const gwAgents = agentCatalogByGateway[selectedGwId];
+  const agentCatalog = useMemo(() => gwAgents?.agents ?? [], [gwAgents]);
+  const defaultAgentId = gwAgents?.defaultId ?? agentCatalog[0]?.id ?? '';
+  const selectedMainAgentId = selectedMainAgentByGateway[selectedGwId] || '';
+  const effectiveAgentId = useMemo(
+    () => (agentCatalog.some((agent) => agent.id === selectedMainAgentId) ? selectedMainAgentId : defaultAgentId),
+    [agentCatalog, defaultAgentId, selectedMainAgentId],
+  );
+  const hasMultipleAgents = agentCatalog.length > 1;
 
   const [activeTab, setActiveTab] = useState<WelcomeTab>(() => {
     const ensemble = activeTaskEnsemble ?? pendingNewTask?.ensemble;
@@ -67,6 +72,20 @@ export default function WelcomeScreen() {
   useEffect(() => {
     loadTeams();
   }, [loadTeams]);
+
+  useEffect(() => {
+    if (!gateways.length) return;
+    if (gateways.some((gw) => gw.id === selectedGwId)) return;
+    const fallback =
+      defaultGatewayId && gateways.some((gw) => gw.id === defaultGatewayId)
+        ? defaultGatewayId
+        : (gateways[0]?.id ?? '');
+    if (fallback && fallback !== selectedGwId) setSelectedGwId(fallback);
+  }, [defaultGatewayId, gateways, selectedGwId]);
+
+  useEffect(() => {
+    if (selectedGwId) fetchAgentsForGateway(selectedGwId);
+  }, [selectedGwId]);
 
   useEffect(() => {
     if (activeTab === 'agent') {

--- a/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
+++ b/packages/desktop/src/renderer/layouts/MainArea/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Bot, ChevronRight, Sparkles, Users, Compass } from 'lucide-react';
+import { Bot, Sparkles, Users, Compass } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Team } from '@clawwork/shared';
 import { useTaskStore } from '@/stores/taskStore';
@@ -8,7 +8,6 @@ import { useTeamStore } from '@/stores/teamStore';
 import { cn } from '@/lib/utils';
 import { motion as animationPresets } from '@/styles/design-tokens';
 import { motion } from 'framer-motion';
-import AgentIcon from '@/components/AgentIcon';
 import { useGatewaySelector } from '@/hooks/useGatewaySelector';
 import GatewayInstanceSelector from '@/components/GatewayInstanceSelector';
 import logo from '@/assets/logo.png';
@@ -43,7 +42,6 @@ export default function WelcomeScreen() {
     agentCatalog,
     defaultAgentId,
     effectiveAgentId,
-    setSelectedAgentId,
     hasMultipleAgents,
   } = useGatewaySelector({
     initialGatewayId: pendingNewTask?.gatewayId,
@@ -61,8 +59,6 @@ export default function WelcomeScreen() {
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(
     pendingNewTask?.teamId ?? activeTaskTeamId ?? null,
   );
-  const [agentExpanded, setAgentExpanded] = useState(false);
-
   const teamsForSelectedGateway = useMemo(
     () => teams.filter((team) => team.gatewayId === selectedGwId),
     [teams, selectedGwId],
@@ -171,10 +167,8 @@ export default function WelcomeScreen() {
   const handleSelectGateway = useCallback(
     (gwId: string) => {
       setSelectedGwId(gwId);
-      setSelectedAgentId('');
-      setAgentExpanded(false);
     },
-    [setSelectedAgentId, setSelectedGwId],
+    [setSelectedGwId],
   );
 
   const handleSelectTeam = useCallback((teamId: string) => {
@@ -184,10 +178,6 @@ export default function WelcomeScreen() {
   const handleBrowseHub = useCallback(() => {
     setMainView('teams');
   }, [setMainView]);
-
-  const MAX_VISIBLE = 3;
-  const visibleAgents = agentExpanded ? agentCatalog : agentCatalog.slice(0, MAX_VISIBLE);
-  const hiddenAgentCount = agentCatalog.length - MAX_VISIBLE;
 
   const visibleTabs = useMemo(() => {
     const all: { id: WelcomeTab; label: string; icon: typeof Bot; visible: boolean }[] = [
@@ -236,21 +226,6 @@ export default function WelcomeScreen() {
         />
 
         <div className="mt-4">
-          {activeTab === 'agent' && (
-            <AgentTabContent
-              agents={visibleAgents}
-              selectedAgentId={effectiveAgentId}
-              selectedGwId={selectedGwId}
-              hiddenCount={hiddenAgentCount}
-              expanded={agentExpanded}
-              onSelect={(id) => {
-                setSelectedAgentId(id);
-                setAgentExpanded(false);
-              }}
-              onExpand={() => setAgentExpanded(true)}
-            />
-          )}
-
           {activeTab === 'team' && (
             <TeamTabContent
               teams={teamsForSelectedGateway}
@@ -299,64 +274,6 @@ function TabButton({
       <Icon size={15} />
       <span>{label}</span>
     </button>
-  );
-}
-
-function AgentTabContent({
-  agents,
-  selectedAgentId,
-  selectedGwId,
-  hiddenCount,
-  expanded,
-  onSelect,
-  onExpand,
-}: {
-  agents: { id: string; name?: string; identity?: { emoji?: string; avatarUrl?: string } }[];
-  selectedAgentId: string;
-  selectedGwId: string;
-  hiddenCount: number;
-  expanded: boolean;
-  onSelect: (id: string) => void;
-  onExpand: () => void;
-}) {
-  if (agents.length === 0) return null;
-
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-2">
-      {agents.map((agent) => (
-        <button
-          key={agent.id}
-          onClick={() => onSelect(agent.id)}
-          className={cn(
-            'type-label inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 transition-all cursor-pointer',
-            'border',
-            agent.id === selectedAgentId
-              ? 'border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--accent)]'
-              : 'border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--text-muted)] hover:text-[var(--text-primary)]',
-          )}
-        >
-          <AgentIcon
-            gatewayId={selectedGwId}
-            agentId={agent.id}
-            gatewayAvatarUrl={agent.identity?.avatarUrl}
-            emoji={agent.identity?.emoji}
-            imgClass="w-3.5 h-3.5 rounded-full object-cover"
-            emojiClass="emoji-sm"
-            iconSize={12}
-          />
-          <span className="max-w-24 truncate">{agent.name ?? agent.id}</span>
-        </button>
-      ))}
-      {!expanded && hiddenCount > 0 && (
-        <button
-          onClick={onExpand}
-          className="type-support inline-flex items-center gap-0.5 rounded-full px-2.5 py-1.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors cursor-pointer"
-        >
-          +{hiddenCount}
-          <ChevronRight size={10} />
-        </button>
-      )}
-    </div>
   );
 }
 

--- a/packages/desktop/src/renderer/platform/index.ts
+++ b/packages/desktop/src/renderer/platform/index.ts
@@ -80,7 +80,8 @@ const taskStoreApi = createTaskStore({
   getDefaultGatewayId: () => uiStoreApi.getState().defaultGatewayId,
   getAgentCatalog: (gatewayId) => {
     const entry = uiStoreApi.getState().agentCatalogByGateway[gatewayId];
-    return entry ? { agents: entry.agents, defaultId: entry.defaultId } : { agents: [], defaultId: null };
+    const selected = uiStoreApi.getState().getSelectedMainAgentId(gatewayId);
+    return entry ? { agents: entry.agents, defaultId: selected ?? entry.defaultId } : { agents: [], defaultId: null };
   },
   onTaskCreated: () => uiStoreApi.getState().setMainView('chat'),
 });

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -11,6 +11,7 @@ const patchConfigMock = vi.fn();
 const getConfigSchemaMock = vi.fn();
 const lookupConfigSchemaMock = vi.fn();
 const getChatHistoryMock = vi.fn();
+const listSessionsMock = vi.fn();
 const listSessionsBySpawnerMock = vi.fn();
 
 const fakeGatewayClient = {
@@ -25,6 +26,7 @@ const fakeGatewayClient = {
   getConfigSchema: getConfigSchemaMock,
   lookupConfigSchema: lookupConfigSchemaMock,
   getChatHistory: getChatHistoryMock,
+  listSessions: listSessionsMock,
   listSessionsBySpawner: listSessionsBySpawnerMock,
 };
 
@@ -49,16 +51,24 @@ vi.mock('../src/main/workspace/config.js', () => ({
 }));
 
 vi.mock('../src/main/debug/index.js', () => ({
-  getDebugLogger: vi.fn(() => ({ emit: vi.fn() })),
+  getDebugLogger: vi.fn(() => ({ emit: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
 }));
 
 vi.mock('@clawwork/shared', () => ({
   isClawWorkSession: vi.fn(() => true),
-  parseTaskIdFromSessionKey: vi.fn(() => 'task-1'),
+  isSubagentSession: vi.fn((key: string) => key.includes(':subagent:')),
+  isSystemSession: vi.fn((key: string) => key.includes(':system:')),
+  parseTaskIdFromSessionKey: vi.fn((key: string) => (key.includes('clawwork:task:') ? 'task-1' : null)),
   parseAgentIdFromSessionKey: vi.fn(() => 'main'),
 }));
 
 vi.mock('@clawwork/core', () => ({
+  normalizeContentBlocks: vi.fn((blocks) => ({
+    content: blocks
+      .filter((block: { type?: string; text?: string }) => block.type === 'text' && block.text)
+      .map((block: { text: string }) => block.text)
+      .join(''),
+  })),
   parseToolArgs: vi.fn(() => ({})),
 }));
 
@@ -73,6 +83,8 @@ describe('ws-handlers: skills + config IPC channels', () => {
     handleMap.clear();
     vi.clearAllMocks();
     getChatHistoryMock.mockReset();
+    listSessionsMock.mockReset();
+    listSessionsBySpawnerMock.mockReset();
     fakeGatewayClient.isConnected = true;
 
     vi.resetModules();
@@ -356,6 +368,92 @@ describe('ws-handlers: skills + config IPC channels', () => {
 
       expect(lookupConfigSchemaMock).toHaveBeenCalledWith('model');
       expect(result).toEqual({ ok: true, result: lookupResult });
+    });
+  });
+
+  describe('ws:sync-sessions', () => {
+    it('passes selected agent list parameters and imports native OpenClaw sessions', async () => {
+      listSessionsMock.mockResolvedValue({
+        sessions: [
+          {
+            key: 'openclaw:session:abc',
+            agentId: 'agent-a',
+            updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
+            label: 'Native OpenClaw session',
+          },
+        ],
+      });
+      getChatHistoryMock.mockResolvedValue({
+        messages: [
+          {
+            role: 'user',
+            timestamp: Date.parse('2026-04-02T09:59:00.000Z'),
+            content: [{ type: 'text', text: 'hello from openclaw' }],
+          },
+        ],
+      });
+
+      const result = (await invoke('ws:sync-sessions', {
+        gatewayId: 'gw-1',
+        agentId: 'agent-a',
+        workspace: 'C:\\work',
+      })) as {
+        ok: boolean;
+        discovered?: Array<{ taskId: string; sessionKey: string; agentId: string; title: string }>;
+      };
+
+      expect(listSessionsMock).toHaveBeenCalledWith({
+        agentId: 'agent-a',
+        includeGlobal: true,
+        includeUnknown: true,
+        includeDerivedTitles: true,
+        includeLastMessage: true,
+      });
+      expect(getChatHistoryMock).toHaveBeenCalledWith('openclaw:session:abc', 200);
+      expect(result.ok).toBe(true);
+      expect(result.discovered).toEqual([
+        expect.objectContaining({
+          taskId: expect.stringMatching(/^native-[a-f0-9]{24}$/),
+          sessionKey: 'openclaw:session:abc',
+          agentId: 'agent-a',
+          title: 'Native OpenClaw session',
+        }),
+      ]);
+    });
+
+    it('does not import spawned, system, or subagent sessions', async () => {
+      listSessionsMock.mockResolvedValue({
+        sessions: [
+          {
+            key: 'openclaw:session:spawned',
+            spawnedBy: 'openclaw:session:parent',
+            updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
+          },
+          {
+            key: 'agent:agent-a:clawwork:system:setup:1',
+            updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
+          },
+          {
+            key: 'agent:agent-a:clawwork:subagent:child',
+            updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
+          },
+        ],
+      });
+
+      const result = (await invoke('ws:sync-sessions', { gatewayId: 'gw-1', agentId: 'agent-a' })) as {
+        ok: boolean;
+        discovered?: unknown[];
+      };
+
+      expect(listSessionsMock).toHaveBeenCalledWith({
+        agentId: 'agent-a',
+        includeGlobal: true,
+        includeUnknown: true,
+        includeDerivedTitles: true,
+        includeLastMessage: true,
+      });
+      expect(getChatHistoryMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: true, discovered: [] });
     });
   });
 

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -416,6 +416,69 @@ describe('ws-handlers: skills + config IPC channels', () => {
       ]);
     });
 
+    it('imports sessions when the gateway returns a bare array payload', async () => {
+      listSessionsMock.mockResolvedValue([
+        {
+          sessionKey: 'agent:agent-b:main',
+          title: 'Bare array session',
+          updatedAt: 1_775_120_400,
+        },
+      ]);
+      getChatHistoryMock.mockResolvedValue({
+        messages: [
+          {
+            role: 'user',
+            ts: 1_775_120_399,
+            content: 'string chat history content',
+          },
+        ],
+      });
+
+      const result = (await invoke('ws:sync-sessions', { gatewayId: 'gw-1', agentId: 'agent-b' })) as {
+        ok: boolean;
+        discovered?: Array<{ sessionKey: string; agentId: string; title: string; messages: Array<{ content: string }> }>;
+      };
+
+      expect(listSessionsMock).toHaveBeenCalledWith({ agentId: 'agent-b' });
+      expect(getChatHistoryMock).toHaveBeenCalledWith('agent:agent-b:main', 200);
+      expect(result.ok).toBe(true);
+      expect(result.discovered).toEqual([
+        expect.objectContaining({
+          sessionKey: 'agent:agent-b:main',
+          agentId: 'agent-b',
+          title: 'Bare array session',
+          messages: [expect.objectContaining({ content: 'string chat history content' })],
+        }),
+      ]);
+    });
+
+    it('imports sessions when the gateway returns an object keyed by session id', async () => {
+      listSessionsMock.mockResolvedValue({
+        'agent:agent-c:main': {
+          displayName: 'Mapped session',
+          updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
+        },
+        count: 1,
+        path: '/tmp/openclaw-sessions.json',
+      });
+      getChatHistoryMock.mockResolvedValue({ messages: [] });
+
+      const result = (await invoke('ws:sync-sessions', { gatewayId: 'gw-1', agentId: 'agent-c' })) as {
+        ok: boolean;
+        discovered?: Array<{ sessionKey: string; agentId: string; title: string }>;
+      };
+
+      expect(getChatHistoryMock).toHaveBeenCalledWith('agent:agent-c:main', 200);
+      expect(result.ok).toBe(true);
+      expect(result.discovered).toEqual([
+        expect.objectContaining({
+          sessionKey: 'agent:agent-c:main',
+          agentId: 'agent-c',
+          title: 'Mapped session',
+        }),
+      ]);
+    });
+
     it('does not import spawned, system, or subagent sessions', async () => {
       listSessionsMock.mockResolvedValue({
         sessions: [

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -485,7 +485,7 @@ describe('ws-handlers: skills + config IPC channels', () => {
           {
             key: 'agent:agent-a:cron:nightly',
             agentId: 'agent-a',
-            title: 'Cron：daily backup',
+            title: 'Cron\uFF1Adaily backup',
             updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
           },
         ],
@@ -503,7 +503,7 @@ describe('ws-handlers: skills + config IPC channels', () => {
     it('imports dashboard sessions and continues when history is unavailable', async () => {
       listSessionsMock.mockResolvedValue({
         'dashboard:agent-a:overview': {
-          title: 'dashboard：overview',
+          title: 'dashboard\uFF1Aoverview',
           updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
         },
       });
@@ -520,10 +520,32 @@ describe('ws-handlers: skills + config IPC channels', () => {
         expect.objectContaining({
           sessionKey: 'dashboard:agent-a:overview',
           agentId: 'agent-a',
-          title: 'dashboard：overview',
+          title: 'dashboard\uFF1Aoverview',
           messages: [],
         }),
       ]);
+    });
+
+    it('does not import metadata or empty placeholder sessions for agents without conversations', async () => {
+      listSessionsMock.mockResolvedValue({
+        sessions: {
+          global: {},
+          main: {},
+          defaults: { mainSessionKey: 'agent:empty-agent:main' },
+          'agent:empty-agent:main': {
+            updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
+          },
+        },
+      });
+      getChatHistoryMock.mockResolvedValue({ messages: [] });
+
+      const result = (await invoke('ws:sync-sessions', { gatewayId: 'gw-1', agentId: 'empty-agent' })) as {
+        ok: boolean;
+        discovered?: unknown[];
+      };
+
+      expect(getChatHistoryMock).toHaveBeenCalledWith('agent:empty-agent:main', 200);
+      expect(result).toEqual({ ok: true, discovered: [] });
     });
 
     it('does not import spawned, system, or subagent sessions', async () => {

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -479,6 +479,53 @@ describe('ws-handlers: skills + config IPC channels', () => {
       ]);
     });
 
+    it('skips scheduled cron sessions by title prefix', async () => {
+      listSessionsMock.mockResolvedValue({
+        sessions: [
+          {
+            key: 'agent:agent-a:cron:nightly',
+            agentId: 'agent-a',
+            title: 'Cron：daily backup',
+            updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
+          },
+        ],
+      });
+      getChatHistoryMock.mockResolvedValue({ messages: [] });
+
+      const result = (await invoke('ws:sync-sessions', { gatewayId: 'gw-1', agentId: 'agent-a' })) as {
+        ok: boolean;
+        discovered?: unknown[];
+      };
+
+      expect(result).toEqual({ ok: true, discovered: [] });
+    });
+
+    it('imports dashboard sessions and continues when history is unavailable', async () => {
+      listSessionsMock.mockResolvedValue({
+        'dashboard:agent-a:overview': {
+          title: 'dashboard：overview',
+          updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
+        },
+      });
+      getChatHistoryMock.mockRejectedValue(new Error('history unavailable'));
+
+      const result = (await invoke('ws:sync-sessions', { gatewayId: 'gw-1', agentId: 'agent-a' })) as {
+        ok: boolean;
+        discovered?: Array<{ sessionKey: string; agentId: string; title: string; messages: unknown[] }>;
+      };
+
+      expect(getChatHistoryMock).toHaveBeenCalledWith('dashboard:agent-a:overview', 200);
+      expect(result.ok).toBe(true);
+      expect(result.discovered).toEqual([
+        expect.objectContaining({
+          sessionKey: 'dashboard:agent-a:overview',
+          agentId: 'agent-a',
+          title: 'dashboard：overview',
+          messages: [],
+        }),
+      ]);
+    });
+
     it('does not import spawned, system, or subagent sessions', async () => {
       listSessionsMock.mockResolvedValue({
         sessions: [

--- a/packages/desktop/test/ws-handlers-skills-config.test.ts
+++ b/packages/desktop/test/ws-handlers-skills-config.test.ts
@@ -378,6 +378,7 @@ describe('ws-handlers: skills + config IPC channels', () => {
           {
             key: 'openclaw:session:abc',
             agentId: 'agent-a',
+            workspace: '/mnt/c/remote/work',
             updatedAt: Date.parse('2026-04-02T10:00:00.000Z'),
             label: 'Native OpenClaw session',
           },
@@ -402,13 +403,7 @@ describe('ws-handlers: skills + config IPC channels', () => {
         discovered?: Array<{ taskId: string; sessionKey: string; agentId: string; title: string }>;
       };
 
-      expect(listSessionsMock).toHaveBeenCalledWith({
-        agentId: 'agent-a',
-        includeGlobal: true,
-        includeUnknown: true,
-        includeDerivedTitles: true,
-        includeLastMessage: true,
-      });
+      expect(listSessionsMock).toHaveBeenCalledWith({ agentId: 'agent-a' });
       expect(getChatHistoryMock).toHaveBeenCalledWith('openclaw:session:abc', 200);
       expect(result.ok).toBe(true);
       expect(result.discovered).toEqual([
@@ -445,13 +440,7 @@ describe('ws-handlers: skills + config IPC channels', () => {
         discovered?: unknown[];
       };
 
-      expect(listSessionsMock).toHaveBeenCalledWith({
-        agentId: 'agent-a',
-        includeGlobal: true,
-        includeUnknown: true,
-        includeDerivedTitles: true,
-        includeLastMessage: true,
-      });
+      expect(listSessionsMock).toHaveBeenCalledWith({ agentId: 'agent-a' });
       expect(getChatHistoryMock).not.toHaveBeenCalled();
       expect(result).toEqual({ ok: true, discovered: [] });
     });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -5,6 +5,7 @@ const CLAWWORK_DEVICE_SESSION_RE = /^agent:([^:]+):clawwork:([^:]+):task:(.+)$/;
 const CLAWWORK_SESSION_RE = /^agent:([^:]+):clawwork:task:(.+)$/;
 const LEGACY_SESSION_KEY_RE = /^agent:[^:]+:task-(.+)$/;
 const SUBAGENT_SESSION_RE = /^agent:([^:]+):subagent:([a-f0-9-]+)$/;
+const GENERIC_AGENT_SESSION_RE = /^agent:([^:]+):/;
 
 export function buildSessionKey(taskId: string, agentId: string = 'main', deviceId?: string): string {
   if (deviceId) return `agent:${agentId}:clawwork:${deviceId}:task:${taskId}`;
@@ -29,6 +30,8 @@ export function parseAgentIdFromSessionKey(sessionKey: string): string {
   if (m) return m[1];
   const sub = sessionKey.match(SUBAGENT_SESSION_RE);
   if (sub) return sub[1];
+  const generic = sessionKey.match(GENERIC_AGENT_SESSION_RE);
+  if (generic) return generic[1];
   return 'main';
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -253,6 +253,7 @@ export interface AgentInfo {
   name?: string;
   identity?: AgentIdentity;
   model?: AgentModelInfo;
+  workspace?: string;
 }
 
 export interface AgentListResponse {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,8 @@ packages:
   - 'packages/desktop'
   - 'keynote'
   - 'website'
+allowBuilds:
+  better-sqlite3: true
+  electron: true
+  esbuild: true
+  win-ca: true


### PR DESCRIPTION
## Summary
- keep the main agent workspace selector persistent in the left nav without auto-selecting a default on first launch
- sync the remembered/selected main agent's direct OpenClaw sessions on startup and when selecting a workspace
- align selected-agent session import with OpenClaw Windows Tray: call `sessions.list` with `{ agentId }` and avoid rejecting returned sessions because of Windows/remote workspace path mismatches
- remove the new-task screen's visible `Agent` tab/button so normal tasks use the left-nav main agent selector
- localize editable context menus and add right-click Copy for selected non-editable text, including context/file preview text
- keep artifact transfer/export changes for assistant-generated files

## Verification
- `vitest run packages/desktop/test/ws-handlers-skills-config.test.ts`
- `tsc -b packages/shared packages/core`
- `tsc -p packages/desktop/tsconfig.json --noEmit`
- `electron-vite build`
- `electron-builder --win --x64`

## Windows package
- `packages/desktop/dist/ClawWork-0.0.16-win-x64.exe`
- SHA256: `3860E260BC90C9BAC519F7D669E1E94CF376596BF8E410D680FE93AFAF2C2847`