### PR TITLE
fix(desktop): stream safeFetch bodies with incremental maxSize enforcement (Closes #408)

### DIFF
--- a/packages/desktop/src/main/net/safe-fetch.ts
+++ b/packages/desktop/src/main/net/safe-fetch.ts
@@ -52,9 +52,23 @@ export async function safeFetch(url: string, opts: SafeFetchOptions = {}): Promi
     if (!res.ok) throw new Error(`fetch ${url}: ${res.status}`);
     const cl = Number(res.headers.get('content-length') ?? '0');
     if (cl > maxSize) throw new Error('response too large');
-    const ab = await res.arrayBuffer();
-    if (ab.byteLength > maxSize) throw new Error('response too large');
-    return Buffer.from(ab);
+
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error('response has no body');
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxSize) {
+        controller.abort();
+        throw new Error('response too large');
+      }
+      chunks.push(Buffer.from(value));
+    }
+    return Buffer.concat(chunks);
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/desktop/test/safe-fetch.test.ts
+++ b/packages/desktop/test/safe-fetch.test.ts
@@ -38,11 +38,27 @@ beforeEach(() => {
 });
 
 function mockResponse(body: ArrayBuffer, status = 200, headers: Record<string, string> = {}): Response {
+  const bytes = new Uint8Array(body);
   return {
     ok: status >= 200 && status < 300,
     status,
     headers: new Headers(headers),
     arrayBuffer: () => Promise.resolve(body),
+    body: {
+      getReader: () => {
+        let offset = 0;
+        const chunkSize = 256;
+        return {
+          read: async () => {
+            if (offset >= bytes.length) return { done: true, value: undefined };
+            const end = Math.min(offset + chunkSize, bytes.length);
+            const value = bytes.subarray(offset, end);
+            offset = end;
+            return { done: false, value };
+          },
+        };
+      },
+    },
   } as unknown as Response;
 }
 
@@ -137,6 +153,14 @@ describe('safeFetch', () => {
     netFetchMock.mockResolvedValue(mockResponse(big));
 
     await expect(safeFetch('https://cdn.example.com/big.bin', { maxSize: 1024 })).rejects.toThrow('too large');
+  });
+
+  it('rejects streaming bodies without content-length before exceeding maxSize', async () => {
+    assertNotPrivateHostMock.mockResolvedValue(null);
+    const big = new ArrayBuffer(4096);
+    netFetchMock.mockResolvedValue(mockResponse(big, 200, {}));
+
+    await expect(safeFetch('https://cdn.example.com/stream.bin', { maxSize: 1024 })).rejects.toThrow('too large');
   });
 
   it('rejects on non-ok HTTP status', async () => {


### PR DESCRIPTION
Closes #408

## Summary
`safeFetch` now reads response bodies with `getReader()` and aborts once `maxSize` is exceeded, instead of calling `arrayBuffer()` on the full payload first.

## Test plan
- [x] `pnpm --filter @clawwork/desktop test -- safe-fetch.test.ts`