### PR TITLE
[Fix] use path.sep in migrateWorkspace nested-path guard

### DIFF
--- a/packages/desktop/src/main/workspace/init.ts
+++ b/packages/desktop/src/main/workspace/init.ts
@@ -12,7 +12,7 @@ export async function migrateWorkspace(oldPath: string, newPath: string): Promis
   if (!existsSync(oldPath)) throw new Error(`Source workspace does not exist: ${oldPath}`);
   const resolvedOld = resolve(oldPath);
   const resolvedNew = resolve(newPath);
-  if (resolvedNew.startsWith(resolvedOld + '/') || resolvedNew === resolvedOld) {
+  if (resolvedNew.startsWith(resolvedOld + sep) || resolvedNew === resolvedOld) {
     throw new Error('New workspace path must not be inside or equal to the current workspace');
   }
   await cp(resolvedOld, resolvedNew, {

--- a/packages/desktop/src/main/workspace/init.ts
+++ b/packages/desktop/src/main/workspace/init.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, existsSync } from 'fs';
 import { cp } from 'fs/promises';
 import { join, resolve, sep } from 'path';
+import { sep as winSep } from 'node:path/win32';
 
 export async function initWorkspace(workspacePath: string): Promise<void> {
   if (!existsSync(workspacePath)) {
@@ -8,11 +9,20 @@ export async function initWorkspace(workspacePath: string): Promise<void> {
   }
 }
 
+/** True when the destination is the same as or nested inside the source workspace path. */
+export function isNestedOrEqualWorkspacePath(resolvedOld: string, resolvedNew: string): boolean {
+  const caseInsensitive = process.platform === 'win32' || process.platform === 'darwin';
+  const normOld = caseInsensitive ? resolvedOld.toLowerCase() : resolvedOld;
+  const normNew = caseInsensitive ? resolvedNew.toLowerCase() : resolvedNew;
+  const pathSep = process.platform === 'win32' ? winSep : sep;
+  return normNew === normOld || normNew.startsWith(normOld + pathSep);
+}
+
 export async function migrateWorkspace(oldPath: string, newPath: string): Promise<void> {
   if (!existsSync(oldPath)) throw new Error(`Source workspace does not exist: ${oldPath}`);
   const resolvedOld = resolve(oldPath);
   const resolvedNew = resolve(newPath);
-  if (resolvedNew.startsWith(resolvedOld + sep) || resolvedNew === resolvedOld) {
+  if (isNestedOrEqualWorkspacePath(resolvedOld, resolvedNew)) {
     throw new Error('New workspace path must not be inside or equal to the current workspace');
   }
   await cp(resolvedOld, resolvedNew, {

--- a/packages/desktop/test/workspace-init.test.ts
+++ b/packages/desktop/test/workspace-init.test.ts
@@ -9,7 +9,7 @@ vi.mock('fs/promises', () => ({
 }));
 
 import { cp } from 'fs/promises';
-import { migrateWorkspace } from '../src/main/workspace/init.js';
+import { migrateWorkspace, isNestedOrEqualWorkspacePath } from '../src/main/workspace/init.js';
 
 const cpMock = vi.mocked(cp);
 
@@ -60,5 +60,31 @@ describe('migrateWorkspace', () => {
 
     expect(resolvedNew.startsWith(resolvedOld + '/')).toBe(false);
     expect(resolvedNew.startsWith(resolvedOld + winSep)).toBe(true);
+  });
+});
+
+describe('isNestedOrEqualWorkspacePath', () => {
+  it('is case-sensitive on linux', () => {
+    const resolvedOld = winResolve('C:\\Workspace');
+    const resolvedNew = winResolve('C:\\workspace\\sub');
+    expect(isNestedOrEqualWorkspacePath(resolvedOld, resolvedNew)).toBe(false);
+  });
+
+  it('is case-insensitive on win32', () => {
+    const resolvedOld = winResolve('C:\\Workspace');
+    const resolvedNew = winResolve('C:\\workspace\\sub');
+
+    const win32Spy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    expect(isNestedOrEqualWorkspacePath(resolvedOld, resolvedNew)).toBe(true);
+    win32Spy.mockRestore();
+  });
+
+  it('is case-insensitive on darwin', () => {
+    const resolvedOld = resolve('/Users/Test/Workspace');
+    const resolvedNew = resolve('/users/test/workspace/sub');
+
+    const darwinSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    expect(isNestedOrEqualWorkspacePath(resolvedOld, resolvedNew)).toBe(true);
+    darwinSpy.mockRestore();
   });
 });

--- a/packages/desktop/test/workspace-init.test.ts
+++ b/packages/desktop/test/workspace-init.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { resolve as winResolve, sep as winSep } from 'node:path/win32';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('fs/promises', () => ({
+  cp: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { cp } from 'fs/promises';
+import { migrateWorkspace } from '../src/main/workspace/init.js';
+
+const cpMock = vi.mocked(cp);
+
+describe('migrateWorkspace', () => {
+  let oldDir: string;
+
+  beforeEach(() => {
+    cpMock.mockClear();
+    oldDir = mkdtempSync(join(tmpdir(), 'clawwork-ws-old-'));
+  });
+
+  afterEach(() => {
+    rmSync(oldDir, { recursive: true, force: true });
+  });
+
+  it('rejects when new path is inside the current workspace', async () => {
+    const nested = join(oldDir, 'sub');
+    await expect(migrateWorkspace(oldDir, nested)).rejects.toThrow(
+      'New workspace path must not be inside or equal to the current workspace',
+    );
+    expect(cpMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when new path equals the current workspace', async () => {
+    await expect(migrateWorkspace(oldDir, oldDir)).rejects.toThrow(
+      'New workspace path must not be inside or equal to the current workspace',
+    );
+    expect(cpMock).not.toHaveBeenCalled();
+  });
+
+  it('allows migration to a sibling directory', async () => {
+    const newDir = mkdtempSync(join(tmpdir(), 'clawwork-ws-new-'));
+    try {
+      await migrateWorkspace(oldDir, newDir);
+      expect(cpMock).toHaveBeenCalledWith(resolve(oldDir), resolve(newDir), {
+        recursive: true,
+        errorOnExist: false,
+        force: true,
+      });
+    } finally {
+      rmSync(newDir, { recursive: true, force: true });
+    }
+  });
+
+  it('detects nested Windows paths when using the platform separator', () => {
+    const resolvedOld = winResolve('C:\\workspace');
+    const resolvedNew = winResolve('C:\\workspace\\sub');
+
+    expect(resolvedNew.startsWith(resolvedOld + '/')).toBe(false);
+    expect(resolvedNew.startsWith(resolvedOld + winSep)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #382

## Summary
`migrateWorkspace` used a hardcoded `/` when checking whether the new workspace path is inside the old one. On Windows, `path.resolve()` returns backslash paths, so the guard never fired and a recursive copy loop was possible.

Uses `path.sep` (same pattern as `ensureTaskDir` in the same file). Also adds a case-insensitive path guard for Windows/macOS.

## Test plan
- [x] `pnpm --filter @clawwork/desktop test` (includes `workspace-init.test.ts`)
- [x] Unix nested-path rejection + win32 separator regression test

## Release note
```release-note
Fixed workspace migration allowing a nested destination path on Windows, which could fill the disk with recursive copies.
```