### PR TITLE
fix(core): preserve double quotes in identity description round-trip

### DIFF
--- a/packages/core/src/services/team-parser.ts
+++ b/packages/core/src/services/team-parser.ts
@@ -71,7 +71,7 @@ export function parseIdentityMd(raw: string): ParsedIdentityMd {
   const match = raw.trim().match(FRONTMATTER_RE);
   if (!match) return { body: raw.trim() };
   const fm = parseFrontmatter(match[1]);
-  const desc = typeof fm.description === 'string' && fm.description ? fm.description : undefined;
+  const desc = typeof fm.description === 'string' && fm.description ? fm.description.replaceAll('\\"', '"') : undefined;
   return { description: desc, body: match[2].trim(), rawFrontmatter: match[1] };
 }
 

--- a/packages/core/test/team-parser.test.ts
+++ b/packages/core/test/team-parser.test.ts
@@ -236,6 +236,30 @@ describe('serializeIdentityMd', () => {
     expect(result).toContain('description: "Expert in \\"React\\""');
   });
 
+  it('round-trips a description containing double quotes without corruption', () => {
+    const desc = 'Agent "Alpha"';
+    const body = 'You coordinate the team.';
+    const parsed = parseIdentityMd(serializeIdentityMd(desc, body));
+    expect(parsed.description).toBe(desc);
+    expect(parsed.body).toBe(body);
+  });
+
+  it('round-trips multiple quoted segments through the existing-frontmatter path', () => {
+    const desc = 'Bridges "alpha" and "beta" squads';
+    const existing = '---\ndescription: "old"\nversion: 2\n---\n\nOld body';
+    expect(extractDescription(serializeIdentityMd(desc, 'New body', existing))).toBe(desc);
+  });
+
+  it('round-trips quotes without corrupting literal backslashes', () => {
+    const desc = 'Config at C:\\Users\\dev runs "beta"';
+    const parsed = parseIdentityMd(serializeIdentityMd(desc, 'body'));
+    expect(parsed.description).toBe(desc);
+  });
+
+  it('round-trips a description that is only a double quote', () => {
+    expect(parseIdentityMd(serializeIdentityMd('"', 'body')).description).toBe('"');
+  });
+
   it('strips newlines from description', () => {
     const result = serializeIdentityMd('line1\nline2', 'body');
     expect(result).toContain('description: "line1 line2"');


### PR DESCRIPTION
## Summary
A double-quote in an agent identity description round-trips cleanly through the team parser instead of accumulating literal backslashes on every save/reload cycle (`Senior "full-stack" engineer` → `Senior \"full-stack\" engineer` → doubling each cycle).

## Root cause
`serializeIdentityMd` escapes `"` → `\"` on write, but the read-side `unquote` never reversed the escape, so the escape sequences compounded on every save/reload.

## Changes
- `packages/core/src/services/team-parser.ts` — reverse the `\"` escape on read so serialize/parse is symmetric (one line).
- `packages/core/test/team-parser.test.ts` — 4 cases proving red→green: a single `"`, multiple quotes, quote + backslashes, and a quote-only description; all fail on the old code (backslashes accumulate) and pass after.

## Test plan
- [x] `npx vitest run test/team-parser.test.ts` — 46 tests pass.

This change was developed with AI assistance (Claude Code); every changed line was reviewed and understood.