### PR TITLE
[Docs] Complete promotion plan Phase 2/3 drafts and readiness checker (Closes #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to ClawWork are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Phase 3 promotion drafts: Product Hunt, Bilibili, and YouTube scripts ([#11](https://github.com/clawwork-ai/ClawWork/issues/11))
+- Phase 2 Sspai product experience outline; Phase 3 Homebrew cask and awesome-list PR guides ([#11](https://github.com/clawwork-ai/ClawWork/issues/11))
+- `pnpm check:promotion-readiness` — validates in-repo pre-launch checklist items from the promotion plan
+
 ## [0.1.0] - TBD
 
 First public launch release. Prior `0.0.x` builds were pre-release iterations.

--- a/docs/promotion/README.md
+++ b/docs/promotion/README.md
@@ -26,19 +26,32 @@ ClawWork is to OpenClaw what GitHub Desktop is to Git — a purpose-built native
 | ------------------------------ | ------------------------------------------------------ | -------- |
 | Juejin technical article       | [juejin-outline.md](./juejin-outline.md)               | Chinese  |
 | Zhihu column                   | [zhihu-outline.md](./zhihu-outline.md)                 | Chinese  |
+| Sspai product experience       | [sspai-outline.md](./sspai-outline.md)                 | Chinese  |
 | WeChat Official Account launch | [wechat-launch-article.md](./wechat-launch-article.md) | Chinese  |
+
+## Phase 3 — video and Product Hunt
+
+| Platform     | File                                       | Language |
+| ------------ | ------------------------------------------ | -------- |
+| Product Hunt | [product-hunt.md](./product-hunt.md)       | English  |
+| Bilibili     | [bilibili-script.md](./bilibili-script.md) | Chinese  |
+| YouTube      | [youtube-script.md](./youtube-script.md)   | English  |
 
 ## Ecosystem integration
 
 | Target                      | File                                         |
 | --------------------------- | -------------------------------------------- |
 | OpenClaw docs PR content    | [openclaw-docs-pr.md](./openclaw-docs-pr.md) |
+| Awesome list PR template    | [awesome-list-pr.md](./awesome-list-pr.md)   |
+| Homebrew cask distribution  | [homebrew-cask.md](./homebrew-cask.md)       |
 | Demo recording checklist    | [demo-recording.md](./demo-recording.md)     |
 | GitHub repo topics (manual) | [github-topics.md](./github-topics.md)       |
 
 ## Before posting
 
-1. Confirm launch prep ([#6](https://github.com/clawwork-ai/ClawWork/issues/6)) is complete.
-2. Record and embed the 60-second demo GIF in README (see [demo-recording.md](./demo-recording.md)).
-3. Verify the latest release DMG/installer is on GitHub Releases.
-4. Post on all high-leverage platforms on the **same day** for maximum impact.
+1. Run `pnpm check:promotion-readiness` — validates in-repo checklist items from [#11](https://github.com/clawwork-ai/ClawWork/issues/11).
+2. Confirm launch prep ([#6](https://github.com/clawwork-ai/ClawWork/issues/6)) is complete.
+3. Record and embed the 60-second demo GIF in README (see [demo-recording.md](./demo-recording.md)).
+4. Verify the latest release DMG/installer is on GitHub Releases.
+5. Apply GitHub repo topics per [github-topics.md](./github-topics.md).
+6. Post on all high-leverage platforms on the **same day** for maximum impact.

--- a/docs/promotion/awesome-list-pr.md
+++ b/docs/promotion/awesome-list-pr.md
@@ -1,0 +1,61 @@
+# Awesome List PR Template
+
+Submit OpenClaw Desktop to curated OpenClaw ecosystem lists ([#11](https://github.com/clawwork-ai/ClawWork/issues/11), Phase 1.5 / Phase 3).
+
+---
+
+## Target repositories
+
+Search for and PR against:
+
+- `awesome-openclaw` or similar community-maintained lists
+- OpenClaw org README "Ecosystem" / "Community Tools" section (coordinate with maintainers)
+- General lists: `awesome-electron`, `awesome-local-first`, `awesome-ai-agents` (if criteria match)
+
+## PR title
+
+```
+Add OpenClaw Desktop to Desktop Clients section
+```
+
+## Entry (markdown)
+
+Add under **Desktop Clients** or **Community Tools**:
+
+```markdown
+- [OpenClaw Desktop](https://github.com/clawwork-ai/ClawWork) — Local-first desktop client with parallel tasks, real-time tool call visualization, and Git-native artifact management. macOS (Homebrew cask), Windows, Linux, and PWA. Apache-2.0.
+```
+
+## Short description (for list maintainers)
+
+OpenClaw Desktop is the purpose-built desktop workspace for OpenClaw — a three-column UI (task list, conversation, progress/artifacts) with per-task session isolation, SQLite + Git local storage, multi-gateway support, and Teams multi-agent orchestration. It replaces using Feishu/Slack/DingTalk as ad-hoc agent channels.
+
+## PR body template
+
+```markdown
+## Summary
+
+Adds OpenClaw Desktop to the Desktop Clients section.
+
+## Project details
+
+- **Repo:** https://github.com/clawwork-ai/ClawWork
+- **License:** Apache-2.0
+- **Install:** GitHub Releases; macOS via `brew tap clawwork-ai/clawwork && brew install --cask clawwork`
+- **Website:** https://clawwork-ai.github.io/ClawWork/
+
+OpenClaw Desktop is an actively maintained open-source client for the OpenClaw agent runtime, with 8-language i18n and cross-platform installers.
+
+## Checklist
+
+- [x] Project is open source with a clear license
+- [x] Project has documentation and install instructions
+- [x] Entry follows the list's existing format
+- [x] Link points to the canonical repository
+```
+
+## After merge
+
+- [ ] Verify link renders correctly on the awesome list
+- [ ] Cross-link from OpenClaw Desktop README if the list is authoritative
+- [ ] Mention inclusion in launch posts (HN, Reddit, V2EX) for social proof

--- a/docs/promotion/bilibili-script.md
+++ b/docs/promotion/bilibili-script.md
@@ -1,0 +1,68 @@
+# Bilibili Demo Video Script
+
+**Target:** 3–5 minute Chinese demo. Tracked in [#11](https://github.com/clawwork-ai/ClawWork/issues/11).
+
+**Title options:**
+
+- OpenClaw 专用桌面客户端：告别飞书聊 Agent
+- 开源 OpenClaw Desktop — 三栏工作区 + 本地 Git 产物管理
+
+**Tags:** OpenClaw, AI Agent, Electron, 开源, 本地优先, 开发者工具
+
+---
+
+## Outline (≈4 minutes)
+
+### 0:00–0:20 开场
+
+- 痛点：用飞书/钉钉和 OpenClaw Agent 聊天，多任务时上下文混乱、工具调用看不见、产物丢在历史里
+- 一句话定位：OpenClaw Desktop = OpenClaw 的专用桌面工作区
+
+### 0:20–0:50 界面总览
+
+- 展示三栏布局：左侧任务列表、中间对话、右侧进度/产物
+- 强调：每个任务独立 Session，可并行切换
+
+### 0:50–1:40 创建任务 + 对话
+
+- 新建任务，选择 Agent 和模型
+- 发送一条真实指令（建议：「写一个 Python CLI 工具」）
+- 展示流式回复和工具调用卡片展开
+
+### 1:40–2:30 产物与 Git
+
+- 右侧文件浏览器展示自动保存的代码/文件
+- 说明本地 Git 版本化 + SQLite 全文搜索
+- 快速演示搜索历史任务/消息
+
+### 2:30–3:20 进阶功能（选 2–3 个）
+
+- 多 Gateway 切换
+- 定时任务（cron）面板
+- Teams 多 Agent 编排（如有录制素材）
+
+### 3:20–3:50 安装方式
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+- 或 GitHub Releases 下载 Windows/Linux 安装包
+- PWA：https://cpwa.pages.dev
+
+### 3:50–4:10 结尾
+
+- 开源 Apache 2.0
+- GitHub 链接 + 求 Star/反馈
+- Discord 社区
+
+---
+
+## Production notes
+
+- 深色主题录制，窗口裁切干净
+- 字幕：中文为主，关键术语保留英文（OpenClaw, Gateway, Session）
+- BGM 轻快但不抢人声；音量 -18 LUFS 左右
+- 封面：三栏布局 + 大标题「OpenClaw 专用桌面客户端」
+- 简介区放 GitHub、官网、Discord 链接

--- a/docs/promotion/homebrew-cask.md
+++ b/docs/promotion/homebrew-cask.md
@@ -1,0 +1,86 @@
+# Homebrew Cask Distribution
+
+Frictionless macOS install for launch promotion ([#11](https://github.com/clawwork-ai/ClawWork/issues/11)).
+
+## Current state (custom tap)
+
+OpenClaw Desktop is available via the **clawwork-ai/clawwork** Homebrew tap:
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+The tap is updated automatically on each GitHub Release via `.github/workflows/update-homebrew.yml` and `scripts/update-homebrew-tap.sh`.
+
+## Pre-launch checklist
+
+- [ ] Verify latest release DMG assets exist for both `arm64` and `x64`
+- [ ] Confirm `brew tap clawwork-ai/clawwork && brew install --cask clawwork` works on Apple Silicon and Intel Macs
+- [ ] Update cask `desc` and `homepage` if rebranding to OpenClaw Desktop (see `RENAME-PLAN.md`)
+- [ ] Mention Homebrew install in all launch posts (drafts already include the command)
+
+## Path to Homebrew core (optional, Phase 3+)
+
+Submitting to [homebrew-cask](https://github.com/Homebrew/homebrew-cask) removes the `brew tap` step:
+
+```bash
+brew install --cask clawwork
+```
+
+### Requirements
+
+- Stable public releases with signed/notarized macOS DMG (or universal build)
+- Verifiable download URL and SHA-256 checksums per architecture
+- App passes `brew audit --cask --strict clawwork`
+- No vendor-specific install scripts that bypass Homebrew conventions
+
+### Submission steps
+
+1. Fork `Homebrew/homebrew-cask`
+2. Add `Casks/c/clawwork.rb` (or `openclaw-desktop.rb` after rename) following [cask cookbook](https://docs.brew.sh/Cask-Cookbook)
+3. Use the same `url`, `sha256`, and `app` stanza as the custom tap cask
+4. Run locally:
+
+   ```bash
+   brew audit --cask --strict clawwork
+   brew install --cask --no-quarantine clawwork
+   ```
+
+5. Open PR with title: `Add clawwork cask`
+6. Respond to maintainer feedback (notarization, livecheck, naming)
+
+### Cask template (starting point)
+
+Adapt from `scripts/update-homebrew-tap.sh` output in `clawwork-ai/homebrew-clawwork`:
+
+```ruby
+cask "clawwork" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.1.0"
+  sha256 arm:   "<arm64-sha256>",
+         intel: "<x64-sha256>"
+
+  url "https://github.com/clawwork-ai/ClawWork/releases/download/v#{version}/ClawWork-#{version}-mac-#{arch}.dmg"
+  name "OpenClaw Desktop"
+  desc "Desktop client for OpenClaw"
+  homepage "https://github.com/clawwork-ai/ClawWork"
+
+  app "ClawWork.app"
+
+  postflight do
+    system_command "xattr", args: ["-cr", "#{appdir}/ClawWork.app"]
+  end
+end
+```
+
+## Promotion copy
+
+Use in launch posts:
+
+> macOS: `brew tap clawwork-ai/clawwork && brew install --cask clawwork`
+
+After core acceptance:
+
+> macOS: `brew install --cask clawwork`

--- a/docs/promotion/product-hunt.md
+++ b/docs/promotion/product-hunt.md
@@ -1,0 +1,60 @@
+# Product Hunt Launch
+
+**Target:** v0.2+ with 5 high-quality screenshots + demo video + polished tagline. Tracked in [#11](https://github.com/clawwork-ai/ClawWork/issues/11).
+
+---
+
+## Tagline (60 chars max)
+
+The dedicated desktop workspace for OpenClaw agents
+
+## One-liner (260 chars max)
+
+OpenClaw Desktop replaces Feishu/Slack chat workarounds with a three-column workspace: parallel tasks, real-time tool calls, and Git-native artifacts — 100% local.
+
+## Description
+
+OpenClaw is a powerful self-hosted agent runtime. Chat channels were never designed for multi-task agent work.
+
+OpenClaw Desktop is the purpose-built client:
+
+- **Three-column layout** — task list, conversation, progress/artifacts panel
+- **Parallel tasks** — each task gets an isolated OpenClaw session
+- **Tool call visibility** — real-time cards with expandable details and exec approval gates
+- **Local-first artifacts** — auto-saved to a Git repo with full-text search
+- **Multi-gateway** — per-task model switching, cron tasks, Teams orchestration
+
+Stack: Electron 34, React 19, TypeScript, SQLite (Drizzle + FTS5).
+
+Available for macOS, Windows, Linux, and as a browser PWA.
+
+## Maker comment (first comment)
+
+Hi Product Hunt! 👋
+
+I built OpenClaw Desktop because running agents through Feishu/Slack breaks down fast — contexts bleed, tool calls vanish, and generated files disappear into chat history.
+
+OpenClaw Desktop treats each task as a durable workspace with its own session, artifacts, and controls. Think GitHub Desktop for Git, but for OpenClaw agents.
+
+Happy to answer questions about the Gateway protocol, local-first architecture, or why chat UIs are a bad container for agent work.
+
+## Assets checklist
+
+- [ ] 5 screenshots (1270×760 recommended): three-column layout, tool call card, file browser, Teams view, settings/gateways
+- [ ] 60-second demo video (MP4, hosted or uploaded to PH)
+- [ ] Logo/icon (240×240)
+- [ ] Gallery thumbnail (hero frame from demo)
+
+## Links
+
+- Website: https://clawwork-ai.github.io/ClawWork/
+- GitHub: https://github.com/clawwork-ai/ClawWork
+- PWA: https://cpwa.pages.dev
+- Discord: https://discord.gg/n9fCgBMgm
+
+## Launch day tips
+
+- Post Tuesday–Thursday, early US morning
+- Rally Discord/community for early upvotes and thoughtful comments
+- Reply to every comment within the first 4 hours
+- Cross-post demo video to Twitter/X with #ProductHunt

--- a/docs/promotion/sspai-outline.md
+++ b/docs/promotion/sspai-outline.md
@@ -1,0 +1,79 @@
+# Sspai Product Experience Article Outline
+
+**Title:** 本地优先的 AI 工作台：OpenClaw Desktop 使用体验
+
+**Target:** Week 2–4, product/experience audience (sspai.com)
+
+**Angle:** Product experience — not a deep technical dive. Complement the Juejin technical article and Zhihu thought piece.
+
+---
+
+## Outline
+
+### 1. 开场：Agent 能力有了，工作界面还停在聊天里
+
+- 自托管 OpenClaw 让 Agent 能调用工具、读写文件、跑 cron
+- 很多人仍用飞书/钉钉当「控制台」——能聊，但不好「干活」
+- 引出：专用桌面客户端解决的是**工作流**，不是聊天体验
+
+### 2. 第一印象：三栏工作区
+
+- 左：任务列表（并行多任务，一眼看到状态）
+- 中：对话（流式回复 + 工具调用卡片）
+- 右：进度/产物（结构化跟踪，不是聊天记录里的附件）
+- 配图：三栏截图 + 暗色主题
+
+### 3. 一个完整任务走一遍
+
+以「生成一个 Python CLI 小工具」为例（与 demo GIF 场景一致）：
+
+1. 新建任务，选 Agent/模型
+2. 发送指令，看流式回复
+3. 展开工具调用卡片（exec、文件读写）
+4. 产物自动落到本地 Git 仓库，文件浏览器可搜
+5. 切换另一个任务 — 上下文完全隔离
+
+### 4. 和飞书/Slack 通道对比（体验维度）
+
+| 维度     | 聊天通道           | OpenClaw Desktop             |
+| -------- | ------------------ | ---------------------------- |
+| 多任务   | 单线程，易串上下文 | 并行任务，Session 隔离       |
+| 工具调用 | 文本里一闪而过     | 实时卡片，可展开审批         |
+| 产物     | 历史消息里难找     | Git 版本化 + 全文搜索        |
+| 数据     | 第三方服务器       | SQLite + 本地 Git，100% 本地 |
+
+### 5. 几个日常场景
+
+- **并行开发**：同时跑前端重构 + 文档生成 + 定时报告
+- **定时任务**：cron 面板，手动触发，看运行历史
+- **多 Gateway**：不同任务连不同 OpenClaw 实例/模型
+- **Teams**：多 Agent 编排（协调者 + 执行者）
+
+### 6. 安装与上手成本
+
+- macOS：`brew tap clawwork-ai/clawwork && brew install --cask clawwork`
+- 其他平台：GitHub Releases 下载 DMG/AppImage/deb
+- PWA：浏览器打开 cpwa.pages.dev
+- 首次启动：Gateway 配对（token / 密码 / pairing code）
+
+### 7. 适合谁 / 不适合谁
+
+**适合：**
+
+- 已跑 OpenClaw，受困于聊天通道局限的开发者
+- 重视本地数据、Git 产物、多任务并行的 power user
+
+**暂不适合：**
+
+- 还没部署 OpenClaw（需要先搭 Gateway）
+- 只要单轮问答、不需要工具链和产物管理
+
+### 8. 结语
+
+- 开源地址：https://github.com/clawwork-ai/ClawWork
+- Discord 反馈：https://discord.gg/n9fCgBMgm
+- 邀请读者试用并留言使用场景
+
+**Estimated length:** 1500–2500 字
+
+**Assets needed:** 3–4 截图 + demo GIF 链接

--- a/docs/promotion/youtube-script.md
+++ b/docs/promotion/youtube-script.md
@@ -1,0 +1,73 @@
+# YouTube Demo Video Script
+
+**Target:** 3–5 minute English demo. Tracked in [#11](https://github.com/clawwork-ai/ClawWork/issues/11).
+
+**Title options:**
+
+- OpenClaw Desktop — The dedicated workspace for self-hosted AI agents
+- Stop chatting with agents in Slack — OpenClaw Desktop walkthrough
+
+**Tags:** OpenClaw, AI agents, Electron, open source, local-first, developer tools, self-hosted AI
+
+---
+
+## Outline (≈4 minutes)
+
+### 0:00–0:25 Hook
+
+- Problem: OpenClaw is powerful, but chat channels (Feishu, Slack, DingTalk) collapse under multi-task agent work
+- Solution: OpenClaw Desktop — purpose-built three-column workspace
+
+### 0:25–0:55 UI tour
+
+- Left: task list with parallel sessions
+- Center: active conversation
+- Right: progress panel + artifact browser
+- Each task = isolated OpenClaw session (`agent:main:clawwork:task:<id>`)
+
+### 0:55–1:45 Create a task
+
+- Connect to local Gateway (`ws://127.0.0.1:18789`)
+- New task → pick agent + model
+- Send prompt: "Build a small Python CLI tool"
+- Show streaming reply + expandable tool call card
+
+### 1:45–2:35 Artifacts and search
+
+- Artifact auto-saved to local Git workspace
+- File browser preview
+- Full-text search across tasks, messages, artifacts (SQLite FTS5)
+
+### 2:35–3:25 Power features (pick 2–3)
+
+- Exec approval gate on risky tool calls
+- Multi-gateway support
+- Cron/scheduled tasks
+- Teams multi-agent orchestration (if footage available)
+
+### 3:25–3:55 Install
+
+```bash
+brew tap clawwork-ai/clawwork
+brew install --cask clawwork
+```
+
+- GitHub Releases for Windows/Linux
+- Browser PWA: https://cpwa.pages.dev
+
+### 3:55–4:15 Outro
+
+- Apache 2.0, fully open source
+- GitHub + Discord links
+- Call to action: star, try it, open issues
+
+---
+
+## Production notes
+
+- Record dark theme, cropped to app window
+- Voiceover or live narration — keep pace brisk
+- Chapters in description matching outline timestamps
+- Thumbnail: three-column layout + bold text "OpenClaw Desktop"
+- Description links: GitHub, website, PWA, Discord
+- End screen: subscribe + GitHub link card

--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
     "test:e2e:smoke": "playwright test --config=e2e/playwright.config.ts --project=smoke",
     "test:e2e:gateway": "playwright test --config=e2e/playwright.config.ts --project=gateway",
     "check:i18n": "node scripts/check-i18n.mjs",
+    "check:promotion-readiness": "node scripts/check-promotion-readiness.mjs",
     "check:dead-code": "knip",
     "typecheck:e2e": "pnpm --filter @clawwork/desktop exec tsc --noEmit -p ../../e2e/tsconfig.json",
     "release-notes": "node scripts/generate-release-notes.mjs",
-    "check": "pnpm lint && pnpm check:architecture && pnpm check:ci-bot-security && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm typecheck:tests && pnpm typecheck:e2e && pnpm test"
+    "check": "pnpm lint && pnpm check:architecture && pnpm check:ci-bot-security && pnpm check:ui-contract && pnpm check:renderer-copy && pnpm check:i18n && pnpm check:promotion-readiness && pnpm check:dead-code && pnpm format:check && pnpm typecheck && pnpm typecheck:tests && pnpm typecheck:e2e && pnpm test"
   },
   "lint-staged": {
     "*.{ts,tsx,mts,cts,js,mjs,cjs}": [

--- a/scripts/check-promotion-readiness.mjs
+++ b/scripts/check-promotion-readiness.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Validates in-repo pre-launch promotion checklist items from #11.
+ * Manual steps (demo GIF recording, GitHub topics, platform posts) are reported as warnings.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const errors = [];
+const warnings = [];
+
+function fail(message) {
+  errors.push(message);
+}
+
+function warn(message) {
+  warnings.push(message);
+}
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!existsSync(absolutePath)) {
+    fail(`Missing file: ${relativePath}`);
+    return null;
+  }
+  return readFileSync(absolutePath, 'utf8');
+}
+
+const REQUIRED_PROMOTION_FILES = [
+  'docs/promotion/README.md',
+  'docs/promotion/hacker-news.md',
+  'docs/promotion/v2ex.md',
+  'docs/promotion/reddit-selfhosted.md',
+  'docs/promotion/reddit-opensource.md',
+  'docs/promotion/reddit-localllama.md',
+  'docs/promotion/twitter-thread.md',
+  'docs/promotion/jike.md',
+  'docs/promotion/juejin-outline.md',
+  'docs/promotion/zhihu-outline.md',
+  'docs/promotion/sspai-outline.md',
+  'docs/promotion/wechat-launch-article.md',
+  'docs/promotion/openclaw-docs-pr.md',
+  'docs/promotion/awesome-list-pr.md',
+  'docs/promotion/homebrew-cask.md',
+  'docs/promotion/demo-recording.md',
+  'docs/promotion/github-topics.md',
+  'docs/promotion/product-hunt.md',
+  'docs/promotion/bilibili-script.md',
+  'docs/promotion/youtube-script.md',
+];
+
+for (const file of REQUIRED_PROMOTION_FILES) {
+  if (!existsSync(path.join(root, file))) {
+    fail(`Missing promotion draft: ${file}`);
+  }
+}
+
+const readme = read('README.md');
+if (readme) {
+  if (!/Feishu\s*\/\s*DingTalk\s*\/\s*Slack/.test(readme)) {
+    fail('README.md missing channel comparison table (Feishu / DingTalk / Slack)');
+  }
+  if (!/## Demo/.test(readme)) {
+    fail('README.md missing ## Demo section');
+  }
+  if (/docs\/demo\.gif/.test(readme) && !existsSync(path.join(root, 'docs/demo.gif'))) {
+    warn('README references docs/demo.gif but file is not present yet (record per demo-recording.md)');
+  }
+}
+
+const pkgRaw = read('package.json');
+if (pkgRaw) {
+  const pkg = JSON.parse(pkgRaw);
+  if (!pkg.repository?.url) fail('package.json missing repository.url');
+  if (!pkg.homepage) fail('package.json missing homepage');
+  if (!pkg.license) fail('package.json missing license');
+}
+
+const changelog = read('CHANGELOG.md');
+if (changelog && !/\[0\.1\.0\]/.test(changelog)) {
+  fail('CHANGELOG.md missing [0.1.0] release section');
+}
+
+if (!existsSync(path.join(root, 'docs/demo.gif'))) {
+  warn('docs/demo.gif not found — record 60-second demo before launch (see docs/promotion/demo-recording.md)');
+}
+
+if (!existsSync(path.join(root, 'docs/screenshot.png'))) {
+  warn('docs/screenshot.png not found — update hero screenshot before launch');
+}
+
+if (warnings.length > 0) {
+  console.warn('Promotion readiness warnings (manual launch steps):\n');
+  for (const message of warnings) {
+    console.warn(`  ⚠ ${message}`);
+  }
+  console.warn('');
+}
+
+if (errors.length > 0) {
+  console.error('Promotion readiness check failed:\n');
+  for (const message of errors) {
+    console.error(`  ✗ ${message}`);
+  }
+  process.exit(1);
+}
+
+console.log('Promotion readiness check passed (in-repo items).');
+if (warnings.length > 0) {
+  console.log(`${warnings.length} manual step(s) still pending — see warnings above.`);
+}


### PR DESCRIPTION
## Summary

Completes remaining in-repo deliverables for the promotion plan ([#11](https://github.com/clawwork-ai/ClawWork/issues/11)) on top of the Phase 1 materials merged in #533:

- **Phase 2:** Sspai product experience article outline
- **Phase 3:** Product Hunt, Bilibili, and YouTube scripts
- **Ecosystem:** Homebrew cask distribution guide and awesome-list PR template
- **Automation:** `pnpm check:promotion-readiness` wired into `pnpm check` to validate in-repo pre-launch checklist items (manual steps like demo GIF remain warnings)

## Files changed

| File | Purpose |
|------|---------|
| `docs/promotion/sspai-outline.md` | Phase 2 Sspai article outline |
| `docs/promotion/product-hunt.md` | Product Hunt launch copy |
| `docs/promotion/bilibili-script.md` | Bilibili video script |
| `docs/promotion/youtube-script.md` | YouTube video script |
| `docs/promotion/homebrew-cask.md` | Homebrew tap + core submission guide |
| `docs/promotion/awesome-list-pr.md` | PR template for ecosystem lists |
| `docs/promotion/README.md` | Index tables for new materials |
| `scripts/check-promotion-readiness.mjs` | Validates required promotion files + README/package.json/CHANGELOG |
| `package.json` | Adds `check:promotion-readiness` to `pnpm check` |
| `CHANGELOG.md` | [Unreleased] entry |

## Test plan

- [x] `node scripts/check-promotion-readiness.mjs` — pass (2 expected warnings for missing `docs/demo.gif`)
- [x] `node scripts/check-architecture.mjs` — pass
- [x] `node scripts/check-ci-bot-security.mjs` — pass
- [x] `node scripts/check-ui-contract.mjs` — pass
- [x] `node scripts/check-renderer-copy.mjs` — pass
- [x] `node scripts/check-i18n.mjs` — pass
- [x] `eslint . --max-warnings 0` — pass
- [x] `prettier --check` on changed files — pass
- [x] `vitest run` — 545 tests pass (shared 13, core 96, desktop 375, pwa 61)
- [x] `tsc` typecheck — pass

Closes #11


Made with [Cursor](https://cursor.com)