### PR TITLE
refactor(ui): consolidate gateway maps into unified registry (Closes #342)

### DIFF
--- a/packages/core/src/stores/ui-store-gateway.ts
+++ b/packages/core/src/stores/ui-store-gateway.ts
@@ -1,0 +1,82 @@
+import type { GatewayState, UiState } from './ui-store.js';
+
+export function emptyGatewayState(gatewayId: string): GatewayState {
+  return {
+    status: 'disconnected',
+    info: { id: gatewayId, name: '' },
+    models: [],
+    agents: { agents: [], defaultId: '' },
+    tools: null,
+    skills: null,
+  };
+}
+
+/** Merge a gateway patch into registry and keep legacy per-field maps in sync. */
+export function patchGatewayState(s: UiState, gatewayId: string, patch: Partial<GatewayState>): Partial<UiState> {
+  const prev = s.gatewayRegistry[gatewayId] ?? emptyGatewayState(gatewayId);
+  const entry: GatewayState = {
+    ...prev,
+    ...patch,
+    info: patch.info ? { ...prev.info, ...patch.info } : prev.info,
+    agents: patch.agents ? { ...prev.agents, ...patch.agents } : prev.agents,
+  };
+
+  const out: Partial<UiState> = {
+    gatewayRegistry: { ...s.gatewayRegistry, [gatewayId]: entry },
+    gatewayStatusMap: { ...s.gatewayStatusMap, [gatewayId]: entry.status },
+  };
+
+  if ('version' in patch) {
+    if (entry.version === undefined) {
+      const next = { ...s.gatewayVersionMap };
+      delete next[gatewayId];
+      out.gatewayVersionMap = next;
+    } else {
+      out.gatewayVersionMap = { ...s.gatewayVersionMap, [gatewayId]: entry.version };
+    }
+  }
+
+  if ('reconnectInfo' in patch) {
+    if (entry.reconnectInfo === undefined) {
+      const next = { ...s.gatewayReconnectInfo };
+      delete next[gatewayId];
+      out.gatewayReconnectInfo = next;
+    } else {
+      out.gatewayReconnectInfo = { ...s.gatewayReconnectInfo, [gatewayId]: entry.reconnectInfo };
+    }
+  }
+
+  if (patch.info !== undefined) {
+    out.gatewayInfoMap = { ...s.gatewayInfoMap, [gatewayId]: entry.info };
+  }
+  if (patch.models !== undefined) {
+    out.modelCatalogByGateway = { ...s.modelCatalogByGateway, [gatewayId]: entry.models };
+  }
+  if (patch.agents !== undefined) {
+    out.agentCatalogByGateway = { ...s.agentCatalogByGateway, [gatewayId]: entry.agents };
+  }
+  if (patch.tools !== undefined) {
+    if (entry.tools === null) {
+      const next = { ...s.toolsCatalogByGateway };
+      delete next[gatewayId];
+      out.toolsCatalogByGateway = next;
+    } else {
+      out.toolsCatalogByGateway = { ...s.toolsCatalogByGateway, [gatewayId]: entry.tools };
+    }
+  }
+  if (patch.skills !== undefined) {
+    if (entry.skills === null) {
+      const next = { ...s.skillsStatusByGateway };
+      delete next[gatewayId];
+      out.skillsStatusByGateway = next;
+    } else {
+      out.skillsStatusByGateway = { ...s.skillsStatusByGateway, [gatewayId]: entry.skills };
+    }
+  }
+
+  return out;
+}
+
+export function applyGatewayPatch(s: UiState, gatewayId: string, patch: Partial<GatewayState>): UiState {
+  return { ...s, ...patchGatewayState(s, gatewayId, patch) };
+}

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'zustand/vanilla';
 import type { AgentInfo, CommandEntry, ModelCatalogEntry, SkillStatusReport, ToolsCatalog } from '@clawwork/shared';
+import { applyGatewayPatch, emptyGatewayState, patchGatewayState } from './ui-store-gateway.js';
 
 export type MainView = 'chat' | 'files' | 'archived' | 'cron' | 'teams' | 'dashboard';
 export type Theme = 'dark' | 'light' | 'auto';
@@ -51,6 +52,8 @@ export interface UiState {
   setGatewayStatusByGateway: (gatewayId: string, status: GatewayConnectionStatus) => void;
 
   gatewayRegistry: Record<string, GatewayState>;
+  updateGateway: (gatewayId: string, patch: Partial<GatewayState>) => void;
+  getGatewayState: (gatewayId: string) => GatewayState;
 
   gatewayVersionMap: Record<string, string>;
   setGatewayVersion: (gatewayId: string, version: string | undefined) => void;
@@ -184,37 +187,29 @@ export function createUiStore(deps: UiStoreDeps) {
     },
 
     gatewayStatusMap: {},
-    setGatewayStatusByGateway: (gatewayId, status) =>
-      set((s) => ({
-        gatewayStatusMap: { ...s.gatewayStatusMap, [gatewayId]: status },
-      })),
+    setGatewayStatusByGateway: (gatewayId, status) => set((s) => patchGatewayState(s, gatewayId, { status })),
 
     gatewayRegistry: {},
+    updateGateway: (gatewayId, patch) => set((s) => patchGatewayState(s, gatewayId, patch)),
+    getGatewayState: (gatewayId) => get().gatewayRegistry[gatewayId] ?? emptyGatewayState(gatewayId),
 
     gatewayVersionMap: {},
     setGatewayVersion: (gatewayId, version) =>
       set((s) => {
-        const current = s.gatewayVersionMap[gatewayId];
         if (!version) {
-          if (current === undefined) return s;
-          const next = { ...s.gatewayVersionMap };
-          delete next[gatewayId];
-          return { gatewayVersionMap: next };
+          return patchGatewayState(s, gatewayId, { version: undefined });
         }
-        if (current === version) return s;
-        return { gatewayVersionMap: { ...s.gatewayVersionMap, [gatewayId]: version } };
+        if (s.gatewayVersionMap[gatewayId] === version) return s;
+        return patchGatewayState(s, gatewayId, { version });
       }),
 
     gatewayReconnectInfo: {},
     setGatewayReconnectInfo: (gatewayId, info) =>
-      set((s) => {
-        if (info === null) {
-          const next = { ...s.gatewayReconnectInfo };
-          delete next[gatewayId];
-          return { gatewayReconnectInfo: next };
-        }
-        return { gatewayReconnectInfo: { ...s.gatewayReconnectInfo, [gatewayId]: info } };
-      }),
+      set((s) =>
+        patchGatewayState(s, gatewayId, {
+          reconnectInfo: info === null ? undefined : info,
+        }),
+      ),
 
     gatewaysLoaded: false,
     setGatewaysLoaded: (loaded) => set({ gatewaysLoaded: loaded }),
@@ -223,7 +218,14 @@ export function createUiStore(deps: UiStoreDeps) {
     setDefaultGatewayId: (id) => set({ defaultGatewayId: id }),
 
     gatewayInfoMap: {},
-    setGatewayInfoMap: (map) => set({ gatewayInfoMap: map }),
+    setGatewayInfoMap: (map) =>
+      set((s) => {
+        let state: UiState = { ...s, gatewayInfoMap: map };
+        for (const [id, info] of Object.entries(map)) {
+          state = applyGatewayPatch(state, id, { info });
+        }
+        return state;
+      }),
 
     unreadTaskIds: new Set(),
     markUnread: (taskId) =>
@@ -243,40 +245,17 @@ export function createUiStore(deps: UiStoreDeps) {
     setHasUpdate: (has) => set({ hasUpdate: has }),
 
     modelCatalogByGateway: {},
-    setModelCatalogForGateway: (gatewayId, models) =>
-      set((s) => ({
-        modelCatalogByGateway: {
-          ...s.modelCatalogByGateway,
-          [gatewayId]: models,
-        },
-      })),
+    setModelCatalogForGateway: (gatewayId, models) => set((s) => patchGatewayState(s, gatewayId, { models })),
 
     agentCatalogByGateway: {},
     setAgentCatalogForGateway: (gatewayId, agents, defaultId) =>
-      set((s) => ({
-        agentCatalogByGateway: {
-          ...s.agentCatalogByGateway,
-          [gatewayId]: { agents, defaultId },
-        },
-      })),
+      set((s) => patchGatewayState(s, gatewayId, { agents: { agents, defaultId } })),
 
     toolsCatalogByGateway: {},
-    setToolsCatalogForGateway: (gatewayId, catalog) =>
-      set((s) => ({
-        toolsCatalogByGateway: {
-          ...s.toolsCatalogByGateway,
-          [gatewayId]: catalog,
-        },
-      })),
+    setToolsCatalogForGateway: (gatewayId, catalog) => set((s) => patchGatewayState(s, gatewayId, { tools: catalog })),
 
     skillsStatusByGateway: {},
-    setSkillsStatusForGateway: (gatewayId, report) =>
-      set((s) => ({
-        skillsStatusByGateway: {
-          ...s.skillsStatusByGateway,
-          [gatewayId]: report,
-        },
-      })),
+    setSkillsStatusForGateway: (gatewayId, report) => set((s) => patchGatewayState(s, gatewayId, { skills: report })),
 
     commandCatalogByGateway: {},
     setCommandCatalogForGateway: (gatewayId, commands) =>

--- a/packages/core/test/ui-store-gateway.test.ts
+++ b/packages/core/test/ui-store-gateway.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { createUiStore } from '../src/stores/ui-store.js';
+
+describe('gateway registry', () => {
+  it('updateGateway keeps registry and legacy maps in sync', () => {
+    const store = createUiStore({
+      updateSettings: async () => ({}),
+      changeLanguage: () => {},
+      storage: { get: () => null, set: () => {} },
+    });
+
+    store.getState().updateGateway('gw-1', {
+      status: 'connected',
+      version: '1.2.3',
+      info: { id: 'gw-1', name: 'Home' },
+      models: [{ id: 'gpt-4', name: 'GPT-4', provider: 'openai' }],
+      agents: { agents: [], defaultId: 'main' },
+    });
+
+    const s = store.getState();
+    expect(s.gatewayRegistry['gw-1']?.status).toBe('connected');
+    expect(s.gatewayStatusMap['gw-1']).toBe('connected');
+    expect(s.gatewayVersionMap['gw-1']).toBe('1.2.3');
+    expect(s.gatewayInfoMap['gw-1']?.name).toBe('Home');
+    expect(s.modelCatalogByGateway['gw-1']).toHaveLength(1);
+    expect(s.getGatewayState('gw-1').status).toBe('connected');
+  });
+
+  it('setGatewayStatusByGateway updates registry entry', () => {
+    const store = createUiStore({
+      updateSettings: async () => ({}),
+      changeLanguage: () => {},
+      storage: { get: () => null, set: () => {} },
+    });
+
+    store.getState().setGatewayStatusByGateway('gw-2', 'connecting');
+    expect(store.getState().gatewayRegistry['gw-2']?.status).toBe('connecting');
+    expect(store.getState().gatewayStatusMap['gw-2']).toBe('connecting');
+  });
+});


### PR DESCRIPTION
Closes #342

## Summary
- Add `gatewayRegistry`, `updateGateway`, and `getGatewayState`
- Legacy per-field maps (`gatewayStatusMap`, `modelCatalogByGateway`, etc.) stay in sync via `patchGatewayState`
- Existing setter APIs unchanged for incremental migration

## Test plan
- [x] `pnpm --filter @clawwork/core test -- ui-store-gateway.test.ts`