### PR TITLE
fix(desktop): refresh renderer stores after workspace change (Closes #404)

### DIFF
--- a/packages/core/src/services/session-sync.ts
+++ b/packages/core/src/services/session-sync.ts
@@ -428,5 +428,13 @@ export function createSessionSync(deps: SessionSyncDeps) {
     }
   }
 
-  return { hydrateFromLocal, syncSessionMessages, syncFromGateway, retrySyncPending };
+  return {
+    hydrateFromLocal,
+    syncSessionMessages,
+    syncFromGateway,
+    retrySyncPending,
+    resetHydration: () => {
+      hydrationPromise = null;
+    },
+  };
 }

--- a/packages/core/src/stores/message-store.ts
+++ b/packages/core/src/stores/message-store.ts
@@ -39,6 +39,7 @@ export interface MessageState {
   clearMessages: (taskId: string) => void;
   setHighlightedMessage: (id: string | null) => void;
   setProcessing: (sessionKey: string, processing: boolean) => void;
+  resetForWorkspaceChange: () => void;
 }
 
 export interface MessageStoreDeps {
@@ -360,6 +361,14 @@ export function createMessageStore(deps: MessageStoreDeps) {
         if (processing) next.add(sessionKey);
         else next.delete(sessionKey);
         return { processingBySession: next };
+      }),
+
+    resetForWorkspaceChange: () =>
+      set({
+        messagesByTask: {},
+        activeTurnBySession: {},
+        processingBySession: new Set(),
+        highlightedMessageId: null,
       }),
   }));
 }

--- a/packages/core/src/stores/room-store.ts
+++ b/packages/core/src/stores/room-store.ts
@@ -62,6 +62,7 @@ export interface RoomState {
   lookupTaskIdBySubagentKey: (subagentKey: string) => string | undefined;
   registerPerformerKey: (taskId: string, subagentKey: string, agentId: string, agentName: string) => void;
   verifyCandidates: (taskId: string, gatewayId: string) => Promise<void>;
+  resetForWorkspaceChange: () => void;
 }
 
 const VERIFY_COOLDOWN_MS = 2000;
@@ -222,6 +223,12 @@ export function createRoomStore(deps: RoomStoreDeps) {
       } finally {
         setTimeout(() => verifyInFlight.delete(taskId), VERIFY_COOLDOWN_MS);
       }
+    },
+
+    resetForWorkspaceChange: () => {
+      taskGateways.clear();
+      verifyInFlight.clear();
+      set({ rooms: {}, subagentKeyMap: {} });
     },
   }));
 

--- a/packages/core/src/stores/task-store.ts
+++ b/packages/core/src/stores/task-store.ts
@@ -41,6 +41,7 @@ export interface TaskState {
     },
   ) => void;
   removeTask: (id: string) => void;
+  resetForWorkspaceChange: () => void;
   hydrate: () => Promise<void>;
   adoptTasks: (
     discovered: {
@@ -251,6 +252,14 @@ export function createTaskStore(deps: TaskStoreDeps) {
         console.error('[persist:task]', err);
       });
     },
+
+    resetForWorkspaceChange: () =>
+      set({
+        tasks: [],
+        activeTaskId: null,
+        hydrated: false,
+        pendingNewTask: null,
+      }),
 
     hydrate: async () => {
       if (get().hydrated) return;

--- a/packages/desktop/src/main/ipc/workspace-handlers.ts
+++ b/packages/desktop/src/main/ipc/workspace-handlers.ts
@@ -13,6 +13,12 @@ import { reinitDatabase, closeDatabase } from '../db/index.js';
 
 const TEAM_WORKSPACE_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
+function broadcastWorkspaceChanged(workspacePath: string): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('workspace:changed', { workspacePath });
+  }
+}
+
 export function registerWorkspaceHandlers(): void {
   ipcMain.handle('workspace:open-folder', () => {
     const p = getWorkspacePath();
@@ -59,6 +65,7 @@ export function registerWorkspaceHandlers(): void {
       await migrateWorkspace(oldPath, newWorkspacePath);
       reinitDatabase(newWorkspacePath);
       updateConfig({ workspacePath: newWorkspacePath });
+      broadcastWorkspaceChanged(newWorkspacePath);
       return { ok: true };
     } catch (err) {
       reinitDatabase(oldPath);

--- a/packages/desktop/src/preload/clawwork.d.ts
+++ b/packages/desktop/src/preload/clawwork.d.ts
@@ -352,6 +352,7 @@ export interface ClawWorkAPI {
   browseWorkspace: () => Promise<string | null>;
   setupWorkspace: (path: string) => Promise<IpcResult>;
   changeWorkspace: (path: string) => Promise<IpcResult>;
+  onWorkspaceChanged: (callback: (payload: { workspacePath: string }) => void) => () => void;
 
   getSettings: () => Promise<AppSettings | null>;
   updateSettings: (partial: Partial<AppSettings>) => Promise<{ ok: boolean; config: AppSettings }>;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -164,6 +164,15 @@ function buildApi(): ClawWorkAPI {
     browseWorkspace: () => ipcRenderer.invoke('workspace:browse') as Promise<string | null>,
     setupWorkspace: (path: string) => ipcRenderer.invoke('workspace:setup', path),
     changeWorkspace: (path: string) => ipcRenderer.invoke('workspace:change', path),
+    onWorkspaceChanged: (callback: (payload: { workspacePath: string }) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload: { workspacePath: string }): void => {
+        callback(payload);
+      };
+      ipcRenderer.on('workspace:changed', listener);
+      return () => {
+        ipcRenderer.removeListener('workspace:changed', listener);
+      };
+    },
 
     getSettings: () => ipcRenderer.invoke('settings:get'),
     updateSettings: (partial: Record<string, unknown>) => ipcRenderer.invoke('settings:update', partial),

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { composer } from './platform';
 import { useGatewayBootstrap } from './hooks/useGatewayBootstrap';
 import { useUpdateCheck } from './hooks/useUpdateCheck';
 import { useTraySync } from './hooks/useTraySync';
+import { useWorkspaceRefresh } from './hooks/useWorkspaceRefresh';
 import { cn } from '@/lib/utils';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { motionDuration, motionEase } from '@/styles/design-tokens';
@@ -65,6 +66,7 @@ export default function App() {
   useGatewayBootstrap();
   useUpdateCheck();
   useTraySync();
+  useWorkspaceRefresh();
 
   const startPanelDrag = useCallback(
     (e: React.MouseEvent, startWidth: number, setWidth: (w: number) => void, dir: 1 | -1) => {

--- a/packages/desktop/src/renderer/hooks/useWorkspaceRefresh.ts
+++ b/packages/desktop/src/renderer/hooks/useWorkspaceRefresh.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { refreshWorkspaceData } from '../lib/workspace-refresh';
+import { useSettingsStore } from '../stores/settingsStore';
+
+/** Re-hydrate renderer stores when the main process switches workspace DB. */
+export function useWorkspaceRefresh(): void {
+  const refreshSettings = useSettingsStore((s) => s.refresh);
+
+  useEffect(() => {
+    const cleanup = window.clawwork.onWorkspaceChanged((payload) => {
+      void refreshSettings()
+        .catch((err) => console.error('[workspace] refreshSettings failed:', err))
+        .then(() => refreshWorkspaceData())
+        .catch((err) => console.error('[workspace] refreshWorkspaceData failed:', err));
+      console.info('[workspace] switched to', payload.workspacePath);
+    });
+    return cleanup;
+  }, [refreshSettings]);
+}

--- a/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/SystemSection.tsx
@@ -19,7 +19,6 @@ export default function SystemSection() {
   const workspacePath = useSettingsStore((s) => s.settings?.workspacePath);
   const settingsLoaded = useSettingsStore((s) => s.loaded);
   const loadSettings = useSettingsStore((s) => s.load);
-  const refreshSettings = useSettingsStore((s) => s.refresh);
 
   useEffect(() => {
     window.clawwork
@@ -79,7 +78,6 @@ export default function SystemSection() {
     try {
       const result = await window.clawwork.changeWorkspace(selected);
       if (result.ok) {
-        await refreshSettings().catch(() => {});
         toast.success(t('settings.workspaceChanged'), {
           description: t('settings.workspaceOldPathHint', { path: oldPath }),
           duration: 8000,
@@ -93,7 +91,7 @@ export default function SystemSection() {
     } finally {
       setChangingWorkspace(false);
     }
-  }, [refreshSettings, workspacePath, t]);
+  }, [workspacePath, t]);
 
   const handleShortcutRecord = useCallback(
     (e: React.KeyboardEvent) => {

--- a/packages/desktop/src/renderer/lib/session-sync.ts
+++ b/packages/desktop/src/renderer/lib/session-sync.ts
@@ -11,4 +11,4 @@ const sync = createSessionSync({
   }),
 });
 
-export const { hydrateFromLocal, syncSessionMessages, syncFromGateway, retrySyncPending } = sync;
+export const { hydrateFromLocal, syncSessionMessages, syncFromGateway, retrySyncPending, resetHydration } = sync;

--- a/packages/desktop/src/renderer/lib/workspace-refresh.ts
+++ b/packages/desktop/src/renderer/lib/workspace-refresh.ts
@@ -1,0 +1,18 @@
+import { hydrateFromLocal, resetHydration, syncFromGateway } from '../lib/session-sync';
+import { useApprovalStore } from '../stores/approvalStore';
+import { useFileStore } from '../stores/fileStore';
+import { useMessageStore, useRoomStore, useTaskStore, useUiStore } from '../platform';
+
+/** Clear renderer caches and reload tasks/messages from the new workspace DB. */
+export async function refreshWorkspaceData(): Promise<void> {
+  resetHydration();
+  useTaskStore.getState().resetForWorkspaceChange();
+  useMessageStore.getState().resetForWorkspaceChange();
+  useRoomStore.getState().resetForWorkspaceChange();
+  useFileStore.getState().resetForWorkspaceChange();
+  useApprovalStore.getState().clear();
+  useUiStore.setState({ unreadTaskIds: new Set(), mainView: 'chat', settingsOpen: false });
+
+  await hydrateFromLocal();
+  await syncFromGateway();
+}

--- a/packages/desktop/src/renderer/stores/fileStore.ts
+++ b/packages/desktop/src/renderer/stores/fileStore.ts
@@ -32,6 +32,7 @@ interface FileState {
   setSearchResults: (results: ArtifactSearchResult[] | null) => void;
   setIsSearching: (v: boolean) => void;
   setTypeFilter: (filter: ArtifactKindFilter) => void;
+  resetForWorkspaceChange: () => void;
 }
 
 export const useFileStore = create<FileState>((set) => ({
@@ -61,4 +62,14 @@ export const useFileStore = create<FileState>((set) => ({
   setIsSearching: (v) => set({ isSearching: v }),
 
   setTypeFilter: (filter) => set({ typeFilter: filter }),
+
+  resetForWorkspaceChange: () =>
+    set({
+      artifacts: [],
+      selectedArtifactId: null,
+      searchQuery: '',
+      searchResults: null,
+      isSearching: false,
+      typeFilter: 'all',
+    }),
 }));

--- a/packages/desktop/test/workspace-handlers.test.ts
+++ b/packages/desktop/test/workspace-handlers.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+const webContentsSendMock = vi.fn();
 
 const isWorkspaceConfiguredMock = vi.fn(() => false);
 const getWorkspacePathMock = vi.fn<() => string | null>(() => '/tmp/old-workspace');
@@ -17,7 +18,7 @@ const closeDatabaseMock = vi.fn();
 
 vi.mock('electron', () => ({
   BrowserWindow: {
-    getAllWindows: vi.fn(() => []),
+    getAllWindows: vi.fn(() => [{ webContents: { send: webContentsSendMock } }]),
   },
   dialog: {
     showOpenDialog: vi.fn(),
@@ -98,6 +99,9 @@ describe('registerWorkspaceHandlers', () => {
     expect(closeDatabaseMock).toHaveBeenCalledTimes(1);
     expect(reinitDatabaseMock).toHaveBeenCalledWith('/tmp/new-workspace');
     expect(updateConfigMock).toHaveBeenCalledWith({ workspacePath: '/tmp/new-workspace' });
+    expect(webContentsSendMock).toHaveBeenCalledWith('workspace:changed', {
+      workspacePath: '/tmp/new-workspace',
+    });
   });
 
   it('returns error without closing database when migration fails', async () => {


### PR DESCRIPTION
Closes #404

## Summary
- Main process broadcasts `workspace:changed` after a successful workspace migration
- Renderer clears task/message/room/file/approval stores and re-hydrates from the new SQLite DB
- `useWorkspaceRefresh` hook wires the IPC event globally

## Test plan
- [x] `pnpm --filter @clawwork/desktop test -- workspace-handlers.test.ts`