### PR TITLE
[Docs] Fix broken star history chart in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -229,7 +229,7 @@ ClawWork は現時点では OpenClaw に最適化されています。私たち�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://star-history.dera.page/#clawwork-ai/ClawWork&type=date&legend=top-left)
 
 ## コントリビュート
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -229,7 +229,7 @@ ClawWork는 현재 OpenClaw에 최적화되어 있습니다. 우리가 향하는
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://star-history.dera.page/#clawwork-ai/ClawWork&type=date&legend=top-left)
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Items move up into _Next up_ as they get scoped. Nothing in this section is a pr
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://star-history.dera.page/#clawwork-ai/ClawWork&type=date&legend=top-left)
 
 ## Contributing
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -226,7 +226,7 @@ ClawWork 目前針對 OpenClaw 最佳化。我們正朝一個未來邁進：工�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://star-history.dera.page/#clawwork-ai/ClawWork&type=date&legend=top-left)
 
 ## 貢獻
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -226,7 +226,7 @@ ClawWork 目前针对 OpenClaw 优化。我们正在构建一个未来：工作�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://www.star-history.com/?repos=clawwork-ai%2FClawWork&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/image?repos=clawwork-ai/ClawWork&type=date&legend=top-left)](https://star-history.dera.page/#clawwork-ai/ClawWork&type=date&legend=top-left)
 
 ## 贡献
 


### PR DESCRIPTION
The star history chart shown in the READMEs is currently broken. This change points the chart image and its wrapping link to the working alternative at star-history.dera.page across the main README and all localized versions (zh, zh-TW, ja, ko).