### PR TITLE
[Cleanup] Extract app bootstrap hooks

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -16,10 +16,11 @@ import { useGatewayBootstrap } from './hooks/useGatewayBootstrap';
 import { useWorkspaceRefresh } from './hooks/useWorkspaceRefresh';
 import { useUpdateCheck } from './hooks/useUpdateCheck';
 import { useTraySync } from './hooks/useTraySync';
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { useSettingsBootstrap } from './hooks/useSettingsBootstrap';
 import { cn } from '@/lib/utils';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { motionDuration, motionEase } from '@/styles/design-tokens';
-import { useSettingsStore } from './stores/settingsStore';
 
 function AppToaster({ themeMode }: { themeMode: Theme }) {
   return (
@@ -59,14 +60,21 @@ export default function App() {
   const leftNavShortcut = useUiStore((s) => s.leftNavShortcut);
   const rightPanelShortcut = useUiStore((s) => s.rightPanelShortcut);
   const themeMode = useUiStore((s) => s.theme);
-  const settings = useSettingsStore((s) => s.settings);
-  const settingsLoaded = useSettingsStore((s) => s.loaded);
-  const loadSettings = useSettingsStore((s) => s.load);
 
   useGatewayBootstrap();
   useWorkspaceRefresh();
   useUpdateCheck();
   useTraySync();
+  useSettingsBootstrap(ready);
+  useKeyboardShortcuts({
+    startNewTask,
+    setMainView,
+    toggleCommandPalette,
+    leftNavShortcut,
+    rightPanelShortcut,
+    toggleLeftNavCollapsed,
+    toggleRightPanel,
+  });
 
   const startPanelDrag = useCallback(
     (e: React.MouseEvent, startWidth: number, setWidth: (w: number) => void, dir: 1 | -1) => {
@@ -109,77 +117,6 @@ export default function App() {
         setNeedsSetup(true);
       });
   }, []);
-
-  useEffect(() => {
-    if (!ready) return;
-    if (settingsLoaded) return;
-    void loadSettings().catch((err: unknown) => {
-      console.error('[App] loadSettings failed:', err);
-    });
-  }, [ready, settingsLoaded, loadSettings]);
-
-  useEffect(() => {
-    if (!ready || !settings) return;
-    useUiStore.setState({
-      ...(settings.sendShortcut ? { sendShortcut: settings.sendShortcut } : {}),
-      ...(settings.leftNavShortcut ? { leftNavShortcut: settings.leftNavShortcut } : {}),
-      ...(settings.rightPanelShortcut ? { rightPanelShortcut: settings.rightPanelShortcut } : {}),
-      devMode: Boolean(settings.devMode),
-    });
-  }, [ready, settings]);
-
-  const handleGlobalKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      const meta = e.metaKey || e.ctrlKey;
-      if (!meta) return;
-
-      if (e.shiftKey && e.code === 'KeyO') {
-        e.preventDefault();
-        startNewTask();
-        return;
-      }
-
-      if (e.shiftKey && e.code === 'KeyF') {
-        e.preventDefault();
-        setMainView('files');
-        return;
-      }
-
-      if (!e.shiftKey && e.code === 'KeyK') {
-        e.preventDefault();
-        toggleCommandPalette();
-        return;
-      }
-
-      const leftCode = leftNavShortcut;
-      const rightCode = rightPanelShortcut;
-
-      if (!e.shiftKey && e.code === leftCode) {
-        e.preventDefault();
-        toggleLeftNavCollapsed();
-        return;
-      }
-
-      if (!e.shiftKey && e.code === rightCode) {
-        e.preventDefault();
-        if (useUiStore.getState().mainView === 'chat') toggleRightPanel();
-      }
-    },
-    [
-      startNewTask,
-      setMainView,
-      toggleCommandPalette,
-      leftNavShortcut,
-      rightPanelShortcut,
-      toggleLeftNavCollapsed,
-      toggleRightPanel,
-    ],
-  );
-
-  useEffect(() => {
-    window.addEventListener('keydown', handleGlobalKeyDown);
-    return () => window.removeEventListener('keydown', handleGlobalKeyDown);
-  }, [handleGlobalKeyDown]);
 
   useEffect(() => {
     window.clawwork.setWindowButtonVisibility(!leftNavCollapsed);

--- a/packages/desktop/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/packages/desktop/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect } from 'react';
+import { useUiStore, type PanelShortcutLeft, type PanelShortcutRight } from '../stores/uiStore';
+
+interface KeyboardShortcutOptions {
+  startNewTask: () => void;
+  setMainView: (view: 'chat' | 'files') => void;
+  toggleCommandPalette: () => void;
+  leftNavShortcut: PanelShortcutLeft;
+  rightPanelShortcut: PanelShortcutRight;
+  toggleLeftNavCollapsed: () => void;
+  toggleRightPanel: () => void;
+}
+
+export function useKeyboardShortcuts({
+  startNewTask,
+  setMainView,
+  toggleCommandPalette,
+  leftNavShortcut,
+  rightPanelShortcut,
+  toggleLeftNavCollapsed,
+  toggleRightPanel,
+}: KeyboardShortcutOptions): void {
+  const handleGlobalKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const meta = e.metaKey || e.ctrlKey;
+      if (!meta) return;
+
+      if (e.shiftKey && e.code === 'KeyO') {
+        e.preventDefault();
+        startNewTask();
+        return;
+      }
+
+      if (e.shiftKey && e.code === 'KeyF') {
+        e.preventDefault();
+        setMainView('files');
+        return;
+      }
+
+      if (!e.shiftKey && e.code === 'KeyK') {
+        e.preventDefault();
+        toggleCommandPalette();
+        return;
+      }
+
+      const leftCode = leftNavShortcut;
+      const rightCode = rightPanelShortcut;
+
+      if (!e.shiftKey && e.code === leftCode) {
+        e.preventDefault();
+        toggleLeftNavCollapsed();
+        return;
+      }
+
+      if (!e.shiftKey && e.code === rightCode) {
+        e.preventDefault();
+        if (useUiStore.getState().mainView === 'chat') toggleRightPanel();
+      }
+    },
+    [
+      startNewTask,
+      setMainView,
+      toggleCommandPalette,
+      leftNavShortcut,
+      rightPanelShortcut,
+      toggleLeftNavCollapsed,
+      toggleRightPanel,
+    ],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleGlobalKeyDown);
+    return () => window.removeEventListener('keydown', handleGlobalKeyDown);
+  }, [handleGlobalKeyDown]);
+}

--- a/packages/desktop/src/renderer/hooks/useSettingsBootstrap.ts
+++ b/packages/desktop/src/renderer/hooks/useSettingsBootstrap.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useSettingsStore } from '../stores/settingsStore';
+import { useUiStore } from '../stores/uiStore';
+
+export function useSettingsBootstrap(ready: boolean): void {
+  const settings = useSettingsStore((s) => s.settings);
+  const settingsLoaded = useSettingsStore((s) => s.loaded);
+  const loadSettings = useSettingsStore((s) => s.load);
+
+  useEffect(() => {
+    if (!ready) return;
+    if (settingsLoaded) return;
+    void loadSettings().catch((err: unknown) => {
+      console.error('[App] loadSettings failed:', err);
+    });
+  }, [ready, settingsLoaded, loadSettings]);
+
+  useEffect(() => {
+    if (!ready || !settings) return;
+    useUiStore.setState({
+      ...(settings.sendShortcut ? { sendShortcut: settings.sendShortcut } : {}),
+      ...(settings.leftNavShortcut ? { leftNavShortcut: settings.leftNavShortcut } : {}),
+      ...(settings.rightPanelShortcut ? { rightPanelShortcut: settings.rightPanelShortcut } : {}),
+      devMode: Boolean(settings.devMode),
+    });
+  }, [ready, settings]);
+}


### PR DESCRIPTION
## Summary

Hey, this PR cleans up App.tsx a bit for #231.

I moved the keyboard shortcut logic into a new useKeyboardShortcuts hook and moved the settings bootstrap logic into useSettingsBootstrap. App.tsx is now a little easier to scan since those concerns are split out.

## Testing

- pnpm check

Closes #231