### PR TITLE
[Fix] Restore window dragging on title bars (no-drag region spanned the whole strip)

### DIFF
--- a/packages/desktop/src/renderer/components/semantic/WindowTitlebar.tsx
+++ b/packages/desktop/src/renderer/components/semantic/WindowTitlebar.tsx
@@ -18,7 +18,7 @@ export default function WindowTitlebar({ left, center, right, className }: Windo
         className,
       )}
     >
-      <div className="titlebar-no-drag flex items-center gap-2 min-w-0 flex-1">{left}</div>
+      <div className="titlebar-no-drag flex items-center gap-2 min-w-0">{left}</div>
       {center && <div className="titlebar-no-drag flex items-center justify-center min-w-0">{center}</div>}
       <div className="titlebar-no-drag flex items-center gap-2 flex-shrink-0">{right}</div>
     </header>


### PR DESCRIPTION
## Problem

The window can only be dragged by grabbing the very top-left corner. Pointing anywhere else on the title bar — most visibly the **Settings** screen's header — does nothing. This is especially annoying on multi-monitor setups.

## Root cause

The shared `WindowTitlebar` renders a `titlebar-drag` `<header>`, but its `left` wrapper carried `flex-1` next to `titlebar-no-drag` (`packages/desktop/src/renderer/components/semantic/WindowTitlebar.tsx:21`). Because the window uses `titleBarStyle: 'hiddenInset'`, the app must supply its own `-webkit-app-region: drag` strip. `flex-1` stretched the `no-drag` wrapper across the entire bar, so `no-drag` overrode the header's `drag` everywhere except the small left padding zone.

It affects every `WindowTitlebar` consumer (Settings, FileBrowser, TeamsPanel, MainArea's archived view); Settings is just the most obvious because its bar is a single static title.

## Fix

Remove `flex-1` so the `no-drag` region only wraps its content. The header already uses `justify-between`, so left/center/right stay correctly positioned, and no consumer relies on the left section growing — no layout regression. Interactive children remain inside their own `titlebar-no-drag` wrappers and stay clickable; `min-w-0` is kept so long titles can still truncate.

## Verification

- `prettier --check` and `eslint` pass on the changed file.
- Verified live in a dev build: the window now drags from the full title bar across all views (previously only the top-left corner worked).

## Release note

Fixed the window not being draggable by its title bar (only the top-left corner worked), most noticeable on the Settings screen.
