### PR TITLE
[Fix] Reset AgentsSection file loading/saving spinners on IPC error

### DIFF
--- a/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
+++ b/packages/desktop/src/renderer/layouts/Settings/sections/AgentsSection.tsx
@@ -991,32 +991,44 @@ export default function AgentsSection() {
       setFileContent(null);
       setEditingFileContent(null);
       setLoadingFileContent(true);
-      const res = await window.clawwork.getAgentFile(selectedGatewayId, agentId, name);
-      setLoadingFileContent(false);
-      if (res.ok && res.result) {
-        const data = res.result as unknown as { file?: { content?: string } };
-        setFileContent(data.file?.content ?? null);
+      try {
+        const res = await window.clawwork.getAgentFile(selectedGatewayId, agentId, name);
+        if (res.ok && res.result) {
+          const data = res.result as unknown as { file?: { content?: string } };
+          setFileContent(data.file?.content ?? null);
+        }
+      } catch (err) {
+        console.error('[AgentsSection] getAgentFile failed:', err);
+        toast.error(t('errors.failed'));
+      } finally {
+        setLoadingFileContent(false);
       }
     },
-    [selectedGatewayId, selectedFileName],
+    [selectedGatewayId, selectedFileName, t],
   );
 
   const handleSaveFile = useCallback(async () => {
     if (!selectedGatewayId || !expandedFilesAgentId || !selectedFileName || editingFileContent === null) return;
     setSavingFile(true);
-    const res = await window.clawwork.setAgentFile(
-      selectedGatewayId,
-      expandedFilesAgentId,
-      selectedFileName,
-      editingFileContent,
-    );
-    setSavingFile(false);
-    if (res.ok) {
-      toast.success(t('settings.agentFileSaved'));
-      setFileContent(editingFileContent);
-      setEditingFileContent(null);
-    } else {
-      toast.error(res.error ?? t('settings.agentFileSaveFailed'));
+    try {
+      const res = await window.clawwork.setAgentFile(
+        selectedGatewayId,
+        expandedFilesAgentId,
+        selectedFileName,
+        editingFileContent,
+      );
+      if (res.ok) {
+        toast.success(t('settings.agentFileSaved'));
+        setFileContent(editingFileContent);
+        setEditingFileContent(null);
+      } else {
+        toast.error(res.error ?? t('settings.agentFileSaveFailed'));
+      }
+    } catch (err) {
+      console.error('[AgentsSection] setAgentFile failed:', err);
+      toast.error(t('settings.agentFileSaveFailed'));
+    } finally {
+      setSavingFile(false);
     }
   }, [selectedGatewayId, expandedFilesAgentId, selectedFileName, editingFileContent, t]);
 

--- a/packages/desktop/test/agents-section-file-spinners.test.tsx
+++ b/packages/desktop/test/agents-section-file-spinners.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18next from 'i18next';
+import '../src/renderer/i18n';
+import { toast as sonnerToast } from 'sonner';
+import { useUiStore } from '../src/renderer/stores/uiStore';
+import { resetSettingsStore } from '../src/renderer/stores/settingsStore';
+import AgentsSection from '../src/renderer/layouts/Settings/sections/AgentsSection';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  const motion = new Proxy(
+    {},
+    {
+      get: (_target, tag: string) =>
+        React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(({ children, ...props }, ref) =>
+          React.createElement(tag, { ...props, ref }, children),
+        ),
+    },
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    motion,
+  };
+});
+
+vi.mock('../src/renderer/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('../src/renderer/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogContent: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p {...props}>{children}</p>
+  ),
+}));
+
+vi.mock('../src/renderer/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../src/renderer/components/AgentBuilderDialog', () => ({
+  default: () => null,
+}));
+
+function render(element: React.ReactElement): { container: HTMLDivElement; unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => {
+    root.render(element);
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 10; i += 1) {
+    await flushAsync();
+  }
+}
+
+async function clickSettle(el: HTMLElement): Promise<void> {
+  await act(async () => {
+    el.click();
+  });
+  await settle();
+}
+
+function findByAriaKey(container: HTMLElement, key: string): HTMLElement {
+  const translated = i18next.t(key);
+  const candidates = Array.from(container.querySelectorAll('[aria-label]')) as HTMLElement[];
+  const match = candidates.find((el) => {
+    const value = el.getAttribute('aria-label');
+    return value === key || value === translated;
+  });
+  if (!match) throw new Error(`element with aria-label for key "${key}" not found`);
+  return match;
+}
+
+function findFileButton(container: HTMLElement, name: string): HTMLElement {
+  const buttons = Array.from(container.querySelectorAll('button'));
+  const match = buttons.find((b) => (b.textContent ?? '').includes(name));
+  if (!match) throw new Error(`file button "${name}" not found`);
+  return match;
+}
+
+function seedConnectedGateway(): void {
+  useUiStore.setState({
+    gatewayStatusMap: { 'gw-1': 'connected' },
+    gatewayInfoMap: { 'gw-1': { id: 'gw-1', name: 'Gateway 1' } },
+    defaultGatewayId: 'gw-1',
+    agentCatalogByGateway: {
+      'gw-1': { agents: [{ id: 'main', name: 'Main' }], defaultId: 'main' },
+    },
+    modelCatalogByGateway: {},
+    skillsStatusByGateway: {},
+  });
+}
+
+describe('AgentsSection file loading/saving spinners', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.clearAllMocks();
+    seedConnectedGateway();
+    resetSettingsStore();
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+
+    (globalThis.window as unknown as Window & typeof globalThis & { clawwork: Record<string, unknown> }).clawwork = {
+      listAgents: vi.fn().mockResolvedValue({ ok: true, result: { agents: [], defaultId: 'main' } }),
+      listAgentFiles: vi
+        .fn()
+        .mockResolvedValue({ ok: true, result: { workspace: '/ws', files: [{ name: 'IDENTITY.md' }] } }),
+      getAgentFile: vi.fn(),
+      setAgentFile: vi.fn(),
+      getSkillsStatus: vi.fn().mockResolvedValue({ ok: true, result: { skills: [] } }),
+    } as unknown as Window['clawwork'] & Record<string, unknown>;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('clears loadingFileContent and toasts when getAgentFile rejects', async () => {
+    window.clawwork.getAgentFile = vi.fn().mockRejectedValue(new Error('boom'));
+
+    const { container, unmount } = render(<AgentsSection />);
+    await settle();
+
+    await clickSettle(findByAriaKey(container, 'settings.agentDetails'));
+    await clickSettle(findFileButton(container, 'IDENTITY.md'));
+
+    expect(sonnerToast.error).toHaveBeenCalledTimes(1);
+    expect(() => findByAriaKey(container, 'settings.agentFileEdit')).not.toThrow();
+
+    unmount();
+  });
+
+  it('clears savingFile and toasts when setAgentFile rejects', async () => {
+    window.clawwork.getAgentFile = vi.fn().mockResolvedValue({ ok: true, result: { file: { content: 'hello' } } });
+    window.clawwork.setAgentFile = vi.fn().mockRejectedValue(new Error('boom'));
+
+    const { container, unmount } = render(<AgentsSection />);
+    await settle();
+
+    await clickSettle(findByAriaKey(container, 'settings.agentDetails'));
+    await clickSettle(findFileButton(container, 'IDENTITY.md'));
+    await clickSettle(findByAriaKey(container, 'settings.agentFileEdit'));
+    await clickSettle(findByAriaKey(container, 'settings.agentFileSave'));
+
+    expect(sonnerToast.error).toHaveBeenCalledTimes(1);
+    expect((findByAriaKey(container, 'settings.agentFileSave') as HTMLButtonElement).disabled).toBe(false);
+
+    unmount();
+  });
+});


### PR DESCRIPTION
### Summary

`AgentsSection.handleSelectFile` and `handleSaveFile` left their `loadingFileContent` / `savingFile` flag set when the underlying `window.clawwork` IPC call rejected, so the file load/save spinner hung forever. Each handler is now wrapped in `try/catch/finally` so the flag always resets, the error is logged, and an existing `toast.error` message is shown. Adds a regression test. This is the same flag-never-reset pattern already fixed in `SkillsSection` (#376/#452) and `SystemSection` (#488); `AgentsSection` was missed.

### Type of change
- [x] `[Fix]` bug fix

### Why is this needed?
When an agent-file IPC call rejects (gateway error, disk error), the loading or saving spinner never clears, leaving the file panel stuck on a spinner with no error feedback.

### What changed?
- `handleSelectFile`: `setLoadingFileContent(false)` moved into `finally`; on reject, `console.error('[AgentsSection] getAgentFile failed:', err)` + `toast.error(t('errors.failed'))`. Added `t` to the `useCallback` deps (now used in the `catch`).
- `handleSaveFile`: `setSavingFile(false)` moved into `finally`; on reject, `console.error('[AgentsSection] setAgentFile failed:', err)` + `toast.error(t('settings.agentFileSaveFailed'))`.
- New `test/agents-section-file-spinners.test.tsx` asserts both flags reset and `toast.error` fires when the IPC mocks reject.

The success path is behavior-equivalent: `res.ok`/`res.result` handling, `toast.success`, and state updates are unchanged; React 19 batches the reordered `setState` calls into one render. No new i18n keys (both are already used elsewhere and present in all 9 locales). No code comments, no `enum`, no layer crossing.

### Architecture impact
- Owning layer: **renderer**.
- Cross-layer impact: **none**: change is renderer-local; IPC still goes only through `window.clawwork`.
- Invariants touched (from `docs/architecture-invariants.md`): **none**: they remain protected. No layer crossing, no new IPC surface, no preload/main change.

### Linked issues
Self-found follow-up to the spinner-flag pattern; no tracked issue closed.

### Validation
- [x] `pnpm lint` (`eslint . --max-warnings 0`) — exit 0
- [x] `pnpm --filter @clawwork/desktop test` — 378 passed; 2 suites (`gateway-auth`, `gateway-tls`) fail with `Electron failed to install correctly`, pre-existing/environmental (electron binary not installed due to pnpm ignored-build-scripts), proven identical on a clean tree via `git stash`. Suite excluding those two: 53 files / 378 tests green, including the new regression test.
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm prettier --check <owned files>` — exit 0
- `pnpm format:check` (full tree) — pre-existing baseline flake (~539 files, reproduces on `main`, see PR #560); not run as a gate per the repo note.

### Release note
```release-note
NONE
```

### Checklist
- [x] All commits signed off (`git commit -s`)
- [x] PR title uses an approved prefix (`[Fix]`)
- [x] Summary explains what and why
- [x] Validation reflects commands actually run
- [x] Architecture impact described; no invariants touched
- [x] No cross-layer changes
- [x] Release note accurate (`NONE`)
