### PR TITLE
[Fix] Add GatewayClient lifecycle tests

### DIFF
--- a/packages/desktop/src/main/ws/gateway-client.ts
+++ b/packages/desktop/src/main/ws/gateway-client.ts
@@ -49,6 +49,12 @@ type PendingReq = {
 };
 
 const REQ_TIMEOUT_MS = 15_000;
+const MAX_RECONNECT_BACKOFF_EXPONENT = 5;
+
+export function calculateReconnectDelay(attempt: number): number {
+  const exponent = Math.min(Math.max(attempt - 1, 0), MAX_RECONNECT_BACKOFF_EXPONENT);
+  return RECONNECT_DELAY_MS * Math.pow(2, exponent);
+}
 
 function isSecureGatewayWebSocketUrl(raw: string): boolean {
   try {
@@ -157,7 +163,7 @@ export class GatewayClient {
       });
       this.authenticated = false;
       this.serverVersion = undefined;
-      this.stopHeartbeat();
+      this.cleanup();
       sendToWindow(getMainWindow(), 'gateway-status', {
         gatewayId: this.gatewayId,
         connected: false,
@@ -866,8 +872,9 @@ export class GatewayClient {
       return;
     }
 
-    const delay = RECONNECT_DELAY_MS * Math.pow(2, Math.min(this.reconnectAttempts, 5));
-    this.reconnectAttempts++;
+    const attempt = this.reconnectAttempts + 1;
+    const delay = calculateReconnectDelay(attempt);
+    this.reconnectAttempts = attempt;
     getDebugLogger().warn({
       domain: 'gateway',
       event: 'gateway.reconnect.scheduled',

--- a/packages/desktop/test/gateway-client.test.ts
+++ b/packages/desktop/test/gateway-client.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAY_MS } from '@clawwork/shared';
+
+const websocketMock = vi.hoisted(() => {
+  type Handler = (...args: unknown[]) => void;
+  type Socket = {
+    readyState: number;
+    on: ReturnType<typeof vi.fn>;
+    removeAllListeners: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+    emit: (event: string, ...args: unknown[]) => void;
+  };
+
+  const instances: Socket[] = [];
+  const constructor = vi.fn().mockImplementation(() => {
+    const handlers = new Map<string, Handler>();
+    const socket: Socket = {
+      readyState: 0,
+      on: vi.fn((event: string, handler: Handler) => {
+        handlers.set(event, handler);
+        return socket;
+      }),
+      removeAllListeners: vi.fn(() => handlers.clear()),
+      close: vi.fn(),
+      send: vi.fn(),
+      emit: (event: string, ...args: unknown[]) => handlers.get(event)?.(...args),
+    };
+    instances.push(socket);
+    return socket;
+  });
+  Object.assign(constructor, { OPEN: 1, CONNECTING: 0 });
+
+  return { constructor, instances };
+});
+
+vi.mock('ws', () => ({
+  default: websocketMock.constructor,
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '0.0.0-test'),
+  },
+}));
+
+vi.mock('../src/main/ws/window-utils.js', () => ({
+  sendToWindow: vi.fn(),
+}));
+
+vi.mock('../src/main/window-manager.js', () => ({
+  getMainWindow: vi.fn(() => null),
+}));
+
+vi.mock('../src/main/ws/device-identity.js', () => ({
+  loadOrCreateDeviceIdentity: vi.fn(() => ({ deviceId: 'device', publicKeyPem: 'public', privateKeyPem: 'private' })),
+  buildDeviceConnectPayload: vi.fn(() => ({})),
+  saveDeviceToken: vi.fn(),
+  loadDeviceToken: vi.fn(() => null),
+}));
+
+vi.mock('../src/main/debug/index.js', () => ({
+  getDebugLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock('../src/main/ws/tls-trust.js', () => ({
+  ensureGatewayWindowsSystemTrust: vi.fn(),
+}));
+
+describe('GatewayClient connection lifecycle', () => {
+  const clients: Array<{ destroy: () => void }> = [];
+
+  function pendingRequestCount(client: object): number {
+    return (client as unknown as { pendingRequests: Map<string, unknown> }).pendingRequests.size;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    websocketMock.constructor.mockClear();
+    websocketMock.instances.length = 0;
+  });
+
+  afterEach(() => {
+    for (const client of clients) client.destroy();
+    clients.length = 0;
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('calculates capped exponential reconnect delays', async () => {
+    const { calculateReconnectDelay } = await import('../src/main/ws/gateway-client.js');
+
+    expect(calculateReconnectDelay(1)).toBe(RECONNECT_DELAY_MS);
+    expect(calculateReconnectDelay(2)).toBe(RECONNECT_DELAY_MS * 2);
+    expect(calculateReconnectDelay(3)).toBe(RECONNECT_DELAY_MS * 4);
+    expect(calculateReconnectDelay(6)).toBe(RECONNECT_DELAY_MS * 32);
+    expect(calculateReconnectDelay(7)).toBe(RECONNECT_DELAY_MS * 32);
+    expect(calculateReconnectDelay(MAX_RECONNECT_ATTEMPTS)).toBe(RECONNECT_DELAY_MS * 32);
+  });
+
+  it('rejects requests that exceed the 15-second timeout', async () => {
+    const { GatewayClient } = await import('../src/main/ws/gateway-client.js');
+    const client = new GatewayClient({
+      id: 'gw-1',
+      name: 'Gateway',
+      url: 'ws://127.0.0.1:18789',
+      auth: { token: 'token' },
+    });
+    clients.push(client);
+    client.connect();
+
+    const socket = websocketMock.instances[0];
+    if (!socket) throw new Error('expected a websocket instance');
+    socket.readyState = 1;
+
+    let settled = false;
+    const request = client.sendReq('slow.request', {});
+    void request.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    vi.advanceTimersByTime(14_999);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(pendingRequestCount(client)).toBe(1);
+
+    vi.advanceTimersByTime(1);
+    await expect(request).rejects.toMatchObject({
+      message: 'request timeout: slow.request',
+      code: 'TIMEOUT',
+    });
+    expect(pendingRequestCount(client)).toBe(0);
+  });
+
+  it('rejects pending requests immediately when the websocket closes', async () => {
+    const { GatewayClient } = await import('../src/main/ws/gateway-client.js');
+    const client = new GatewayClient({
+      id: 'gw-1',
+      name: 'Gateway',
+      url: 'ws://127.0.0.1:18789',
+      auth: { token: 'token' },
+    });
+    clients.push(client);
+    client.connect();
+
+    const socket = websocketMock.instances[0];
+    if (!socket) throw new Error('expected a websocket instance');
+    socket.readyState = 1;
+
+    const first = client.sendReq('first', {});
+    const second = client.sendReq('second', {});
+    const settled = Promise.allSettled([first, second]);
+
+    expect(pendingRequestCount(client)).toBe(2);
+
+    socket.emit('close', 1006, Buffer.from('network failure'));
+    const results = await settled;
+
+    expect(results).toEqual([
+      {
+        status: 'rejected',
+        reason: expect.objectContaining({ message: 'connection closed', code: 'GATEWAY_CONNECTION_CLOSED' }),
+      },
+      {
+        status: 'rejected',
+        reason: expect.objectContaining({ message: 'connection closed', code: 'GATEWAY_CONNECTION_CLOSED' }),
+      },
+    ]);
+    expect(pendingRequestCount(client)).toBe(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.advanceTimersByTime(15_000);
+    expect(pendingRequestCount(client)).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Add focused unit coverage for the desktop `GatewayClient` reconnect, timeout, and pending-request lifecycle. The change also fixes the confirmed close-path gap so pending requests are rejected immediately when the WebSocket closes.

## Type of change

- [ ] `[Feat]` new feature
- [x] `[Fix]` bug fix
- [ ] `[UI]` UI or UX change
- [ ] `[Docs]` documentation-only change
- [ ] `[Refactor]` internal cleanup
- [ ] `[Build]` CI, packaging, or tooling change
- [ ] `[Chore]` maintenance

## Why is this needed?

`GatewayClient` is the desktop transport for Gateway communication, but reconnect backoff, request timeout, and pending-request cleanup had no focused unit coverage. The close handler scheduled reconnect without immediately invoking the existing cleanup path, allowing pending requests to remain alive until reconnect or timeout.

## What changed?

- Extracted the existing 1-based exponential reconnect delay calculation into `calculateReconnectDelay()` with the existing 96-second cap.
- Added a lightweight local WebSocket fake and fake-timer tests for backoff, the 15-second timeout boundary, and close rejection of multiple requests.
- Reused `cleanup()` from the WebSocket close handler so pending requests are rejected and their timers cleared immediately.

## Architecture impact

- Owning layer: main
- Cross-layer impact: none
- Invariants touched from `docs/architecture-invariants.md`: none
- Why those invariants remain protected: the change stays within the desktop WebSocket client, does not alter protocol types, renderer boundaries, session routing, reconnect limits, or public client APIs.

## Linked issues

Closes #230

## Validation

- [x] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] `pnpm check:ui-contract`
- [ ] Manual smoke test
- [ ] Not run

Commands, screenshots, or notes:

```text
Focused GatewayClient and TLS tests: 8 passed.
Full desktop suite: 367 passed, 17 baseline failures in 6 unrelated filesystem/path test files.
The same 17 failures reproduce on untouched upstream/main.
Desktop source and test TypeScript checks passed after referenced package builds.
Changed-file ESLint and Prettier checks passed.
pnpm check passed lint, architecture, CI-bot security, UI contracts, renderer-copy, i18n, and dead-code checks, then stopped at the repository's pre-existing formatting baseline of 539 files.
```

## Screenshots or recordings

Not applicable. This PR has no UI changes.

## Release note

- [ ] No user-facing change. Release note is `NONE`.
- [x] User-facing change. Release note is included below.

```release-note
Pending Gateway requests now fail immediately when the Gateway connection closes.
```

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] The PR title uses an approved prefix: `[Fix]`
- [x] The summary explains both what changed and why
- [x] Validation reflects the commands actually run for this PR
- [x] Architecture impact is described and references any touched invariants
- [x] Cross-layer changes are explicitly justified
- [x] The release note block is accurate