### PR TITLE
test(desktop): file-index skips root-level hidden dotfiles (Closes #390)

### DIFF
--- a/packages/desktop/test/file-index.test.ts
+++ b/packages/desktop/test/file-index.test.ts
@@ -1,0 +1,27 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { scanFolder } from '../src/main/context/file-index.js';
+
+describe('scanFolder hidden files', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'clawwork-file-index-'));
+    writeFileSync(join(dir, 'file.ts'), 'export const x = 1;\n');
+    writeFileSync(join(dir, '.DS_Store'), 'noise');
+    writeFileSync(join(dir, '.env'), 'SECRET=1\n');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('skips hidden dotfiles at the scan root but keeps allow-listed ones', () => {
+    const names = scanFolder(dir)
+      .map((e) => e.fileName)
+      .sort();
+    expect(names).toEqual(['.env', 'file.ts']);
+  });
+});


### PR DESCRIPTION
Closes #390

## Summary
Adds a regression test for `scanFolder` / `walkDir` hidden-file filtering at depth 0.

The implementation already skips hidden dotfiles at the scan root while keeping allow-listed entries (`.env`, `.gitignore`, `.dockerfile`).

## Test plan
- [x] `pnpm --filter @clawwork/desktop test -- file-index.test.ts`