### PR TITLE
fix(core): attach sessionKey to chat-composer system messages

### DIFF
--- a/packages/core/src/services/chat-composer.ts
+++ b/packages/core/src/services/chat-composer.ts
@@ -27,7 +27,7 @@ export interface ChatComposerDeps {
       role: 'user' | 'system',
       content: string,
       attachments?: MessageAttachment[],
-      options?: { persist?: boolean },
+      options?: { persist?: boolean; sessionKey?: string },
     ) => Message;
     setProcessing: (taskId: string, processing: boolean) => void;
     clearMessages: (taskId: string) => void;
@@ -112,10 +112,11 @@ export function createChatComposer(deps: ChatComposerDeps) {
     rawMessage: string,
     code?: string,
     details?: Record<string, unknown>,
+    sessionKey?: string,
   ): void {
     const store = deps.getMessageStore();
     const appError = buildAppError({ source, stage, rawMessage, code, details });
-    store.addMessage(taskId, 'system', formatErrorForUser(appError, deps.translate));
+    store.addMessage(taskId, 'system', formatErrorForUser(appError, deps.translate), undefined, { sessionKey });
     const toast = formatErrorForToast(appError, deps.translate);
     deps.onError?.(toast);
   }
@@ -169,7 +170,15 @@ export function createChatComposer(deps: ChatComposerDeps) {
           });
           if (!modelRes.ok) {
             store.setProcessing(task.sessionKey, false);
-            emitError(task.id, 'gateway', 'send', modelRes.error || deps.translate('errors.sendFailed'));
+            emitError(
+              task.id,
+              'gateway',
+              'send',
+              modelRes.error || deps.translate('errors.sendFailed'),
+              undefined,
+              undefined,
+              task.sessionKey,
+            );
             return { ok: false, taskId: task.id };
           }
           deps.getTaskStore().updateTaskMetadata(task.id, {
@@ -183,7 +192,15 @@ export function createChatComposer(deps: ChatComposerDeps) {
           });
           if (!thinkingRes.ok) {
             store.setProcessing(task.sessionKey, false);
-            emitError(task.id, 'gateway', 'send', thinkingRes.error || deps.translate('errors.sendFailed'));
+            emitError(
+              task.id,
+              'gateway',
+              'send',
+              thinkingRes.error || deps.translate('errors.sendFailed'),
+              undefined,
+              undefined,
+              task.sessionKey,
+            );
             return { ok: false, taskId: task.id };
           }
           deps.getTaskStore().updateTaskMetadata(task.id, { thinkingLevel: options.presetThinking });
@@ -202,7 +219,15 @@ export function createChatComposer(deps: ChatComposerDeps) {
           store.setProcessing(task.sessionKey, false);
           const reason =
             failed.status === 'rejected' ? String(failed.reason) : 'value' in failed ? (failed.value?.error ?? '') : '';
-          emitError(task.id, 'gateway', 'send', reason || deps.translate('errors.sendFailed'));
+          emitError(
+            task.id,
+            'gateway',
+            'send',
+            reason || deps.translate('errors.sendFailed'),
+            undefined,
+            undefined,
+            task.sessionKey,
+          );
           return { ok: false, taskId: task.id };
         }
 
@@ -233,6 +258,7 @@ export function createChatComposer(deps: ChatComposerDeps) {
             result.error || deps.translate('errors.sendFailed'),
             result.errorCode,
             result.errorDetails,
+            task.sessionKey,
           );
           return { ok: false, taskId: task.id };
         }
@@ -251,7 +277,11 @@ export function createChatComposer(deps: ChatComposerDeps) {
             stage: 'lifecycle',
             rawMessage: deps.translate('errors.agentNotResponding'),
           });
-          deps.getMessageStore().addMessage(task.id, 'system', formatErrorForUser(appError, deps.translate));
+          deps
+            .getMessageStore()
+            .addMessage(task.id, 'system', formatErrorForUser(appError, deps.translate), undefined, {
+              sessionKey: task.sessionKey,
+            });
         }, SEND_TIMEOUT_MS),
       );
 
@@ -271,7 +301,15 @@ export function createChatComposer(deps: ChatComposerDeps) {
       return { ok: true, taskId: task.id };
     } catch (err) {
       store.setProcessing(task.sessionKey, false);
-      emitError(task.id, 'local', 'send', err instanceof Error ? err.message : String(err));
+      emitError(
+        task.id,
+        'local',
+        'send',
+        err instanceof Error ? err.message : String(err),
+        undefined,
+        undefined,
+        task.sessionKey,
+      );
       return { ok: false, taskId: task.id };
     }
   }
@@ -320,7 +358,7 @@ export function createChatComposer(deps: ChatComposerDeps) {
         const res = await deps.compactSession(task.gatewayId, task.sessionKey);
         if (res.ok) {
           const msg = deps.translate('session.contextCompacted');
-          store.addMessage(taskId, 'system', msg);
+          store.addMessage(taskId, 'system', msg, undefined, { sessionKey: task.sessionKey });
           return { ok: true, message: msg };
         }
         return { ok: false };
@@ -330,7 +368,7 @@ export function createChatComposer(deps: ChatComposerDeps) {
         if (res.ok) {
           store.clearMessages(taskId);
           const msg = deps.translate('session.contextReset');
-          store.addMessage(taskId, 'system', msg);
+          store.addMessage(taskId, 'system', msg, undefined, { sessionKey: task.sessionKey });
           return { ok: true, message: msg };
         }
         return { ok: false };

--- a/packages/core/test/chat-composer.test.ts
+++ b/packages/core/test/chat-composer.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildSessionKey } from '@clawwork/shared';
+import type { Message, MessageAttachment } from '@clawwork/shared';
+import { createChatComposer } from '../src/services/chat-composer';
+import type { ChatComposerDeps } from '../src/services/chat-composer';
+
+const TASK_ID = 'abc';
+const SESSION_KEY = buildSessionKey(TASK_ID);
+const SEND_TIMEOUT_MS = 30_000;
+
+type AddMessageOptions = { persist?: boolean; sessionKey?: string };
+
+function setup() {
+  const addMessage = vi.fn(
+    (
+      _taskId: string,
+      _role: 'user' | 'system',
+      _content: string,
+      _attachments?: MessageAttachment[],
+      _options?: AddMessageOptions,
+    ): Message => ({
+      id: 'm1',
+      taskId: TASK_ID,
+      role: 'user',
+      content: '',
+      artifacts: [],
+      toolCalls: [],
+      timestamp: '',
+    }),
+  );
+
+  const sendMessage = vi.fn().mockResolvedValue({ ok: true });
+  const abortChat = vi.fn().mockResolvedValue({ ok: true });
+  const patchSession = vi.fn().mockResolvedValue({ ok: true });
+  const compactSession = vi.fn().mockResolvedValue({ ok: true });
+  const resetSession = vi.fn().mockResolvedValue({ ok: true });
+  const task = { id: TASK_ID, gatewayId: 'gw-1', sessionKey: SESSION_KEY, title: 'T' };
+
+  const deps: ChatComposerDeps = {
+    gateway: { sendMessage, abortChat, patchSession },
+    getTaskStore: () => ({
+      tasks: [task],
+      commitPendingTask: () => task,
+      updateTaskTitle: vi.fn(),
+      updateTaskMetadata: vi.fn(),
+    }),
+    getMessageStore: () => ({
+      addMessage,
+      setProcessing: vi.fn(),
+      clearMessages: vi.fn(),
+    }),
+    persistMessage: vi.fn().mockResolvedValue(undefined),
+    markAbortedByUser: vi.fn(),
+    compactSession,
+    resetSession,
+    translate: (key: string) => key,
+    onError: vi.fn(),
+  };
+
+  const composer = createChatComposer(deps);
+
+  function systemOptions(): (AddMessageOptions | undefined)[] {
+    return addMessage.mock.calls.filter((c) => c[1] === 'system').map((c) => c[4]);
+  }
+
+  return { composer, addMessage, systemOptions, sendMessage, compactSession, resetSession };
+}
+
+describe('chat-composer', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('attaches task.sessionKey to system messages from emitError, send-timeout, compact, reset', async () => {
+    {
+      const { composer, systemOptions, sendMessage } = setup();
+      sendMessage.mockResolvedValueOnce({ ok: false });
+      await composer.send(TASK_ID, { content: 'hi' });
+      const system = systemOptions();
+      expect(system).toHaveLength(1);
+      expect(system[0]?.sessionKey).toBe(SESSION_KEY);
+    }
+
+    {
+      const { composer, systemOptions, sendMessage } = setup();
+      vi.useFakeTimers();
+      sendMessage.mockResolvedValueOnce({ ok: true });
+      await composer.send(TASK_ID, { content: 'hi' });
+      await vi.advanceTimersByTimeAsync(SEND_TIMEOUT_MS);
+      vi.useRealTimers();
+      const system = systemOptions();
+      expect(system).toHaveLength(1);
+      expect(system[0]?.sessionKey).toBe(SESSION_KEY);
+    }
+
+    {
+      const { composer, systemOptions, compactSession } = setup();
+      compactSession.mockResolvedValueOnce({ ok: true });
+      await composer.applySlashCommand(TASK_ID, 'compact');
+      const system = systemOptions();
+      expect(system).toHaveLength(1);
+      expect(system[0]?.sessionKey).toBe(SESSION_KEY);
+    }
+
+    {
+      const { composer, systemOptions, resetSession } = setup();
+      resetSession.mockResolvedValueOnce({ ok: true });
+      await composer.applySlashCommand(TASK_ID, 'reset');
+      const system = systemOptions();
+      expect(system).toHaveLength(1);
+      expect(system[0]?.sessionKey).toBe(SESSION_KEY);
+    }
+  });
+});


### PR DESCRIPTION
Closes #214.

## Problem

System messages emitted by the chat composer (send errors, send-timeout, compact, reset) were added via `addMessage(taskId, 'system', …)` without a `sessionKey`, so they were not associated with the task's session — breaking the per-session message scoping the rest of the message store relies on.

## Fix

Thread `task.sessionKey` into every system-message path in `createChatComposer` (packages/core/src/services/chat-composer.ts):

- `emitError` gains a trailing `sessionKey?` parameter; all five call sites (gateway send-error ×3, lifecycle send-timeout, local catch) pass `task.sessionKey` in the correct positional slot.
- The three direct `addMessage(…, 'system', …)` sites (send-timeout, compact, reset) pass `{ sessionKey: task.sessionKey }`.

The change is purely additive — `options.sessionKey` is optional, so no existing `addMessage` consumer is affected.

## Tests

New `packages/core/test/chat-composer.test.ts` exercises four system-message paths (send-error, send-timeout, compact, reset) and asserts each carries the task's `sessionKey`.

`pnpm --filter @clawwork/core test` → 110 passed.

## Scope / follow-up

This PR covers the **core chat-composer** paths from #214. The same `addMessage(…, 'system', …)` pattern exists in a few desktop-only call sites (the `LeftNav` compact/reset shortcuts and a `useChatSend` catch fallback) that also omit `sessionKey`; those are intentionally out of scope here (one concern per PR) and are good candidates for a follow-up.
