### PR TITLE
test: expand MessageStore streaming lifecycle coverage

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,6 +100,14 @@ export type { GatewayDispatcherDeps } from './services/gateway-dispatcher.js';
 export { createChatComposer } from './services/chat-composer.js';
 export type { ChatComposerDeps, ChatComposer, SendOptions } from './services/chat-composer.js';
 
+export {
+  hasPreferencesShortcutConflict,
+  isTextInputElement,
+  resolveGlobalShortcutAction,
+  shouldDeferGlobalShortcut,
+} from './lib/global-shortcuts.js';
+export type { GlobalShortcutAction, GlobalShortcutConfig } from './lib/global-shortcuts.js';
+
 export { createSystemSessionService } from './services/system-session-service.js';
 export type { SystemSessionServiceDeps, SystemSessionService } from './services/system-session-service.js';
 

--- a/packages/core/src/lib/global-shortcuts.ts
+++ b/packages/core/src/lib/global-shortcuts.ts
@@ -1,0 +1,73 @@
+import type { PanelShortcutLeft, PanelShortcutRight } from '../stores/ui-store.js';
+
+export type GlobalShortcutAction =
+  | 'new-task'
+  | 'open-files'
+  | 'toggle-command-palette'
+  | 'toggle-left-nav'
+  | 'toggle-right-panel';
+
+export interface GlobalShortcutConfig {
+  leftNavShortcut: PanelShortcutLeft;
+  rightPanelShortcut: PanelShortcutRight;
+}
+
+const TEXT_INPUT_SELECTOR =
+  'input:not([type=checkbox]):not([type=radio]):not([type=button]):not([type=submit]):not([type=reset]), textarea, select, [contenteditable=""], [contenteditable="true"]';
+
+type SelectorCapableElement = EventTarget & {
+  matches: (selector: string) => boolean;
+  closest: (selector: string) => Element | null;
+};
+
+function isElementWithSelectorSupport(target: EventTarget | null): target is SelectorCapableElement {
+  return (
+    typeof target === 'object' &&
+    target !== null &&
+    'matches' in target &&
+    typeof (target as { matches?: unknown }).matches === 'function' &&
+    'closest' in target &&
+    typeof (target as { closest?: unknown }).closest === 'function'
+  );
+}
+
+export function isTextInputElement(target: EventTarget | null): boolean {
+  if (!isElementWithSelectorSupport(target)) return false;
+  if (target.matches(TEXT_INPUT_SELECTOR)) return true;
+  return Boolean(target.closest('[contenteditable="true"], [contenteditable=""]'));
+}
+
+export function shouldDeferGlobalShortcut(
+  event: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey' | 'shiftKey' | 'code' | 'target'>,
+): boolean {
+  if (!isTextInputElement(event.target)) return false;
+  const meta = event.metaKey || event.ctrlKey;
+  if (meta && !event.shiftKey && event.code === 'KeyK') return false;
+  return true;
+}
+
+export function resolveGlobalShortcutAction(
+  event: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey' | 'shiftKey' | 'code'>,
+  config: GlobalShortcutConfig,
+): GlobalShortcutAction | null {
+  const meta = event.metaKey || event.ctrlKey;
+  if (!meta) return null;
+
+  if (event.shiftKey && event.code === 'KeyO') return 'new-task';
+  if (event.shiftKey && event.code === 'KeyF') return 'open-files';
+  if (!event.shiftKey && event.code === 'KeyK') return 'toggle-command-palette';
+
+  if (!event.shiftKey && config.leftNavShortcut !== 'None' && event.code === config.leftNavShortcut) {
+    return 'toggle-left-nav';
+  }
+
+  if (!event.shiftKey && config.rightPanelShortcut !== 'None' && event.code === config.rightPanelShortcut) {
+    return 'toggle-right-panel';
+  }
+
+  return null;
+}
+
+export function hasPreferencesShortcutConflict(leftNavShortcut: PanelShortcutLeft, platform: string): boolean {
+  return platform === 'darwin' && leftNavShortcut === 'Comma';
+}

--- a/packages/core/src/ports/settings.ts
+++ b/packages/core/src/ports/settings.ts
@@ -10,8 +10,8 @@ export interface AppSettings {
   density?: 'compact' | 'comfortable' | 'spacious';
   language?: string;
   sendShortcut?: 'enter' | 'cmdEnter';
-  leftNavShortcut?: 'Comma' | 'BracketLeft';
-  rightPanelShortcut?: 'Period' | 'BracketRight';
+  leftNavShortcut?: 'Comma' | 'BracketLeft' | 'None';
+  rightPanelShortcut?: 'Period' | 'BracketRight' | 'None';
   devMode?: boolean;
   notifications?: NotificationSettings;
 }

--- a/packages/core/src/stores/task-store.ts
+++ b/packages/core/src/stores/task-store.ts
@@ -110,9 +110,6 @@ export interface TaskStoreDeps {
 export function createTaskStore(deps: TaskStoreDeps) {
   let cachedDeviceId: string | null = null;
   let hydrationPromise: Promise<void> | null = null;
-  const deviceIdReady = deps.getDeviceId().then((id) => {
-    cachedDeviceId = id;
-  });
 
   return createStore<TaskState>((set, get) => ({
     tasks: [],
@@ -262,7 +259,7 @@ export function createTaskStore(deps: TaskStoreDeps) {
 
       hydrationPromise = (async () => {
         try {
-          await deviceIdReady;
+          cachedDeviceId = await deps.getDeviceId();
           const res = await deps.loadTasks();
           if (res.ok && res.rows) {
             set({

--- a/packages/core/src/stores/task-store.ts
+++ b/packages/core/src/stores/task-store.ts
@@ -109,6 +109,10 @@ export interface TaskStoreDeps {
 
 export function createTaskStore(deps: TaskStoreDeps) {
   let cachedDeviceId: string | null = null;
+  let hydrationPromise: Promise<void> | null = null;
+  const deviceIdReady = deps.getDeviceId().then((id) => {
+    cachedDeviceId = id;
+  });
 
   return createStore<TaskState>((set, get) => ({
     tasks: [],
@@ -254,37 +258,45 @@ export function createTaskStore(deps: TaskStoreDeps) {
 
     hydrate: async () => {
       if (get().hydrated) return;
-      try {
-        cachedDeviceId = await deps.getDeviceId();
-        const res = await deps.loadTasks();
-        if (res.ok && res.rows) {
-          set({
-            tasks: res.rows.map((r) => ({
-              id: r.id,
-              sessionKey: r.sessionKey,
-              sessionId: r.sessionId,
-              title: r.title,
-              status: r.status as TaskStatus,
-              ensemble: r.ensemble ?? undefined,
-              model: r.model ?? undefined,
-              modelProvider: r.modelProvider ?? undefined,
-              thinkingLevel: r.thinkingLevel ?? undefined,
-              inputTokens: r.inputTokens ?? undefined,
-              outputTokens: r.outputTokens ?? undefined,
-              contextTokens: r.contextTokens ?? undefined,
-              teamId: r.teamId ?? undefined,
-              createdAt: r.createdAt,
-              updatedAt: r.updatedAt,
-              tags: r.tags,
-              artifactDir: r.artifactDir,
-              gatewayId: r.gatewayId,
-            })),
-            hydrated: true,
-          });
+      if (hydrationPromise) return hydrationPromise;
+
+      hydrationPromise = (async () => {
+        try {
+          await deviceIdReady;
+          const res = await deps.loadTasks();
+          if (res.ok && res.rows) {
+            set({
+              tasks: res.rows.map((r) => ({
+                id: r.id,
+                sessionKey: r.sessionKey,
+                sessionId: r.sessionId,
+                title: r.title,
+                status: r.status as TaskStatus,
+                ensemble: r.ensemble ?? undefined,
+                model: r.model ?? undefined,
+                modelProvider: r.modelProvider ?? undefined,
+                thinkingLevel: r.thinkingLevel ?? undefined,
+                inputTokens: r.inputTokens ?? undefined,
+                outputTokens: r.outputTokens ?? undefined,
+                contextTokens: r.contextTokens ?? undefined,
+                teamId: r.teamId ?? undefined,
+                createdAt: r.createdAt,
+                updatedAt: r.updatedAt,
+                tags: r.tags,
+                artifactDir: r.artifactDir,
+                gatewayId: r.gatewayId,
+              })),
+              hydrated: true,
+            });
+          }
+        } catch (err) {
+          console.warn('[taskStore] hydrate failed:', err);
+        } finally {
+          hydrationPromise = null;
         }
-      } catch (err) {
-        console.warn('[taskStore] hydrate failed:', err);
-      }
+      })();
+
+      return hydrationPromise;
     },
 
     adoptTasks: (discovered) => {

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -6,8 +6,8 @@ export type Theme = 'dark' | 'light' | 'auto';
 export type DensityMode = 'compact' | 'comfortable' | 'spacious';
 export type SendShortcut = 'enter' | 'cmdEnter';
 export type MessageLayout = 'centered' | 'wide';
-export type PanelShortcutLeft = 'Comma' | 'BracketLeft';
-export type PanelShortcutRight = 'Period' | 'BracketRight';
+export type PanelShortcutLeft = 'Comma' | 'BracketLeft' | 'None';
+export type PanelShortcutRight = 'Period' | 'BracketRight' | 'None';
 export interface GatewayInfo {
   id: string;
   name: string;

--- a/packages/core/test/global-shortcuts.test.ts
+++ b/packages/core/test/global-shortcuts.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasPreferencesShortcutConflict,
+  isTextInputElement,
+  resolveGlobalShortcutAction,
+  shouldDeferGlobalShortcut,
+} from '../src/lib/global-shortcuts.js';
+
+function keyEvent(
+  partial: Partial<KeyboardEvent> & Pick<KeyboardEvent, 'code'>,
+  target: EventTarget | null = null,
+): KeyboardEvent {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    target,
+    ...partial,
+  } as KeyboardEvent;
+}
+
+function mockTextInput(): EventTarget {
+  return {
+    matches: () => true,
+    closest: () => null,
+  } as unknown as EventTarget;
+}
+
+function mockNonInput(): EventTarget {
+  return {
+    matches: () => false,
+    closest: () => null,
+  } as unknown as EventTarget;
+}
+
+const defaultConfig = {
+  leftNavShortcut: 'Comma' as const,
+  rightPanelShortcut: 'Period' as const,
+};
+
+describe('resolveGlobalShortcutAction', () => {
+  it('does not bind Ctrl/Cmd+P', () => {
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ ctrlKey: true, code: 'KeyP' }), defaultConfig),
+    ).toBeNull();
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'KeyP' }), defaultConfig),
+    ).toBeNull();
+  });
+
+  it('resolves built-in shortcuts', () => {
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ metaKey: true, shiftKey: true, code: 'KeyO' }), defaultConfig),
+    ).toBe('new-task');
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ metaKey: true, shiftKey: true, code: 'KeyF' }), defaultConfig),
+    ).toBe('open-files');
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'KeyK' }), defaultConfig),
+    ).toBe('toggle-command-palette');
+  });
+
+  it('respects configurable panel shortcuts', () => {
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Comma' }), defaultConfig),
+    ).toBe('toggle-left-nav');
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Period' }), defaultConfig),
+    ).toBe('toggle-right-panel');
+  });
+
+  it('skips panel shortcuts when set to None', () => {
+    const disabled = { leftNavShortcut: 'None' as const, rightPanelShortcut: 'None' as const };
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Comma' }), disabled),
+    ).toBeNull();
+    expect(
+      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Period' }), disabled),
+    ).toBeNull();
+  });
+});
+
+describe('shouldDeferGlobalShortcut', () => {
+  it('defers panel shortcuts while typing in a text field', () => {
+    expect(
+      shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'Comma' }, mockTextInput())),
+    ).toBe(true);
+  });
+
+  it('still allows Cmd/Ctrl+K inside text fields', () => {
+    expect(
+      shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'KeyK' }, mockTextInput())),
+    ).toBe(false);
+  });
+
+  it('does not defer shortcuts outside text inputs', () => {
+    expect(
+      shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'Comma' }, mockNonInput())),
+    ).toBe(false);
+  });
+
+  it('defers Ctrl/Cmd+P inside text fields so print can pass through', () => {
+    expect(
+      shouldDeferGlobalShortcut(keyEvent({ ctrlKey: true, code: 'KeyP' }, mockTextInput())),
+    ).toBe(true);
+  });
+});
+
+describe('isTextInputElement', () => {
+  it('detects editable targets', () => {
+    expect(isTextInputElement(mockTextInput())).toBe(true);
+    expect(isTextInputElement(mockNonInput())).toBe(false);
+  });
+});
+
+describe('hasPreferencesShortcutConflict', () => {
+  it('flags Cmd+, on macOS', () => {
+    expect(hasPreferencesShortcutConflict('Comma', 'darwin')).toBe(true);
+    expect(hasPreferencesShortcutConflict('BracketLeft', 'darwin')).toBe(false);
+    expect(hasPreferencesShortcutConflict('Comma', 'win32')).toBe(false);
+  });
+});

--- a/packages/core/test/global-shortcuts.test.ts
+++ b/packages/core/test/global-shortcuts.test.ts
@@ -40,69 +40,53 @@ const defaultConfig = {
 
 describe('resolveGlobalShortcutAction', () => {
   it('does not bind Ctrl/Cmd+P', () => {
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ ctrlKey: true, code: 'KeyP' }), defaultConfig),
-    ).toBeNull();
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'KeyP' }), defaultConfig),
-    ).toBeNull();
+    expect(resolveGlobalShortcutAction(keyEvent({ ctrlKey: true, code: 'KeyP' }), defaultConfig)).toBeNull();
+    expect(resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'KeyP' }), defaultConfig)).toBeNull();
   });
 
   it('resolves built-in shortcuts', () => {
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ metaKey: true, shiftKey: true, code: 'KeyO' }), defaultConfig),
-    ).toBe('new-task');
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ metaKey: true, shiftKey: true, code: 'KeyF' }), defaultConfig),
-    ).toBe('open-files');
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'KeyK' }), defaultConfig),
-    ).toBe('toggle-command-palette');
+    expect(resolveGlobalShortcutAction(keyEvent({ metaKey: true, shiftKey: true, code: 'KeyO' }), defaultConfig)).toBe(
+      'new-task',
+    );
+    expect(resolveGlobalShortcutAction(keyEvent({ metaKey: true, shiftKey: true, code: 'KeyF' }), defaultConfig)).toBe(
+      'open-files',
+    );
+    expect(resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'KeyK' }), defaultConfig)).toBe(
+      'toggle-command-palette',
+    );
   });
 
   it('respects configurable panel shortcuts', () => {
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Comma' }), defaultConfig),
-    ).toBe('toggle-left-nav');
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Period' }), defaultConfig),
-    ).toBe('toggle-right-panel');
+    expect(resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Comma' }), defaultConfig)).toBe(
+      'toggle-left-nav',
+    );
+    expect(resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Period' }), defaultConfig)).toBe(
+      'toggle-right-panel',
+    );
   });
 
   it('skips panel shortcuts when set to None', () => {
     const disabled = { leftNavShortcut: 'None' as const, rightPanelShortcut: 'None' as const };
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Comma' }), disabled),
-    ).toBeNull();
-    expect(
-      resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Period' }), disabled),
-    ).toBeNull();
+    expect(resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Comma' }), disabled)).toBeNull();
+    expect(resolveGlobalShortcutAction(keyEvent({ metaKey: true, code: 'Period' }), disabled)).toBeNull();
   });
 });
 
 describe('shouldDeferGlobalShortcut', () => {
   it('defers panel shortcuts while typing in a text field', () => {
-    expect(
-      shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'Comma' }, mockTextInput())),
-    ).toBe(true);
+    expect(shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'Comma' }, mockTextInput()))).toBe(true);
   });
 
   it('still allows Cmd/Ctrl+K inside text fields', () => {
-    expect(
-      shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'KeyK' }, mockTextInput())),
-    ).toBe(false);
+    expect(shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'KeyK' }, mockTextInput()))).toBe(false);
   });
 
   it('does not defer shortcuts outside text inputs', () => {
-    expect(
-      shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'Comma' }, mockNonInput())),
-    ).toBe(false);
+    expect(shouldDeferGlobalShortcut(keyEvent({ metaKey: true, code: 'Comma' }, mockNonInput()))).toBe(false);
   });
 
   it('defers Ctrl/Cmd+P inside text fields so print can pass through', () => {
-    expect(
-      shouldDeferGlobalShortcut(keyEvent({ ctrlKey: true, code: 'KeyP' }, mockTextInput())),
-    ).toBe(true);
+    expect(shouldDeferGlobalShortcut(keyEvent({ ctrlKey: true, code: 'KeyP' }, mockTextInput()))).toBe(true);
   });
 });
 

--- a/packages/core/test/task-store.test.ts
+++ b/packages/core/test/task-store.test.ts
@@ -71,19 +71,11 @@ describe('task-store hydrate', () => {
     expect(store.getState().tasks).toHaveLength(1);
   });
 
-  it('includes deviceId in session keys created after store init', async () => {
-    let resolveDeviceId!: (id: string) => void;
-    const getDeviceId = vi.fn(
-      () =>
-        new Promise<string>((resolve) => {
-          resolveDeviceId = resolve;
-        }),
-    );
-    const deps = createDeps({ getDeviceId });
+  it('includes deviceId in session keys created after hydrate', async () => {
+    const deps = createDeps({ getDeviceId: vi.fn(async () => 'device-abc') });
     const store = createTaskStore(deps);
 
-    resolveDeviceId('device-abc');
-    await Promise.resolve();
+    await store.getState().hydrate();
 
     const task = store.getState().createTask({ gatewayId: 'gw-1', agentId: 'main' });
 

--- a/packages/core/test/task-store.test.ts
+++ b/packages/core/test/task-store.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildSessionKey } from '@clawwork/shared';
+import { createTaskStore, type TaskStoreDeps } from '../src/stores/task-store';
+
+function createDeps(overrides: Partial<TaskStoreDeps> = {}): TaskStoreDeps {
+  return {
+    persistTask: vi.fn(async () => ({ ok: true })),
+    persistTaskUpdate: vi.fn(async () => ({ ok: true })),
+    deleteTask: vi.fn(async () => ({ ok: true })),
+    loadTasks: vi.fn(async () => ({ ok: true, rows: [] })),
+    patchSession: vi.fn(async () => ({ ok: true })),
+    getDeviceId: vi.fn(async () => 'device-abc'),
+    getDefaultGatewayId: () => 'gw-1',
+    getAgentCatalog: () => ({ agents: [], defaultId: 'main' }),
+    ...overrides,
+  };
+}
+
+describe('task-store hydrate', () => {
+  beforeEach(() => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  });
+
+  it('serializes concurrent hydrate calls and resolves deviceId once', async () => {
+    let resolveDeviceId!: (id: string) => void;
+    const getDeviceId = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveDeviceId = resolve;
+        }),
+    );
+    let resolveLoadTasks!: (value: Awaited<ReturnType<TaskStoreDeps['loadTasks']>>) => void;
+    const loadTasksPromise = new Promise<Awaited<ReturnType<TaskStoreDeps['loadTasks']>>>((resolve) => {
+      resolveLoadTasks = resolve;
+    });
+    const loadTasks = vi.fn(() => loadTasksPromise);
+    const deps = createDeps({ getDeviceId, loadTasks });
+    const store = createTaskStore(deps);
+
+    const hydrate1 = store.getState().hydrate();
+    const hydrate2 = store.getState().hydrate();
+
+    expect(getDeviceId).toHaveBeenCalledTimes(1);
+    expect(loadTasks).not.toHaveBeenCalled();
+
+    resolveDeviceId('device-abc');
+    await vi.waitFor(() => expect(loadTasks).toHaveBeenCalledTimes(1));
+
+    resolveLoadTasks({
+      ok: true,
+      rows: [
+        {
+          id: 'task-1',
+          sessionKey: buildSessionKey('task-1', 'main', 'device-abc'),
+          sessionId: 'session-1',
+          title: 'Existing task',
+          status: 'active',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          tags: [],
+          artifactDir: 'tasks/task-1',
+          gatewayId: 'gw-1',
+        },
+      ],
+    });
+
+    await Promise.all([hydrate1, hydrate2]);
+
+    expect(loadTasks).toHaveBeenCalledTimes(1);
+    expect(store.getState().hydrated).toBe(true);
+    expect(store.getState().tasks).toHaveLength(1);
+  });
+
+  it('includes deviceId in session keys created after store init', async () => {
+    let resolveDeviceId!: (id: string) => void;
+    const getDeviceId = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveDeviceId = resolve;
+        }),
+    );
+    const deps = createDeps({ getDeviceId });
+    const store = createTaskStore(deps);
+
+    resolveDeviceId('device-abc');
+    await Promise.resolve();
+
+    const task = store.getState().createTask({ gatewayId: 'gw-1', agentId: 'main' });
+
+    expect(task.sessionKey).toBe(buildSessionKey('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', 'main', 'device-abc'));
+  });
+});

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -73,7 +73,18 @@ function buildAppMenu(devMode = false): Menu {
       : []),
     {
       label: 'File',
-      submenu: [isMac ? { role: 'close' as const, accelerator: 'Command+W' } : { role: 'quit' as const }],
+      submenu: [
+        {
+          label: 'Print',
+          accelerator: isMac ? 'Command+P' : 'Ctrl+P',
+          click: () => {
+            const win = BrowserWindow.getFocusedWindow();
+            win?.webContents.print({});
+          },
+        },
+        { type: 'separator' as const },
+        isMac ? { role: 'close' as const, accelerator: 'Command+W' } : { role: 'quit' as const },
+      ],
     },
     { role: 'editMenu' as const },
     {

--- a/packages/desktop/src/main/workspace/config.ts
+++ b/packages/desktop/src/main/workspace/config.ts
@@ -50,8 +50,8 @@ export interface AppConfig {
   quickLaunch?: QuickLaunchConfig;
   trayEnabled?: boolean;
   notifications?: NotificationConfig;
-  leftNavShortcut?: 'Comma' | 'BracketLeft';
-  rightPanelShortcut?: 'Period' | 'BracketRight';
+  leftNavShortcut?: 'Comma' | 'BracketLeft' | 'None';
+  rightPanelShortcut?: 'Period' | 'BracketRight' | 'None';
   deviceId?: string;
   zoomLevel?: number;
   devMode?: boolean;

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -131,8 +131,8 @@ interface AppSettings {
   quickLaunch?: QuickLaunchSettings;
   trayEnabled?: boolean;
   notifications?: NotificationSettings;
-  leftNavShortcut?: 'Comma' | 'BracketLeft';
-  rightPanelShortcut?: 'Period' | 'BracketRight';
+  leftNavShortcut?: 'Comma' | 'BracketLeft' | 'None';
+  rightPanelShortcut?: 'Period' | 'BracketRight' | 'None';
   devMode?: boolean;
   teamHubRegistries?: Array<{ id: string; url: string; isOfficial: boolean }>;
   updateChannel?: 'stable' | 'beta';

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import CommandPalette from './components/CommandPalette';
 import { useUiStore, type Theme } from './stores/uiStore';
 import { useTaskStore } from './stores/taskStore';
 import { useFileStore } from './stores/fileStore';
+import { resolveGlobalShortcutAction, shouldDeferGlobalShortcut } from '@clawwork/core';
 import { composer } from './platform';
 import { useGatewayBootstrap } from './hooks/useGatewayBootstrap';
 import { useWorkspaceRefresh } from './hooks/useWorkspaceRefresh';
@@ -130,39 +131,32 @@ export default function App() {
 
   const handleGlobalKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      const meta = e.metaKey || e.ctrlKey;
-      if (!meta) return;
+      if (shouldDeferGlobalShortcut(e)) return;
 
-      if (e.shiftKey && e.code === 'KeyO') {
-        e.preventDefault();
-        startNewTask();
-        return;
-      }
+      const action = resolveGlobalShortcutAction(e, {
+        leftNavShortcut,
+        rightPanelShortcut,
+      });
+      if (!action) return;
 
-      if (e.shiftKey && e.code === 'KeyF') {
-        e.preventDefault();
-        setMainView('files');
-        return;
-      }
+      e.preventDefault();
 
-      if (!e.shiftKey && e.code === 'KeyK') {
-        e.preventDefault();
-        toggleCommandPalette();
-        return;
-      }
-
-      const leftCode = leftNavShortcut;
-      const rightCode = rightPanelShortcut;
-
-      if (!e.shiftKey && e.code === leftCode) {
-        e.preventDefault();
-        toggleLeftNavCollapsed();
-        return;
-      }
-
-      if (!e.shiftKey && e.code === rightCode) {
-        e.preventDefault();
-        if (useUiStore.getState().mainView === 'chat') toggleRightPanel();
+      switch (action) {
+        case 'new-task':
+          startNewTask();
+          return;
+        case 'open-files':
+          setMainView('files');
+          return;
+        case 'toggle-command-palette':
+          toggleCommandPalette();
+          return;
+        case 'toggle-left-nav':
+          toggleLeftNavCollapsed();
+          return;
+        case 'toggle-right-panel':
+          if (useUiStore.getState().mainView === 'chat') toggleRightPanel();
+          return;
       }
     },
     [

--- a/packages/desktop/src/renderer/i18n/locales/de.json
+++ b/packages/desktop/src/renderer/i18n/locales/de.json
@@ -564,6 +564,8 @@
     "setupCodeParsed": "Gateway-URL erkannt",
     "setupCodePlaceholder": "Setup-Code aus der Gateway-Weboberflaeche oder openclaw qr einfuegen",
     "shortcuts": "Tastenkuerzel",
+    "shortcutConflictPreferences": "Dieses Tastenkuerzel kann mit den macOS-Systemeinstellungen (⌘,) kollidieren",
+    "shortcutDisabled": "Deaktiviert",
     "shortcutUpdated": "Tastenkuerzel aktualisiert",
     "showSecret": "Zugangsdaten anzeigen",
     "skillApiKeySave": "Speichern",

--- a/packages/desktop/src/renderer/i18n/locales/en.json
+++ b/packages/desktop/src/renderer/i18n/locales/en.json
@@ -564,6 +564,8 @@
     "setupCodeParsed": "Gateway URL detected",
     "setupCodePlaceholder": "Paste setup code from gateway web UI or openclaw qr",
     "shortcuts": "Shortcuts",
+    "shortcutConflictPreferences": "This shortcut may conflict with system Preferences (⌘,) on macOS",
+    "shortcutDisabled": "Disabled",
     "shortcutUpdated": "Shortcut updated",
     "showSecret": "Show secret",
     "skillApiKeySave": "Save",

--- a/packages/desktop/src/renderer/i18n/locales/es.json
+++ b/packages/desktop/src/renderer/i18n/locales/es.json
@@ -564,6 +564,8 @@
     "setupCodeParsed": "URL del Gateway detectada",
     "setupCodePlaceholder": "Pega el código de configuración desde la interfaz web del Gateway o el QR de OpenClaw",
     "shortcuts": "Atajos",
+    "shortcutConflictPreferences": "Este atajo puede entrar en conflicto con Preferencias del sistema (⌘,) en macOS",
+    "shortcutDisabled": "Desactivado",
     "shortcutUpdated": "Atajo actualizado",
     "showSecret": "Mostrar secreto",
     "skillApiKeySave": "Guardar",

--- a/packages/desktop/src/renderer/i18n/locales/ja.json
+++ b/packages/desktop/src/renderer/i18n/locales/ja.json
@@ -564,6 +564,8 @@
     "setupCodeParsed": "ゲートウェイ URL を検出しました",
     "setupCodePlaceholder": "ゲートウェイ Web UI または openclaw qr からセットアップコードを貼り付け",
     "shortcuts": "ショートカット",
+    "shortcutConflictPreferences": "このショートカットは macOS のシステム設定 (⌘,) と競合する可能性があります",
+    "shortcutDisabled": "無効",
     "shortcutUpdated": "ショートカットを更新しました",
     "showSecret": "シークレットを表示",
     "skillApiKeySave": "保存",

--- a/packages/desktop/src/renderer/i18n/locales/ko.json
+++ b/packages/desktop/src/renderer/i18n/locales/ko.json
@@ -564,6 +564,8 @@
     "setupCodeParsed": "게이트웨이 URL이 감지되었습니다",
     "setupCodePlaceholder": "게이트웨이 웹 UI 또는 openclaw qr에서 설정 코드를 붙여넣으세요",
     "shortcuts": "단축키",
+    "shortcutConflictPreferences": "이 단축키는 macOS 시스템 설정(⌘,)과 충돌할 수 있습니다",
+    "shortcutDisabled": "사용 안 함",
     "shortcutUpdated": "단축키가 변경되었습니다",
     "showSecret": "비밀 표시",
     "skillApiKeySave": "저장",

--- a/packages/desktop/src/renderer/i18n/locales/pt.json
+++ b/packages/desktop/src/renderer/i18n/locales/pt.json
@@ -564,6 +564,8 @@
     "setupCodeParsed": "URL do Gateway detectada",
     "setupCodePlaceholder": "Cole o código de configuração da interface web do gateway ou do openclaw qr",
     "shortcuts": "Atalhos",
+    "shortcutConflictPreferences": "Este atalho pode entrar em conflito com Preferências do sistema (⌘,) no macOS",
+    "shortcutDisabled": "Desativado",
     "shortcutUpdated": "Atalho atualizado",
     "showSecret": "Mostrar segredo",
     "skillApiKeySave": "Salvar",

--- a/packages/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -564,6 +564,8 @@
     "setupCodeParsed": "已偵測到 Gateway URL",
     "setupCodePlaceholder": "貼上來自 Gateway Web UI 或 openclaw qr 的設定碼",
     "shortcuts": "快捷鍵",
+    "shortcutConflictPreferences": "此快捷鍵可能與 macOS 系統偏好設定 (⌘,) 衝突",
+    "shortcutDisabled": "已停用",
     "shortcutUpdated": "快捷鍵已更新",
     "showSecret": "顯示憑證",
     "skillApiKeySave": "儲存",

--- a/packages/desktop/src/renderer/i18n/locales/zh.json
+++ b/packages/desktop/src/renderer/i18n/locales/zh.json
@@ -564,6 +564,8 @@
     "setupCodeParsed": "已识别网关地址",
     "setupCodePlaceholder": "粘贴来自网关 Web UI 或 openclaw qr 的 Setup Code",
     "shortcuts": "快捷键",
+    "shortcutConflictPreferences": "此快捷键可能与 macOS 系统偏好设置 (⌘,) 冲突",
+    "shortcutDisabled": "已禁用",
     "shortcutUpdated": "快捷键已更新",
     "showSecret": "显示凭据",
     "skillApiKeySave": "保存",

--- a/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/GeneralSection.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Moon, Sun, Monitor, Bell, Smartphone } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@/lib/toast';
-import { modKey } from '@/lib/utils';
+import { modKey, isMacPlatform } from '@/lib/utils';
 import {
   useUiStore,
   type Theme,
@@ -18,6 +18,7 @@ import SegmentedControl from '../components/SegmentedControl';
 import Toggle from '../components/Toggle';
 import SettingGroup from '@/components/semantic/SettingGroup';
 import PairMobileDialog from '../components/PairMobileDialog';
+import { hasPreferencesShortcutConflict } from '@clawwork/core';
 import { useSettingsStore } from '@/stores/settingsStore';
 
 export default function GeneralSection() {
@@ -194,16 +195,24 @@ export default function GeneralSection() {
             />
           </SettingRow>
           <SettingRow label={t('settings.leftNavShortcut')}>
-            <SegmentedControl
-              layoutId="seg-left-nav"
-              value={leftNavShortcut}
-              onChange={handleLeftNavShortcutChange}
-              ariaLabel={t('settings.leftNavShortcut')}
-              options={[
-                { value: 'Comma' as const, label: `${modKey} ,` },
-                { value: 'BracketLeft' as const, label: `${modKey} [` },
-              ]}
-            />
+            <div className="flex flex-col items-end gap-1">
+              <SegmentedControl
+                layoutId="seg-left-nav"
+                value={leftNavShortcut}
+                onChange={handleLeftNavShortcutChange}
+                ariaLabel={t('settings.leftNavShortcut')}
+                options={[
+                  { value: 'Comma' as const, label: `${modKey} ,` },
+                  { value: 'BracketLeft' as const, label: `${modKey} [` },
+                  { value: 'None' as const, label: t('settings.shortcutDisabled') },
+                ]}
+              />
+              {hasPreferencesShortcutConflict(leftNavShortcut, isMacPlatform ? 'darwin' : 'win32') && (
+                <p className="type-support max-w-xs text-right text-[var(--text-muted)]">
+                  {t('settings.shortcutConflictPreferences')}
+                </p>
+              )}
+            </div>
           </SettingRow>
           <SettingRow label={t('settings.rightPanelShortcut')}>
             <SegmentedControl
@@ -214,6 +223,7 @@ export default function GeneralSection() {
               options={[
                 { value: 'Period' as const, label: `${modKey} .` },
                 { value: 'BracketRight' as const, label: `${modKey} ]` },
+                { value: 'None' as const, label: t('settings.shortcutDisabled') },
               ]}
             />
           </SettingRow>

--- a/packages/desktop/src/renderer/lib/utils.ts
+++ b/packages/desktop/src/renderer/lib/utils.ts
@@ -50,4 +50,5 @@ export function formatCost(usd: number): string {
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
+export const isMacPlatform = isMac;
 export const modKey = isMac ? '⌘' : 'Ctrl';

--- a/packages/desktop/test/message-store.test.ts
+++ b/packages/desktop/test/message-store.test.ts
@@ -6,17 +6,34 @@ async function loadStore() {
   return module;
 }
 
+function setupClawworkMock() {
+  const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as unknown as Window & {
+    clawwork: {
+      persistMessage: ReturnType<typeof vi.fn>;
+    };
+  };
+  windowWithClawwork.clawwork = {
+    persistMessage: vi.fn().mockResolvedValue({ ok: true }),
+  } as unknown as typeof windowWithClawwork.clawwork;
+}
+
+function resetStoreState(
+  useMessageStore: Awaited<ReturnType<typeof loadStore>>['useMessageStore'],
+  overrides: Record<string, unknown> = {},
+) {
+  useMessageStore.setState({
+    messagesByTask: {},
+    activeTurnBySession: {},
+    processingBySession: new Set(),
+    highlightedMessageId: null,
+    ...overrides,
+  });
+}
+
 describe('message store tool call persistence', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    const windowWithClawwork = (globalThis.window ??= {} as typeof globalThis.window) as unknown as Window & {
-      clawwork: {
-        persistMessage: ReturnType<typeof vi.fn>;
-      };
-    };
-    windowWithClawwork.clawwork = {
-      persistMessage: vi.fn().mockResolvedValue({ ok: true }),
-    } as unknown as typeof windowWithClawwork.clawwork;
+    setupClawworkMock();
   });
 
   it('persists tool status updates for the latest assistant message after promotion', async () => {
@@ -92,6 +109,387 @@ describe('message store tool call persistence', () => {
     expect(useMessageStore.getState().activeTurnBySession[sessionKey]).toEqual(
       expect.objectContaining({ finalized: true, toolCalls: [expect.objectContaining({ id: 'exec-1' })] }),
     );
+    expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('message store streaming lifecycle', () => {
+  const sessionKey = 'agent:main:clawwork:task:task-1';
+  const taskId = 'task-1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupClawworkMock();
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('11111111-1111-4111-8111-111111111111');
+  });
+
+  describe('appendStreamDelta', () => {
+    it('creates a new active turn when none exists and appends text', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore);
+
+      useMessageStore.getState().appendStreamDelta(sessionKey, 'Hello');
+
+      const turn = useMessageStore.getState().activeTurnBySession[sessionKey];
+      expect(turn).toEqual(
+        expect.objectContaining({
+          id: '11111111-1111-4111-8111-111111111111',
+          streamingText: 'Hello',
+          finalized: false,
+        }),
+      );
+    });
+
+    it('appends incremental text to an existing active turn', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore, {
+        activeTurnBySession: {
+          [sessionKey]: {
+            id: 'turn-existing',
+            streamingText: 'Hello',
+            streamingThinking: '',
+            toolCalls: [],
+            finalized: false,
+            content: '',
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+        },
+      });
+
+      useMessageStore.getState().appendStreamDelta(sessionKey, ' world');
+
+      expect(useMessageStore.getState().activeTurnBySession[sessionKey].streamingText).toBe('Hello world');
+    });
+
+    it('ignores empty deltas without changing accumulated text', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore, {
+        activeTurnBySession: {
+          [sessionKey]: {
+            id: 'turn-existing',
+            streamingText: 'Hello',
+            streamingThinking: '',
+            toolCalls: [],
+            finalized: false,
+            content: '',
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+        },
+      });
+
+      useMessageStore.getState().appendStreamDelta(sessionKey, '');
+
+      expect(useMessageStore.getState().activeTurnBySession[sessionKey].streamingText).toBe('Hello');
+    });
+  });
+
+  describe('finalizeStream', () => {
+    it('marks an active turn as finalized with streamed content', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore, {
+        activeTurnBySession: {
+          [sessionKey]: {
+            id: 'turn-finalize',
+            streamingText: 'Complete reply',
+            streamingThinking: 'thoughts',
+            toolCalls: [],
+            finalized: false,
+            content: '',
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+        },
+      });
+
+      useMessageStore.getState().finalizeStream(sessionKey);
+
+      expect(useMessageStore.getState().activeTurnBySession[sessionKey]).toEqual(
+        expect.objectContaining({
+          finalized: true,
+          content: 'Complete reply',
+          thinkingContent: 'thoughts',
+          streamingText: '',
+          streamingThinking: '',
+        }),
+      );
+    });
+
+    it('applies runId metadata when provided', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore, {
+        activeTurnBySession: {
+          [sessionKey]: {
+            id: 'turn-run',
+            streamingText: 'Done',
+            streamingThinking: '',
+            toolCalls: [],
+            finalized: false,
+            content: '',
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+        },
+      });
+
+      useMessageStore.getState().finalizeStream(sessionKey, { runId: 'run-42' });
+
+      expect(useMessageStore.getState().activeTurnBySession[sessionKey].runId).toBe('run-42');
+    });
+
+    it('is a no-op when no active turn exists', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore);
+
+      useMessageStore.getState().finalizeStream(sessionKey);
+
+      expect(useMessageStore.getState().activeTurnBySession).toEqual({});
+    });
+
+    it('clears streaming buffers without finalizing when the turn has no content', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore, {
+        activeTurnBySession: {
+          [sessionKey]: {
+            id: 'turn-empty',
+            streamingText: '',
+            streamingThinking: '',
+            toolCalls: [],
+            finalized: false,
+            content: '',
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+        },
+      });
+
+      useMessageStore.getState().finalizeStream(sessionKey);
+
+      expect(useMessageStore.getState().activeTurnBySession[sessionKey]).toEqual(
+        expect.objectContaining({
+          finalized: false,
+          streamingText: '',
+          streamingThinking: '',
+        }),
+      );
+    });
+  });
+
+  describe('promoteActiveTurn', () => {
+    it('moves a finalized active turn into the message array with merged metadata', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore, {
+        activeTurnBySession: {
+          [sessionKey]: {
+            id: 'turn-promote',
+            streamingText: '',
+            streamingThinking: '',
+            toolCalls: [
+              {
+                id: 'exec-1',
+                name: 'exec',
+                status: 'done',
+                result: 'ok',
+                startedAt: '2026-03-16T10:00:00.000Z',
+                completedAt: '2026-03-16T10:00:01.000Z',
+              },
+            ],
+            finalized: true,
+            content: 'Merged reply',
+            thinkingContent: 'Merged thought',
+            runId: 'run-promote',
+            timestamp: '2026-03-16T10:00:01.000Z',
+          },
+        },
+      });
+
+      useMessageStore.getState().promoteActiveTurn(sessionKey, taskId, {
+        id: 'canonical-1',
+        taskId,
+        role: 'assistant',
+        content: 'Merged reply',
+        artifacts: [],
+        toolCalls: [
+          {
+            id: 'exec-1',
+            name: 'exec',
+            status: 'running',
+            startedAt: '2026-03-16T10:00:00.000Z',
+          },
+        ],
+        timestamp: '2026-03-16T10:00:01.000Z',
+      });
+
+      const messages = useMessageStore.getState().messagesByTask[taskId];
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual(
+        expect.objectContaining({
+          id: 'canonical-1',
+          content: 'Merged reply',
+          thinkingContent: 'Merged thought',
+          runId: 'run-promote',
+          toolCalls: [expect.objectContaining({ id: 'exec-1', status: 'done', result: 'ok' })],
+        }),
+      );
+      expect(useMessageStore.getState().activeTurnBySession[sessionKey]).toBeUndefined();
+    });
+
+    it('promotes the canonical message safely when no active turn exists', async () => {
+      const { useMessageStore } = await loadStore();
+      resetStoreState(useMessageStore);
+
+      useMessageStore.getState().promoteActiveTurn(sessionKey, taskId, {
+        id: 'canonical-only',
+        taskId,
+        role: 'assistant',
+        content: 'Canonical reply',
+        artifacts: [],
+        toolCalls: [],
+        timestamp: '2026-03-16T10:00:02.000Z',
+      });
+
+      const messages = useMessageStore.getState().messagesByTask[taskId];
+      expect(messages).toEqual([
+        expect.objectContaining({
+          id: 'canonical-only',
+          content: 'Canonical reply',
+        }),
+      ]);
+      expect(useMessageStore.getState().activeTurnBySession).toEqual({});
+    });
+  });
+});
+
+describe('message store upsertToolCall fallback chain', () => {
+  const sessionKey = 'agent:main:clawwork:task:task-1';
+  const taskId = 'task-1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupClawworkMock();
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('22222222-2222-4222-8222-222222222222');
+  });
+
+  it('updates tool calls on an existing active turn without persisting', async () => {
+    const { useMessageStore } = await loadStore();
+    resetStoreState(useMessageStore, {
+      activeTurnBySession: {
+        [sessionKey]: {
+          id: 'turn-tool',
+          streamingText: 'Working',
+          streamingThinking: '',
+          toolCalls: [
+            {
+              id: 'exec-1',
+              name: 'exec',
+              status: 'running',
+              startedAt: '2026-03-16T10:00:00.000Z',
+            },
+          ],
+          finalized: false,
+          content: '',
+          timestamp: '2026-03-16T10:00:00.000Z',
+        },
+      },
+    });
+
+    useMessageStore.getState().upsertToolCall(sessionKey, taskId, {
+      id: 'exec-1',
+      name: 'exec',
+      status: 'done',
+      result: 'finished',
+      startedAt: '2026-03-16T10:00:00.000Z',
+      completedAt: '2026-03-16T10:00:02.000Z',
+    });
+
+    expect(useMessageStore.getState().activeTurnBySession[sessionKey].toolCalls).toEqual([
+      expect.objectContaining({ id: 'exec-1', status: 'done', result: 'finished' }),
+    ]);
+    expect(useMessageStore.getState().messagesByTask[taskId]).toBeUndefined();
+    expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the latest assistant message after the latest user message', async () => {
+    const { useMessageStore } = await loadStore();
+    resetStoreState(useMessageStore, {
+      messagesByTask: {
+        [taskId]: [
+          {
+            id: 'user-1',
+            taskId,
+            role: 'user',
+            content: 'Run command',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+          {
+            id: 'assistant-1',
+            taskId,
+            role: 'assistant',
+            content: 'Running',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T10:00:01.000Z',
+          },
+        ],
+      },
+    });
+
+    useMessageStore.getState().upsertToolCall(sessionKey, taskId, {
+      id: 'exec-1',
+      name: 'exec',
+      status: 'running',
+      startedAt: '2026-03-16T10:00:02.000Z',
+    });
+
+    const assistant = useMessageStore.getState().messagesByTask[taskId][1];
+    expect(assistant.toolCalls).toEqual([expect.objectContaining({ id: 'exec-1', status: 'running' })]);
+    expect(window.clawwork.persistMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'assistant-1',
+        toolCalls: [expect.objectContaining({ id: 'exec-1', status: 'running' })],
+      }),
+    );
+  });
+
+  it('creates a new active turn when the latest assistant predates the latest user message', async () => {
+    const { useMessageStore } = await loadStore();
+    resetStoreState(useMessageStore, {
+      messagesByTask: {
+        [taskId]: [
+          {
+            id: 'assistant-old',
+            taskId,
+            role: 'assistant',
+            content: 'Old reply',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T10:00:00.000Z',
+          },
+          {
+            id: 'user-1',
+            taskId,
+            role: 'user',
+            content: 'Follow up',
+            artifacts: [],
+            toolCalls: [],
+            timestamp: '2026-03-16T10:00:01.000Z',
+          },
+        ],
+      },
+    });
+
+    useMessageStore.getState().upsertToolCall(sessionKey, taskId, {
+      id: 'exec-1',
+      name: 'exec',
+      status: 'running',
+      startedAt: '2026-03-16T10:00:02.000Z',
+    });
+
+    expect(useMessageStore.getState().activeTurnBySession[sessionKey]).toEqual(
+      expect.objectContaining({
+        id: '22222222-2222-4222-8222-222222222222',
+        toolCalls: [expect.objectContaining({ id: 'exec-1', status: 'running' })],
+      }),
+    );
+    expect(useMessageStore.getState().messagesByTask[taskId]).toHaveLength(2);
     expect(window.clawwork.persistMessage).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Expand `packages/desktop/test/message-store.test.ts` with dedicated unit tests for the streaming lifecycle (`appendStreamDelta`, `finalizeStream`, `promoteActiveTurn`) and the full `upsertToolCall` fallback chain.
- Add shared test helpers (`setupClawworkMock`, `resetStoreState`) and use valid UUID strings for `crypto.randomUUID` mocks.

Closes #232

## Test plan
- [x] `pnpm --filter @clawwork/desktop test -- test/message-store.test.ts` — 14/14 pass
- [x] Full desktop suite — 387/387 pass
- [x] `pnpm --filter @clawwork/desktop exec tsc --noEmit -p tsconfig.test.json`

Made with [Cursor](https://cursor.com)