### PR TITLE
[Fix] readContextFile macOS /dev/fd fallback (Closes #381)

### DIFF
--- a/packages/desktop/src/main/context/file-reader.ts
+++ b/packages/desktop/src/main/context/file-reader.ts
@@ -10,7 +10,15 @@ export function resolveFdRealPath(fd: number, absolutePath: string): string {
   if (process.platform === 'win32') {
     return realpathSync(absolutePath);
   }
-  return realpathSync(`/dev/fd/${fd}`);
+  try {
+    const target = realpathSync(`/dev/fd/${fd}`);
+    if (!target.startsWith('/dev/fd/')) {
+      return target;
+    }
+  } catch {
+    // macOS may leave /dev/fd aliases unresolved; fall back to the opened path.
+  }
+  return realpathSync(absolutePath);
 }
 
 export function readContextFile(absolutePath: string, contextFolders: string[]): FileReadResult {

--- a/packages/desktop/test/file-reader.test.ts
+++ b/packages/desktop/test/file-reader.test.ts
@@ -177,4 +177,19 @@ describe('resolveFdRealPath', () => {
     expect(mockRealpathSync).not.toHaveBeenCalledWith(`/dev/fd/${FAKE_FD}`);
     win32Spy.mockRestore();
   });
+
+  it('falls back to absolutePath when macOS leaves /dev/fd aliases unresolved', () => {
+    const filePath = `${CONTEXT_DIR}/doc.pdf`;
+    const darwinSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    mockRealpathSync.mockImplementation(((p: string) => {
+      if (p === `/dev/fd/${FAKE_FD}`) return `/dev/fd/${FAKE_FD}`;
+      if (p === filePath) return filePath;
+      throw new Error(`unexpected path ${p}`);
+    }) as typeof realpathSync);
+
+    expect(resolveFdRealPath(FAKE_FD, filePath)).toBe(filePath);
+    expect(mockRealpathSync).toHaveBeenCalledWith(`/dev/fd/${FAKE_FD}`);
+    expect(mockRealpathSync).toHaveBeenCalledWith(filePath);
+    darwinSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

- Harden `resolveFdRealPath` so macOS `/dev/fd` aliases that stay unresolved fall back to `realpathSync(absolutePath)`, matching the pattern in `media/resolve.ts`
- Add regression test for the unresolved `/dev/fd` alias case on darwin
- Windows already skips `/dev/fd` via `resolveFdRealPath`; this completes cross-platform fd resolution parity

Closes #381

## Test plan

- [x] `cd packages/desktop && npx vitest run test/file-reader.test.ts` — 12/12 passed
- [ ] Manual on Windows: attach a context file from an allowed folder; expect content, not ENOENT